### PR TITLE
Toeplitz fix

### DIFF
--- a/src/furax/core/_toeplitz.py
+++ b/src/furax/core/_toeplitz.py
@@ -170,7 +170,7 @@ class SymmetricBandToeplitzOperator(AbstractLinearOperator):
         x_padding_start = overlap
         x_padding_end = total_length - overlap - l
         x_padded = jnp.pad(x, (x_padding_start, x_padding_end), mode='constant')
-        y = jnp.zeros(l + x_padding_end)
+        y = jnp.zeros(l + x_padding_end, dtype=x.dtype)
 
         def func(iblock, y):  # type: ignore[no-untyped-def]
             position = iblock * step_size
@@ -235,7 +235,7 @@ def _overlap_add_jax(x, H, fft_size, b):  # type: ignore[no-untyped-def]
     # pad x so that its size is a multiple of m
     x_padding = 0 if l % m == 0 else m - (l % m)
     x_padded = jnp.pad(x, (x_padding,), mode='constant')
-    y = jnp.zeros(l + b)
+    y = jnp.zeros(l + b, dtype=x.dtype)
 
     def func(j, y):  # type: ignore[no-untyped-def]
         i = j * m

--- a/src/furax/core/_toeplitz.py
+++ b/src/furax/core/_toeplitz.py
@@ -74,7 +74,7 @@ class SymmetricBandToeplitzOperator(AbstractLinearOperator):
         if method not in self.METHODS:
             raise ValueError(f'Invalid method {method}. Choose from: {", ".join(self.METHODS)}')
 
-        band_number = 2 * band_values.size - 1
+        band_number = 2 * band_values.shape[-1] - 1
         if fft_size is not None:
             if not method.startswith('overlap_'):
                 raise ValueError('The FFT size is only used by the overlap methods.')

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,6 +10,11 @@ from furax.obs.stokes import StokesIQU, ValidStokesType
 from tests.helpers import TEST_DATA_PLANCK, TEST_DATA_SAT
 
 
+@pytest.fixture(scope='session', autouse=True)
+def enable_x64() -> None:
+    jax.config.update('jax_enable_x64', True)
+
+
 def load_planck(nside: int) -> np.array:
     PLANCK_URL = 'https://irsa.ipac.caltech.edu/data/Planck/release_3/all-sky-maps/maps/HFI_SkyMap_143_2048_R3.01_full.fits'
     map_2048 = hp.read_map(PLANCK_URL, field=['I_STOKES', 'Q_STOKES', 'U_STOKES'])

--- a/tests/core/test_toeplitz.py
+++ b/tests/core/test_toeplitz.py
@@ -1,4 +1,5 @@
 import itertools
+from math import prod
 
 import jax
 import jax.numpy as jnp
@@ -88,7 +89,7 @@ def test(method: str, do_jit: bool) -> None:
 def test_multidimensional(
     in_shape: tuple[int, ...], band_shape: tuple[int, ...], method: str
 ) -> None:
-    band_values = jnp.arange(np.prod(band_shape)).reshape(band_shape)
+    band_values = jnp.arange(prod(band_shape), dtype=jnp.float64).reshape(band_shape)
     in_structure = jax.ShapeDtypeStruct(in_shape, jnp.float64)
     op = SymmetricBandToeplitzOperator(band_values, in_structure, method=method)
     broadcast_band_values = jnp.broadcast_to(band_values, in_shape[:-1] + (4,))


### PR DESCRIPTION
Minor fix for two issues with the SymmetricBandToeplitzOperator:
- Add two missing 'dtype' arguments to support data types other than float64
- Fix band_values to the intended value for multidimensional arrays