### PR TITLE
Small fix for the index operator

### DIFF
--- a/src/furax/core/_indices.py
+++ b/src/furax/core/_indices.py
@@ -116,7 +116,7 @@ class IndexOperator(AbstractLinearOperator):
         for axis, index in enumerate(self.indices):
             if axis >= ellipsis_index:
                 break
-            if index == slice(None):
+            if isinstance(index, slice) and index == slice(None):
                 continue
             axes.append(axis)
         for axis, index in enumerate(self.indices[ellipsis_index + 1 :], ellipsis_index + 1):


### PR DESCRIPTION
This small fix addresses the error when using a numpy integer array as indices in the IndexOperator.

The previous version throws an error at `reduce()` since the expression `index == slice(None)` evaluates to a numpy boolean array, which cannot serve as a condition for the `if` statement.