### PR TITLE
Sharding-aware CG solver

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,4 +48,7 @@ jobs:
         run: uv sync --locked --all-extras
 
       - name: Run tests
-        run: uv run pytest -vv -m "not slow"
+        run: uv run pytest -vv
+
+      - name: Run distributed tests
+        run: uv run pytest -vv -m distributed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -142,7 +142,10 @@ addopts = [
 ]
 minversion = "9"
 testpaths = ['tests']
-markers = ["slow: mark test as slow."]
+markers = [
+    "slow: mark test as slow.",
+    "distributed: multi-device test; run in its own session via `pytest -m distributed`.",
+]
 log_level = "INFO"
 xfail_strict = true
 

--- a/src/furax/linalg/__init__.py
+++ b/src/furax/linalg/__init__.py
@@ -1,8 +1,11 @@
+from ._cg import CGResult, cg
 from ._eigvalsh import eigvalsh
 from ._lanczos import LanczosResult, lanczos_eigh, lanczos_tr
 from .low_rank import LowRankOperator, LowRankTerms, low_rank, low_rank_mv
 
 __all__ = [
+    'cg',
+    'CGResult',
     'eigvalsh',
     'lanczos_eigh',
     'lanczos_tr',

--- a/src/furax/linalg/_cg.py
+++ b/src/furax/linalg/_cg.py
@@ -1,6 +1,7 @@
 from collections.abc import Callable
 from typing import NamedTuple
 
+import equinox as eqx
 import equinox.internal as eqxi
 import jax
 import jax.numpy as jnp
@@ -33,24 +34,20 @@ def cg(
     atol: float = 0.0,
     rtol: float = 1e-5,
     stabilise_every: int = 10,
+    truncate: bool = False,
     iteration_callback: Callable[[Array, Array], None] | None = None,
 ) -> CGResult:
     """Conjugate Gradient solver for symmetric positive definite systems Ax = b.
 
-    Unlike lineax's CG solver, this implementation records the residual norm at
-    every iteration so you can monitor convergence, tolerates inputs sharded
-    along their contracting dimensions via sharding-aware reductions, and is both
-    forward- and reverse-mode differentiable (it loops with a bounded
-    ``equinox.internal.while_loop``).
+    The residual norm is recorded at every iteration (see ``CGResult.residuals``)
+    so convergence can be monitored. Inputs may be sharded along their contracting
+    dimensions, and the solve is both forward- and reverse-mode differentiable.
 
-    Convergence is declared when ``||r|| <= atol + rtol * ||b||``.
-
-    Memory: the loop carry holds three vectors the size of the solution -- the
-    iterate ``x``, the residual ``r`` and the search direction ``p``. The
-    preconditioned residual ``z = M(r)`` and the matvec result ``A(p)`` are
-    transient within each iteration and not carried across steps. So peak working
-    set is roughly five solution-sized vectors plus whatever ``A`` and ``M`` need
-    internally for a single matvec.
+    Convergence is declared when ``||r|| <= atol + rtol * ||b||``. With ``atol``
+    and ``rtol`` both 0 the criterion is never met and the solver runs for exactly
+    ``max_steps`` steps; otherwise it stops early once the residual is small enough,
+    and ``max_steps`` is only a ceiling. Negative curvature (a non positive definite
+    ``A``) is handled per ``truncate``.
 
     Args:
         A: A symmetric positive definite linear operator.
@@ -61,12 +58,15 @@ def cg(
         max_steps: Maximum number of iteration steps.
         atol: Absolute tolerance on the residual norm.
         rtol: Relative tolerance on the residual norm (scaled by ``||b||``).
-            When both ``atol`` and ``rtol`` are 0, convergence is never
-            declared and the solver runs for exactly ``max_steps`` steps.
         stabilise_every: If set, replace the recursively-updated residual with
             the true residual ``b - A x`` every N iterations (after steps
             N, 2N, 3N, ...). This counters floating-point drift at the cost of
             one extra matvec per stabilisation.
+        truncate: How to handle negative curvature ``p^T A p < 0``, which a
+            positive definite ``A`` never produces. If False (default), raise a
+            runtime error (configurable via Equinox's ``EQX_ON_ERROR``; see
+            ``equinox.error_if``). If True, stop iterating and return the last
+            iterate before the bad direction (truncated CG).
         iteration_callback: Optional host callback called after each step with
             ``(step, r_norm)`` as 0-d JAX arrays.  Runs via
             ``jax.debug.callback`` so it is JIT-compatible and ordered.
@@ -83,8 +83,9 @@ def cg(
         >>> A = DiagonalOperator(d, in_structure=as_structure(d))
         >>> b = jnp.ones(5)
         >>> result = cg(A, b, max_steps=20)
-        >>> result.solution
-        Array([1.  , 0.5 , 0.333..., 0.25 , 0.2 ], dtype=float32)
+        >>> expected = jnp.array([1.0, 0.5, 1 / 3, 0.25, 0.2])
+        >>> bool(jnp.allclose(result.solution, expected, atol=1e-4))
+        True
     """
     if x0 is None:
         x0 = tree.zeros_like(b)
@@ -118,17 +119,27 @@ def cg(
     residuals = jnp.zeros(max_steps).at[0].set(r0_norm)
 
     def cond_fn(carry):  # type: ignore[no-untyped-def]
-        *_, converged, i, _ = carry
-        return ~converged & (i < max_steps)
+        _, _, _, _, converged, truncated, i, _ = carry
+        return ~converged & ~truncated & (i < max_steps)
 
     def body_fn(carry):  # type: ignore[no-untyped-def]
-        x, r, p, rz, _, i, residuals = carry
+        x, r, p, rz, _, _, i, residuals = carry
 
         Ap = A(p)
         pAp = tree.dot(p, Ap)
 
-        safe_pAp = jnp.where(pAp == 0, 1.0, pAp)
-        alpha = rz / safe_pAp
+        # `pAp == 0` only at convergence (p -> 0), handled by `safe_pAp`
+        # `pAp < 0` is genuine negative curvature, which a positive definite A should never produce
+        if truncate:
+            # Negative curvature: take no step this iteration and flag the loop to stop.
+            truncated = pAp < 0
+            safe_pAp = jnp.where(pAp == 0, 1.0, pAp)
+            alpha = jnp.where(truncated, 0.0, rz / safe_pAp)
+        else:
+            pAp = eqx.error_if(pAp, pAp < 0, 'cg: negative curvature detected p^T A p < 0')
+            truncated = jnp.array(False)
+            safe_pAp = jnp.where(pAp == 0, 1.0, pAp)
+            alpha = rz / safe_pAp
 
         x = tree.add(x, tree.mul(alpha, p))
 
@@ -158,14 +169,14 @@ def cg(
         converged = _converged(r_norm)
         residuals = residuals.at[i + 1].set(r_norm)
 
-        return x, r, p, rz_new, converged, i + 1, residuals
+        return x, r, p, rz_new, converged, truncated, i + 1, residuals
 
     already_converged = _converged(r0_norm)
-    init_carry = (x0, r, p, rz, already_converged, jnp.int32(0), residuals)
+    init_carry = (x0, r, p, rz, already_converged, jnp.array(False), jnp.int32(0), residuals)
     # `residuals` is only ever written (`.at[i].set`) inside the loop, never read, so mark it a
     # buffer. `kind='bounded'` makes the loop both forward- and reverse-mode differentiable (lax's
     # while_loop is forward-only); it unrolls up to `max_steps` with logarithmic checkpointing.
-    x, _, _, _, _, num_steps, residuals = eqxi.while_loop(
+    x, _, _, _, _, _, num_steps, residuals = eqxi.while_loop(
         cond_fn,
         body_fn,
         init_carry,

--- a/src/furax/linalg/_cg.py
+++ b/src/furax/linalg/_cg.py
@@ -3,8 +3,6 @@ from typing import NamedTuple
 
 import jax
 import jax.numpy as jnp
-from jax.sharding import NamedSharding
-from jax.sharding import PartitionSpec as P
 from jaxtyping import Array, Float, Num, PyTree
 
 from furax import AbstractLinearOperator, tree
@@ -22,38 +20,6 @@ class CGResult(NamedTuple):
     solution: PyTree[Num[Array, '...']]
     residuals: Float[Array, ' max_steps']
     num_steps: Array
-
-
-def _replicated_sharding() -> NamedSharding | None:
-    """Return a fully-replicated NamedSharding for the active mesh, or None."""
-    mesh = jax.sharding.get_abstract_mesh()
-    if mesh.empty:
-        return None
-    return NamedSharding(mesh, P())
-
-
-def _sharded_dot(x: PyTree[Num[Array, '...']], y: PyTree[Num[Array, '...']]) -> Num[Array, '']:
-    """Sharding-aware scalar product of two PyTrees.
-
-    Equivalent to ``furax.tree.dot`` but tolerates inputs sharded along their
-    contracting dimensions: leaf reductions are constrained to fully-replicated
-    output sharding, which makes JAX insert an all-reduce instead of erroring.
-    """
-    replicated = _replicated_sharding()
-
-    def leaf_dot(a: Array, b: Array) -> Array:
-        prod = jnp.conj(a) * b
-        if replicated is None:
-            return jnp.sum(prod)
-        return jax.lax.with_sharding_constraint(jnp.sum(prod), replicated)  # type: ignore[no-any-return]
-
-    parts = jax.tree.map(leaf_dot, x, y)
-    return sum(jax.tree.leaves(parts), start=jnp.array(0))
-
-
-def _sharded_norm(x: PyTree[Num[Array, '...']]) -> Num[Array, '']:
-    """Sharding-aware Euclidean norm of a PyTree, mirroring ``_sharded_dot``."""
-    return jnp.sqrt(jnp.real(_sharded_dot(x, x)))
 
 
 def cg(
@@ -121,7 +87,7 @@ def cg(
         x0 = tree.zeros_like(b)
 
     has_scale = atol > 0 or rtol > 0
-    norm_b = _sharded_norm(b)
+    norm_b = tree.norm(b)
     abs_tol = atol + rtol * norm_b
 
     def _converged(r_norm: Array) -> Array:
@@ -141,9 +107,9 @@ def cg(
     z = M(r)
 
     p = z
-    rz = _sharded_dot(r, z)  # r^T z (or r^T M^{-1} r)
+    rz = tree.dot(r, z)  # r^T z (or r^T M^{-1} r)
 
-    r0_norm = _sharded_norm(r)
+    r0_norm = tree.norm(r)
     # residuals[0] = initial residual; residuals[i+1] = residual after step i.
     # If i+1 >= max_steps (loop ran to completion), the last write is dropped by JAX.
     residuals = jnp.zeros(max_steps).at[0].set(r0_norm)
@@ -156,7 +122,7 @@ def cg(
         x, r, p, rz, _, i, residuals = carry
 
         Ap = A(p)
-        pAp = _sharded_dot(p, Ap)
+        pAp = tree.dot(p, Ap)
 
         safe_pAp = jnp.where(pAp == 0, 1.0, pAp)
         alpha = rz / safe_pAp
@@ -173,14 +139,14 @@ def cg(
         else:
             r = _cheap_r(r, alpha, Ap)
 
-        r_norm = _sharded_norm(r)
+        r_norm = tree.norm(r)
 
         if iteration_callback is not None:
             # `ordered = True` would error in distributed mode
             jax.debug.callback(iteration_callback, i, r_norm)
 
         z = M(r)
-        rz_new = _sharded_dot(r, z)
+        rz_new = tree.dot(r, z)
         safe_rz = jnp.where(rz == 0, 1.0, rz)
         beta = rz_new / safe_rz
 

--- a/src/furax/linalg/_cg.py
+++ b/src/furax/linalg/_cg.py
@@ -1,0 +1,198 @@
+from collections.abc import Callable
+from typing import NamedTuple
+
+import jax
+import jax.numpy as jnp
+from jax.sharding import NamedSharding
+from jax.sharding import PartitionSpec as P
+from jaxtyping import Array, Float, Num, PyTree
+
+from furax import AbstractLinearOperator, tree
+
+
+class CGResult(NamedTuple):
+    """Result of the Conjugate Gradient solver.
+
+    Attributes:
+        solution: The approximate solution x to Ax = b.
+        residuals: Norm of the residual at each iteration, shape (max_steps,).
+        num_steps: Number of CG steps taken.
+    """
+
+    solution: PyTree[Num[Array, '...']]
+    residuals: Float[Array, ' max_steps']
+    num_steps: Array
+
+
+def _replicated_sharding() -> NamedSharding | None:
+    """Return a fully-replicated NamedSharding for the active mesh, or None."""
+    mesh = jax.sharding.get_abstract_mesh()
+    if mesh.empty:
+        return None
+    return NamedSharding(mesh, P())
+
+
+def _sharded_dot(x: PyTree[Num[Array, '...']], y: PyTree[Num[Array, '...']]) -> Num[Array, '']:
+    """Sharding-aware scalar product of two PyTrees.
+
+    Equivalent to ``furax.tree.dot`` but tolerates inputs sharded along their
+    contracting dimensions: leaf reductions are constrained to fully-replicated
+    output sharding, which makes JAX insert an all-reduce instead of erroring.
+    """
+    replicated = _replicated_sharding()
+
+    def leaf_dot(a: Array, b: Array) -> Array:
+        prod = jnp.conj(a) * b
+        if replicated is None:
+            return jnp.sum(prod)
+        return jax.lax.with_sharding_constraint(jnp.sum(prod), replicated)  # type: ignore[no-any-return]
+
+    parts = jax.tree.map(leaf_dot, x, y)
+    return sum(jax.tree.leaves(parts), start=jnp.array(0))
+
+
+def _sharded_norm(x: PyTree[Num[Array, '...']]) -> Num[Array, '']:
+    """Sharding-aware Euclidean norm of a PyTree, mirroring ``_sharded_dot``."""
+    return jnp.sqrt(jnp.real(_sharded_dot(x, x)))
+
+
+def cg(
+    A: AbstractLinearOperator,
+    b: PyTree[Num[Array, '...']],
+    x0: PyTree[Num[Array, '...']] | None = None,
+    *,
+    preconditioner: AbstractLinearOperator | None = None,
+    max_steps: int = 500,
+    atol: float = 0.0,
+    rtol: float = 1e-5,
+    stabilise_every: int = 10,
+    iteration_callback: Callable[[Array, Array], None] | None = None,
+) -> CGResult:
+    """Conjugate Gradient solver for symmetric positive definite systems Ax = b.
+
+    Unlike lineax's CG solver, this implementation records the residual norm at
+    every iteration so you can monitor convergence, and tolerates inputs
+    sharded along their contracting dimensions via sharding-aware reductions.
+
+    Convergence is declared when ``||r|| <= atol + rtol * ||b||``.
+
+    Memory: the loop carry holds three vectors the size of the solution -- the
+    iterate ``x``, the residual ``r`` and the search direction ``p``. The
+    preconditioned residual ``z = M(r)`` and the matvec result ``A(p)`` are
+    transient within each iteration and not carried across steps. So peak working
+    set is roughly five solution-sized vectors plus whatever ``A`` and ``M`` need
+    internally for a single matvec.
+
+    Args:
+        A: A symmetric positive definite linear operator.
+        b: Right-hand side of the system.
+        x0: Initial guess. Defaults to zeros.
+        preconditioner: Optional preconditioner M such that MA is better
+            conditioned. M must be symmetric positive definite.
+        max_steps: Maximum number of iteration steps.
+        atol: Absolute tolerance on the residual norm.
+        rtol: Relative tolerance on the residual norm (scaled by ``||b||``).
+            When both ``atol`` and ``rtol`` are 0, convergence is never
+            declared and the solver runs for exactly ``max_steps`` steps.
+        stabilise_every: If set, replace the recursively-updated residual with
+            the true residual ``b - A x`` every N iterations (after steps
+            N, 2N, 3N, ...). This counters floating-point drift at the cost of
+            one extra matvec per stabilisation.
+        iteration_callback: Optional host callback called after each step with
+            ``(step, r_norm)`` as 0-d JAX arrays.  Runs via
+            ``jax.debug.callback`` so it is JIT-compatible and ordered.
+
+    Returns:
+        CGResult with the solution, per-iteration residual norms, and iteration count.
+
+    Example:
+        >>> import jax.numpy as jnp
+        >>> from furax import DiagonalOperator
+        >>> from furax.tree import as_structure
+        >>> from furax.linalg import cg
+        >>> d = jnp.array([1., 2., 3., 4., 5.])
+        >>> A = DiagonalOperator(d, in_structure=as_structure(d))
+        >>> b = jnp.ones(5)
+        >>> result = cg(A, b, max_steps=20)
+        >>> result.solution
+        Array([1.  , 0.5 , 0.333..., 0.25 , 0.2 ], dtype=float32)
+    """
+    if x0 is None:
+        x0 = tree.zeros_like(b)
+
+    has_scale = atol > 0 or rtol > 0
+    norm_b = _sharded_norm(b)
+    abs_tol = atol + rtol * norm_b
+
+    def _converged(r_norm: Array) -> Array:
+        return has_scale & (r_norm <= abs_tol)
+
+    def _stable_r(x: PyTree) -> PyTree:
+        return tree.sub(b, A(x))
+
+    def _cheap_r(r: PyTree, alpha: Array, Ap: PyTree) -> PyTree:
+        return tree.sub(r, tree.mul(alpha, Ap))
+
+    # Initial residual r = b - A @ x0
+    r = _stable_r(x0)
+
+    # Apply preconditioner: z = M r
+    M = preconditioner or (lambda _: _)
+    z = M(r)
+
+    p = z
+    rz = _sharded_dot(r, z)  # r^T z (or r^T M^{-1} r)
+
+    r0_norm = _sharded_norm(r)
+    # residuals[0] = initial residual; residuals[i+1] = residual after step i.
+    # If i+1 >= max_steps (loop ran to completion), the last write is dropped by JAX.
+    residuals = jnp.zeros(max_steps).at[0].set(r0_norm)
+
+    def cond_fn(carry):  # type: ignore[no-untyped-def]
+        *_, converged, i, _ = carry
+        return ~converged & (i < max_steps)
+
+    def body_fn(carry):  # type: ignore[no-untyped-def]
+        x, r, p, rz, _, i, residuals = carry
+
+        Ap = A(p)
+        pAp = _sharded_dot(p, Ap)
+
+        safe_pAp = jnp.where(pAp == 0, 1.0, pAp)
+        alpha = rz / safe_pAp
+
+        x = tree.add(x, tree.mul(alpha, p))
+
+        # Choose between stable (true) and cheap (recursive) residual
+        if stabilise_every > 0:
+            r = jax.lax.cond(
+                i % stabilise_every == stabilise_every - 1,
+                lambda: _stable_r(x),
+                lambda: _cheap_r(r, alpha, Ap),
+            )
+        else:
+            r = _cheap_r(r, alpha, Ap)
+
+        r_norm = _sharded_norm(r)
+
+        if iteration_callback is not None:
+            # `ordered = True` would error in distributed mode
+            jax.debug.callback(iteration_callback, i, r_norm)
+
+        z = M(r)
+        rz_new = _sharded_dot(r, z)
+        safe_rz = jnp.where(rz == 0, 1.0, rz)
+        beta = rz_new / safe_rz
+
+        p = tree.add(z, tree.mul(beta, p))
+
+        converged = _converged(r_norm)
+        residuals = residuals.at[i + 1].set(r_norm)
+
+        return x, r, p, rz_new, converged, i + 1, residuals
+
+    already_converged = _converged(r0_norm)
+    init_carry = (x0, r, p, rz, already_converged, jnp.int32(0), residuals)
+    x, _, _, _, _, num_steps, residuals = jax.lax.while_loop(cond_fn, body_fn, init_carry)
+
+    return CGResult(solution=x, residuals=residuals, num_steps=num_steps)

--- a/src/furax/linalg/_cg.py
+++ b/src/furax/linalg/_cg.py
@@ -1,6 +1,7 @@
 from collections.abc import Callable
 from typing import NamedTuple
 
+import equinox.internal as eqxi
 import jax
 import jax.numpy as jnp
 from jaxtyping import Array, Float, Num, PyTree
@@ -37,8 +38,10 @@ def cg(
     """Conjugate Gradient solver for symmetric positive definite systems Ax = b.
 
     Unlike lineax's CG solver, this implementation records the residual norm at
-    every iteration so you can monitor convergence, and tolerates inputs
-    sharded along their contracting dimensions via sharding-aware reductions.
+    every iteration so you can monitor convergence, tolerates inputs sharded
+    along their contracting dimensions via sharding-aware reductions, and is both
+    forward- and reverse-mode differentiable (it loops with a bounded
+    ``equinox.internal.while_loop``).
 
     Convergence is declared when ``||r|| <= atol + rtol * ||b||``.
 
@@ -159,6 +162,16 @@ def cg(
 
     already_converged = _converged(r0_norm)
     init_carry = (x0, r, p, rz, already_converged, jnp.int32(0), residuals)
-    x, _, _, _, _, num_steps, residuals = jax.lax.while_loop(cond_fn, body_fn, init_carry)
+    # `residuals` is only ever written (`.at[i].set`) inside the loop, never read, so mark it a
+    # buffer. `kind='bounded'` makes the loop both forward- and reverse-mode differentiable (lax's
+    # while_loop is forward-only); it unrolls up to `max_steps` with logarithmic checkpointing.
+    x, _, _, _, _, num_steps, residuals = eqxi.while_loop(
+        cond_fn,
+        body_fn,
+        init_carry,
+        max_steps=max_steps,
+        buffers=lambda carry: carry[-1],
+        kind='bounded',
+    )
 
     return CGResult(solution=x, residuals=residuals, num_steps=num_steps)

--- a/src/furax/linalg/_cg.py
+++ b/src/furax/linalg/_cg.py
@@ -28,7 +28,7 @@ class _CGCarry(NamedTuple):
     """Loop-carried state for the CG iteration.
 
     ``residuals`` is kept last and write-only so it can be passed as the ``eqxi.while_loop``
-    buffer. ``truncated`` ends the loop early on negative curvature (``truncate=True``).
+    buffer. ``truncated`` ends the loop early on negative curvature (``negative_curvature='truncate'``).
     """
 
     x: PyTree[Num[Array, '...']]
@@ -51,8 +51,7 @@ def cg(
     atol: float = 0.0,
     rtol: float = 1e-5,
     stabilise_every: int = 10,
-    truncate: bool = False,
-    check_curvature: bool = False,
+    negative_curvature: Literal['ignore', 'error', 'truncate'] = 'ignore',
     loop_kind: Literal['lax', 'checkpointed', 'bounded'] = 'lax',
     iteration_callback: Callable[[Array, Array], None] | None = None,
 ) -> CGResult:
@@ -66,8 +65,8 @@ def cg(
     Convergence is declared when ``||r|| <= atol + rtol * ||b||``. With ``atol``
     and ``rtol`` both 0 the criterion is never met and the solver runs for exactly
     ``max_steps`` steps; otherwise it stops early once the residual is small enough,
-    and ``max_steps`` is only a ceiling. ``A`` is assumed positive definite and its
-    curvature is not checked unless ``truncate`` or ``check_curvature`` is set.
+    and ``max_steps`` is only a ceiling. ``A`` is assumed positive definite; negative
+    curvature is handled per ``negative_curvature``.
 
     Args:
         A: A symmetric positive definite linear operator.
@@ -82,15 +81,16 @@ def cg(
             the true residual ``b - A x`` every N iterations (after steps
             N, 2N, 3N, ...). This counters floating-point drift at the cost of
             one extra matvec per stabilisation.
-        truncate: If True, stop on negative curvature ``p^T A p < 0`` and return
-            the last iterate before the bad direction (truncated CG, as used by
-            Newton-CG on indefinite Hessians). A positive definite ``A`` never
-            produces negative curvature, so this is a no-op for well-posed solves.
-        check_curvature: If True, raise as soon as negative curvature ``p^T A p < 0``
-            is encountered (a debugging aid for verifying ``A`` is positive definite;
-            configurable via Equinox's ``EQX_ON_ERROR``, see ``equinox.error_if``).
-            Off by default: the per-iteration check has a real runtime cost. Ignored
-            when ``truncate`` is set.
+        negative_curvature: How to handle negative curvature ``p^T A p < 0``, which a
+            positive definite ``A`` never produces. One of:
+
+            - ``'ignore'`` (default): assume ``A`` is positive definite and do not
+                check. Fastest; the other modes add a per-iteration check.
+            - ``'error'``: raise as soon as negative curvature is encountered (a
+                debugging aid for verifying ``A``; configurable via Equinox's
+                ``EQX_ON_ERROR``, see ``equinox.error_if``).
+            - ``'truncate'``: stop and return the last iterate before the bad
+                direction (truncated CG, as used by Newton-CG on indefinite Hessians).
         loop_kind: Lowering for the iteration loop (``equinox.internal.while_loop``).
             ``'lax'`` (default) is fastest and forward-mode differentiable only.
             ``'bounded'`` adds reverse-mode AD but its cost scales with ``max_steps``
@@ -116,6 +116,13 @@ def cg(
         >>> bool(jnp.allclose(result.solution, expected, atol=1e-4))
         True
     """
+    if negative_curvature not in ('ignore', 'error', 'truncate'):
+        raise ValueError(
+            f'negative_curvature must be ignore/error/truncate, got {negative_curvature!r}'
+        )
+    truncate = negative_curvature == 'truncate'
+    check_curvature = negative_curvature == 'error'
+
     if x0 is None:
         x0 = tree.zeros_like(b)
 

--- a/src/furax/linalg/_cg.py
+++ b/src/furax/linalg/_cg.py
@@ -1,5 +1,5 @@
 from collections.abc import Callable
-from typing import NamedTuple
+from typing import Literal, NamedTuple
 
 import equinox as eqx
 import equinox.internal as eqxi
@@ -24,6 +24,23 @@ class CGResult(NamedTuple):
     num_steps: Array
 
 
+class _CGCarry(NamedTuple):
+    """Loop-carried state for the CG iteration.
+
+    ``residuals`` is kept last and write-only so it can be passed as the ``eqxi.while_loop``
+    buffer. ``truncated`` ends the loop early on negative curvature (``truncate=True``).
+    """
+
+    x: PyTree[Num[Array, '...']]
+    r: PyTree[Num[Array, '...']]
+    p: PyTree[Num[Array, '...']]
+    rz: Array
+    converged: Array
+    truncated: Array
+    step: Array
+    residuals: Float[Array, ' max_steps']
+
+
 def cg(
     A: AbstractLinearOperator,
     b: PyTree[Num[Array, '...']],
@@ -35,19 +52,22 @@ def cg(
     rtol: float = 1e-5,
     stabilise_every: int = 10,
     truncate: bool = False,
+    check_curvature: bool = False,
+    loop_kind: Literal['lax', 'checkpointed', 'bounded'] = 'lax',
     iteration_callback: Callable[[Array, Array], None] | None = None,
 ) -> CGResult:
     """Conjugate Gradient solver for symmetric positive definite systems Ax = b.
 
     The residual norm is recorded at every iteration (see ``CGResult.residuals``)
     so convergence can be monitored. Inputs may be sharded along their contracting
-    dimensions, and the solve is both forward- and reverse-mode differentiable.
+    dimensions. The solve is forward-mode differentiable by default; reverse-mode
+    (``grad``/``vjp``) requires ``loop_kind='bounded'`` or ``'checkpointed'``.
 
     Convergence is declared when ``||r|| <= atol + rtol * ||b||``. With ``atol``
     and ``rtol`` both 0 the criterion is never met and the solver runs for exactly
     ``max_steps`` steps; otherwise it stops early once the residual is small enough,
-    and ``max_steps`` is only a ceiling. Negative curvature (a non positive definite
-    ``A``) is handled per ``truncate``.
+    and ``max_steps`` is only a ceiling. ``A`` is assumed positive definite and its
+    curvature is not checked unless ``truncate`` or ``check_curvature`` is set.
 
     Args:
         A: A symmetric positive definite linear operator.
@@ -62,11 +82,20 @@ def cg(
             the true residual ``b - A x`` every N iterations (after steps
             N, 2N, 3N, ...). This counters floating-point drift at the cost of
             one extra matvec per stabilisation.
-        truncate: How to handle negative curvature ``p^T A p < 0``, which a
-            positive definite ``A`` never produces. If False (default), raise a
-            runtime error (configurable via Equinox's ``EQX_ON_ERROR``; see
-            ``equinox.error_if``). If True, stop iterating and return the last
-            iterate before the bad direction (truncated CG).
+        truncate: If True, stop on negative curvature ``p^T A p < 0`` and return
+            the last iterate before the bad direction (truncated CG, as used by
+            Newton-CG on indefinite Hessians). A positive definite ``A`` never
+            produces negative curvature, so this is a no-op for well-posed solves.
+        check_curvature: If True, raise as soon as negative curvature ``p^T A p < 0``
+            is encountered (a debugging aid for verifying ``A`` is positive definite;
+            configurable via Equinox's ``EQX_ON_ERROR``, see ``equinox.error_if``).
+            Off by default: the per-iteration check has a real runtime cost. Ignored
+            when ``truncate`` is set.
+        loop_kind: Lowering for the iteration loop (``equinox.internal.while_loop``).
+            ``'lax'`` (default) is fastest and forward-mode differentiable only.
+            ``'bounded'`` adds reverse-mode AD but its cost scales with ``max_steps``
+            (the checkpoint structure runs to the ceiling regardless of early exit),
+            so keep ``max_steps`` tight. ``'checkpointed'`` is reverse-mode only.
         iteration_callback: Optional host callback called after each step with
             ``(step, r_norm)`` as 0-d JAX arrays.  Runs via
             ``jax.debug.callback`` so it is JIT-compatible and ordered.
@@ -118,12 +147,11 @@ def cg(
     # If i+1 >= max_steps (loop ran to completion), the last write is dropped by JAX.
     residuals = jnp.zeros(max_steps).at[0].set(r0_norm)
 
-    def cond_fn(carry):  # type: ignore[no-untyped-def]
-        _, _, _, _, converged, truncated, i, _ = carry
-        return ~converged & ~truncated & (i < max_steps)
+    def cond_fn(c: _CGCarry) -> Array:
+        return ~c.converged & ~c.truncated & (c.step < max_steps)
 
-    def body_fn(carry):  # type: ignore[no-untyped-def]
-        x, r, p, rz, _, _, i, residuals = carry
+    def body_fn(c: _CGCarry) -> _CGCarry:
+        x, r, p, rz, i = c.x, c.r, c.p, c.rz, c.step
 
         Ap = A(p)
         pAp = tree.dot(p, Ap)
@@ -136,8 +164,9 @@ def cg(
             safe_pAp = jnp.where(pAp == 0, 1.0, pAp)
             alpha = jnp.where(truncated, 0.0, rz / safe_pAp)
         else:
-            pAp = eqx.error_if(pAp, pAp < 0, 'cg: negative curvature detected p^T A p < 0')
-            truncated = jnp.array(False)
+            truncated = c.truncated
+            if check_curvature:
+                pAp = eqx.error_if(pAp, pAp < 0, 'cg: negative curvature detected p^T A p < 0')
             safe_pAp = jnp.where(pAp == 0, 1.0, pAp)
             alpha = rz / safe_pAp
 
@@ -167,22 +196,30 @@ def cg(
         p = tree.add(z, tree.mul(beta, p))
 
         converged = _converged(r_norm)
-        residuals = residuals.at[i + 1].set(r_norm)
+        residuals = c.residuals.at[i + 1].set(r_norm)
 
-        return x, r, p, rz_new, converged, truncated, i + 1, residuals
+        return _CGCarry(x, r, p, rz_new, converged, truncated, i + 1, residuals)
 
-    already_converged = _converged(r0_norm)
-    init_carry = (x0, r, p, rz, already_converged, jnp.array(False), jnp.int32(0), residuals)
+    init_carry = _CGCarry(
+        x=x0,
+        r=r,
+        p=p,
+        rz=rz,
+        converged=_converged(r0_norm),
+        truncated=jnp.array(False),
+        step=jnp.int32(0),
+        residuals=residuals,
+    )
     # `residuals` is only ever written (`.at[i].set`) inside the loop, never read, so mark it a
-    # buffer. `kind='bounded'` makes the loop both forward- and reverse-mode differentiable (lax's
-    # while_loop is forward-only); it unrolls up to `max_steps` with logarithmic checkpointing.
-    x, _, _, _, _, _, num_steps, residuals = eqxi.while_loop(
+    # buffer for an efficient in-place scatter. `loop_kind` selects the lowering: 'lax' is fastest
+    # (forward-mode AD only), 'bounded'/'checkpointed' add reverse-mode AD (see `loop_kind` arg).
+    out = eqxi.while_loop(
         cond_fn,
         body_fn,
         init_carry,
         max_steps=max_steps,
-        buffers=lambda carry: carry[-1],
-        kind='bounded',
+        buffers=lambda c: c.residuals,
+        kind=loop_kind,
     )
 
-    return CGResult(solution=x, residuals=residuals, num_steps=num_steps)
+    return CGResult(solution=out.x, residuals=out.residuals, num_steps=out.step)

--- a/src/furax/tree.py
+++ b/src/furax/tree.py
@@ -254,7 +254,15 @@ def dot(x: PyTree[Num[Array, '...']], y: PyTree[Num[Array, '...']]) -> Num[Array
         >>> fx.tree.dot(x, y)
         Array(5., dtype=float32)
     """
-    xy = jax.tree.map(jnp.vdot, x, y)
+    # No `jnp.vdot`: it lowers to `dot_general`, which under explicit-axis sharding refuses
+    # to pick an output sharding when the contracting axis is sharded (raises ShardingTypeError).
+    #
+    # Instead, simply use the reduction `sum(conj(x) * y)` for which JAX auto-inserts the
+    # all-reduce,so the dot is well-defined when sharded.
+    #
+    # Trade-off: we lose `dot_general`'s fused high-precision accumulation (vdot can pass
+    # `precision=HIGHEST`); a plain `jnp.sum` accumulates in the leaf dtype.
+    xy = jax.tree.map(lambda a, b: jnp.sum(jnp.conj(a) * b), x, y)
     return sum(jax.tree.leaves(xy), start=jnp.array(0))
 
 
@@ -272,7 +280,9 @@ def norm(x: PyTree[Num[Array, '...']]) -> Num[Array, '']:
         >>> fx.tree.norm(x)
         Array(5., dtype=float32)
     """
-    return jnp.sqrt(dot(x, x))
+    # `dot(x, x) = sum(|x|^2)` is already real-valued
+    # explicit `.real` keeps the result real-dtyped for complex inputs
+    return jnp.sqrt(dot(x, x).real)
 
 
 def matvec(

--- a/src/furax/tree.py
+++ b/src/furax/tree.py
@@ -125,7 +125,7 @@ def full_like(x: P, fill_value: ScalarLike) -> P:
         ...          'b': jax.ShapeDtypeStruct((), jnp.float32)}, 3)
         {'a': Array([3, 3], dtype=int32), 'b': Array(3., dtype=float32)}
     """
-    result: P = jax.tree.map(lambda leaf: jnp.full(leaf.shape, fill_value, leaf.dtype), x)
+    result: P = jax.tree.map(lambda leaf: jnp.full_like(leaf, fill_value), x)
     return result
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,65 +1,54 @@
 import logging
 import os
-from typing import get_args
 
-import healpy as hp
-import jax
-import numpy as np
 import pytest
-from jaxtyping import Array, Float
-
-from furax.obs.stokes import StokesIQU, ValidStokesType
-from tests.helpers import TEST_DATA_PLANCK, TEST_DATA_SAT
 
 # Disable JAX GPU memory pre-allocation so the allocator can free memory between
 # tests instead of holding 75% of GPU memory for the entire session.
 os.environ.setdefault('XLA_PYTHON_CLIENT_PREALLOCATE', 'false')
 
+# Do not import JAX here (directly or transitively): `JAX_PLATFORMS` and the device
+# count are snapshotted at `import jax`, which must happen after pytest_configure has
+# set them. Hence JAX-touching imports are deferred into fixtures and test modules.
+
+
+def pytest_configure(config: pytest.Config) -> None:
+    """Provision several CPU devices for a ``-m distributed`` selection.
+
+    Must run before any ``import jax``: the platform and device count are fixed at backend init.
+    """
+    markexpr = str(getattr(config.option, 'markexpr', '') or '')
+    running_distributed = 'distributed' in markexpr and 'not distributed' not in markexpr
+    if not running_distributed:
+        return
+    if 'SLURM_JOB_ID' in os.environ:
+        import jax
+
+        jax.distributed.initialize()
+    else:
+        os.environ.setdefault('JAX_PLATFORMS', 'cpu')
+        os.environ.setdefault('XLA_FLAGS', '--xla_force_host_platform_device_count=8')
+
+
+def pytest_collection_modifyitems(items: list[pytest.Item]) -> None:
+    """Skip ``distributed``-marked tests unless several devices are available."""
+    import jax
+
+    if jax.device_count() >= 2:
+        return
+    skip = pytest.mark.skip(reason='distributed test; run with `pytest -m distributed`')
+    for item in items:
+        if item.get_closest_marker('distributed'):
+            item.add_marker(skip)
+
 
 @pytest.fixture(scope='session', autouse=True)
 def enable_x64() -> None:
+    import jax
+
     jax.config.update('jax_enable_x64', True)
 
 
 @pytest.fixture(scope='session', autouse=True)
 def silence_furax_logger() -> None:
     logging.getLogger('furax-mapmaking').setLevel(logging.WARNING)
-
-
-def load_planck(nside: int) -> np.ndarray:
-    PLANCK_URL = 'https://irsa.ipac.caltech.edu/data/Planck/release_3/all-sky-maps/maps/HFI_SkyMap_143_2048_R3.01_full.fits'
-    map_2048 = hp.read_map(PLANCK_URL, field=['I_STOKES', 'Q_STOKES', 'U_STOKES'])
-    return hp.ud_grade(map_2048, nside)
-
-
-@pytest.fixture(scope='session')
-def planck_iqu_256() -> StokesIQU:
-    nside = 256
-    path = TEST_DATA_PLANCK / f'HFI_SkyMap_143_{nside}_R3.01_full_IQU.fits'
-    if path.exists():
-        maps = hp.read_map(path, field=[0, 1, 2])
-    else:
-        maps = load_planck(nside)
-        TEST_DATA_PLANCK.mkdir(parents=True, exist_ok=True)
-        hp.write_map(path, maps)
-    i, q, u = maps.astype(float)
-    return StokesIQU(
-        i=jax.device_put(i),
-        q=jax.device_put(q),
-        u=jax.device_put(u),
-    )
-
-
-@pytest.fixture(scope='session')
-def sat_nhits() -> Float[Array, '...']:
-    nhits = hp.read_map(TEST_DATA_SAT / 'norm_nHits_SA_35FOV_G_nside512.fits').astype('<f8')
-    npixel = nhits.size
-    nhits[: npixel // 2] = 0
-    nhits /= np.sum(nhits)
-    return jax.device_put(nhits)
-
-
-@pytest.fixture(params=get_args(ValidStokesType))
-def stokes(request: pytest.FixtureRequest) -> ValidStokesType:
-    """Parametrized fixture for I, QU, IQU and IQUV."""
-    return request.param

--- a/tests/linalg/test_cg.py
+++ b/tests/linalg/test_cg.py
@@ -236,6 +236,31 @@ class TestCGGrad:
         assert_allclose(jac, jnp.diag(1.0 / d), atol=1e-4)
 
 
+class TestCGCurvature:
+    """Negative curvature p^T A p < 0, which a positive definite A never produces."""
+
+    def test_raises_on_negative_curvature(self):
+        d = jnp.arange(1.0, 6.0)
+        A = DiagonalOperator(-d, in_structure=as_structure(d))  # negative definite
+        b = jnp.ones(5)
+        with pytest.raises(Exception, match='negative curvature'):
+            jax.block_until_ready(cg(A, b, max_steps=20))
+
+    def test_truncate_stops_instead_of_raising(self):
+        d = jnp.arange(1.0, 6.0)
+        A = DiagonalOperator(-d, in_structure=as_structure(d))  # negative definite
+        b = jnp.ones(5)
+        # Bad curvature hits on the first direction: no step taken, solution stays at x0 (zeros).
+        result = cg(A, b, max_steps=20, truncate=True)
+        assert int(result.num_steps) == 1
+        assert_allclose(result.solution, jnp.zeros(5), atol=0.0)
+
+    def test_truncate_matches_default_when_positive_definite(self):
+        A, b, x_true = _diagonal_system()
+        result = cg(A, b, max_steps=20, truncate=True)
+        assert_allclose(result.solution, x_true, rtol=1e-4)
+
+
 _AXIS_TYPES = {'explicit': AxisType.Explicit, 'auto': AxisType.Auto}
 
 

--- a/tests/linalg/test_cg.py
+++ b/tests/linalg/test_cg.py
@@ -160,8 +160,8 @@ class TestCGJit:
 class TestCGGrad:
     """Gradient tests for the CG solver.
 
-    The CG solver uses jax.lax.while_loop, which supports forward-mode AD
-    (jvp/jacfwd) but not reverse-mode AD (grad/vjp).
+    The CG solver uses eqxi.while_loop(kind='bounded'), which supports both
+    forward-mode (jvp/jacfwd) and reverse-mode (grad/vjp) autodiff.
 
     For f(b) = h(cg(A, b).solution), the Jacobian is A^{-1}: each column of
     jacfwd(solve)(b) is A^{-1} applied to the corresponding standard basis
@@ -211,9 +211,8 @@ class TestCGGrad:
         expected = v / d
         assert_allclose(jvp_val, expected, rtol=1e-4)
 
-    def test_grad_raises_for_while_loop(self):
-        """Reverse-mode AD through while_loop is not supported."""
-
+    def test_grad_wrt_b(self):
+        """Reverse-mode AD through the bounded while_loop: grad sum(A^{-1} b) = A^{-T} 1 = 1/d."""
         d = jnp.arange(1.0, 6.0)
         A = DiagonalOperator(d, in_structure=as_structure(d))
         b = jnp.ones(5)
@@ -221,8 +220,20 @@ class TestCGGrad:
         def f(b):
             return jnp.sum(cg(A, b, max_steps=20).solution)
 
-        with pytest.raises(ValueError, match='Reverse-mode differentiation'):
-            jax.grad(f)(b)
+        grad = jax.grad(f)(b)
+        assert_allclose(grad, 1.0 / d, rtol=1e-4)
+
+    def test_jacrev_wrt_b_equals_inverse(self):
+        """Full reverse-mode Jacobian of the solution w.r.t. b is A^{-1}."""
+        d = jnp.arange(1.0, 6.0)
+        A = DiagonalOperator(d, in_structure=as_structure(d))
+        b = jnp.ones(5)
+
+        def solve(b):
+            return cg(A, b, max_steps=20).solution
+
+        jac = jax.jacrev(solve)(b)
+        assert_allclose(jac, jnp.diag(1.0 / d), atol=1e-4)
 
 
 _AXIS_TYPES = {'explicit': AxisType.Explicit, 'auto': AxisType.Auto}
@@ -241,12 +252,7 @@ def _sharded_layout(ndim: int) -> tuple[tuple[int, ...], tuple[str, ...], P]:
 
 @pytest.mark.distributed
 class TestCGDistributed:
-    """Multi-device CG over a vector sharded along its contracting axis.
-
-    ``furax.tree.dot`` contracts via a reduction, so the all-reduce is inserted automatically where
-    ``jnp.vdot`` would raise ``ShardingTypeError`` under explicit-axis sharding. Run with
-    ``pytest -m distributed`` (the conftest provisions the devices); skipped otherwise.
-    """
+    """Multi-device CG over a vector sharded along its contracting axis."""
 
     K = 3  # replicated trailing dimension (amplitudes per block)
 

--- a/tests/linalg/test_cg.py
+++ b/tests/linalg/test_cg.py
@@ -2,8 +2,11 @@
 
 import jax
 import jax.numpy as jnp
+import numpy as np
 import pytest
 from equinox import tree_equal
+from jax.sharding import AxisType, NamedSharding
+from jax.sharding import PartitionSpec as P
 from numpy.testing import assert_allclose
 
 from furax import BlockDiagonalOperator, DiagonalOperator, IdentityOperator
@@ -220,3 +223,69 @@ class TestCGGrad:
 
         with pytest.raises(ValueError, match='Reverse-mode differentiation'):
             jax.grad(f)(b)
+
+
+_AXIS_TYPES = {'explicit': AxisType.Explicit, 'auto': AxisType.Auto}
+
+
+def _sharded_layout(ndim: int) -> tuple[tuple[int, ...], tuple[str, ...], P]:
+    """Mesh shape, axis names and partition spec sharding the leading axes over all devices."""
+    n = jax.device_count()
+    if ndim == 1:
+        return (n,), ('i',), P('i', None)
+    if ndim == 2:
+        assert n % 2 == 0, n
+        return (2, n // 2), ('i', 'j'), P('i', 'j', None)
+    raise ValueError(ndim)
+
+
+@pytest.mark.distributed
+class TestCGDistributed:
+    """Multi-device CG over a vector sharded along its contracting axis.
+
+    ``furax.tree.dot`` contracts via a reduction, so the all-reduce is inserted automatically where
+    ``jnp.vdot`` would raise ``ShardingTypeError`` under explicit-axis sharding. Run with
+    ``pytest -m distributed`` (the conftest provisions the devices); skipped otherwise.
+    """
+
+    K = 3  # replicated trailing dimension (amplitudes per block)
+
+    @pytest.mark.parametrize('ndim', [1, 2], ids=['mesh1d', 'mesh2d'])
+    @pytest.mark.parametrize('axis_type', ['explicit', 'auto'])
+    def test_solves_vector_sharded_on_contracting_axis(self, axis_type: str, ndim: int) -> None:
+        axis = _AXIS_TYPES[axis_type]
+        mesh_shape, axis_names, spec = _sharded_layout(ndim)
+
+        # SPD diagonal system over a vector of shape (*mesh_shape, K).
+        vec_shape = (*mesh_shape, self.K)
+        size = int(np.prod(vec_shape))
+        diag = (1.0 + jnp.arange(size, dtype=float)).reshape(vec_shape)
+        b = jnp.ones(vec_shape)
+        x_true = b / diag
+
+        # Single-device reference (no mesh): plain replicated solve.
+        reference = cg(
+            DiagonalOperator(diag, in_structure=as_structure(b)), b, max_steps=50, rtol=1e-10
+        )
+        assert_allclose(np.asarray(reference.solution), x_true, rtol=1e-9)
+
+        mesh = jax.make_mesh(mesh_shape, axis_names, axis_types=(axis,) * ndim)
+        with jax.set_mesh(mesh):
+            shard = NamedSharding(mesh, spec)
+            b_s = jax.device_put(b, shard)
+            diag_s = jax.device_put(diag, shard)
+            A = DiagonalOperator(diag_s, in_structure=as_structure(b_s))
+            M = DiagonalOperator(1.0 / diag_s, in_structure=as_structure(b_s))
+
+            plain = jax.jit(lambda b: cg(A, b, max_steps=50, rtol=1e-10))(b_s)
+            # preconditioner exercises M(r) under sharding; exact M -> converges in one step.
+            precond = jax.jit(lambda b: cg(A, b, max_steps=50, rtol=1e-10, preconditioner=M))(b_s)
+
+        for result in (plain, precond):
+            assert_allclose(np.asarray(result.solution), x_true, rtol=1e-9)
+        assert int(precond.num_steps) == 1, int(precond.num_steps)
+
+        # Under explicit axes the sharding is part of the type and propagates to the solution;
+        # under auto axes JAX is free to choose, so only assert the spec in the explicit case.
+        if axis is AxisType.Explicit:
+            assert plain.solution.sharding.spec == spec, plain.solution.sharding.spec

--- a/tests/linalg/test_cg.py
+++ b/tests/linalg/test_cg.py
@@ -1,0 +1,222 @@
+"""Tests for the Conjugate Gradient solver."""
+
+import jax
+import jax.numpy as jnp
+import pytest
+from equinox import tree_equal
+from numpy.testing import assert_allclose
+
+from furax import BlockDiagonalOperator, DiagonalOperator, IdentityOperator
+from furax.linalg import CGResult, cg
+from furax.tree import as_structure
+
+
+def _diagonal_system(n: int = 5):
+    """Return a diagonal SPD operator and a simple RHS."""
+    d = jnp.arange(1, n + 1, dtype=float)
+    A = DiagonalOperator(d, in_structure=as_structure(d))
+    b = jnp.ones(n, dtype=float)
+    x_true = b / d
+    return A, b, x_true
+
+
+class TestCGBasic:
+    def test_solves_diagonal_system(self):
+        A, b, x_true = _diagonal_system()
+        result = cg(A, b, max_steps=20)
+        assert isinstance(result, CGResult)
+        assert_allclose(result.solution, x_true, rtol=1e-4)
+
+    def test_residuals(self):
+        A, b, _ = _diagonal_system(n=20)
+        result = cg(A, b, max_steps=20, rtol=0.0, atol=0.0)
+        assert result.residuals.shape == (20,)
+        assert_allclose(result.residuals[0], jnp.linalg.norm(b), rtol=1e-5)
+
+    def test_custom_x0(self):
+        A, b, _ = _diagonal_system()
+        x0 = jax.random.normal(jax.random.key(0), b.shape, dtype=b.dtype)
+        result_default = cg(A, b, max_steps=20)
+        result_x0 = cg(A, b, x0, max_steps=20)
+        assert_allclose(result_x0.solution, result_default.solution, rtol=1e-5)
+
+    def test_iterations_count_when_x0_is_solution(self):
+        A, b, x_true = _diagonal_system(n=5)
+        result = cg(A, b, x_true, max_steps=20, rtol=1e-10, atol=0.0)
+        assert int(result.num_steps) == 0
+
+    def test_iterations_count_when_tol_is_zero(self):
+        # iterates for max_iter even with true solution as starting vector
+        A, b, x_true = _diagonal_system(n=10)
+        result = cg(A, b, x_true, max_steps=5, rtol=0.0, atol=0.0)
+        assert int(result.num_steps) == 5
+
+
+class TestCGPreconditioner:
+    def test_identity_preconditioner_same_result(self):
+        A, b, _ = _diagonal_system()
+        M = IdentityOperator(in_structure=as_structure(b))
+        result = cg(A, b, max_steps=20)
+        result_m = cg(A, b, max_steps=20, preconditioner=M)
+        assert tree_equal(result, result_m)
+
+    def test_exact_preconditioner_converges_in_one_step(self):
+        d = jnp.arange(1.0, 6.0)
+        A = DiagonalOperator(d, in_structure=as_structure(d))
+        b = jnp.ones(5)
+        # M = A^{-1} makes M A = I → converges in 1 iteration
+        M = DiagonalOperator(1.0 / d, in_structure=as_structure(d))
+        result = cg(A, b, max_steps=20, preconditioner=M, rtol=1e-8, atol=0.0)
+        assert int(result.num_steps) == 1
+
+
+class TestCGPyTree:
+    def test_pytree_rhs(self):
+        d1 = jnp.array([1.0, 2.0])
+        d2 = jnp.array([3.0, 4.0])
+        structure = {'a': as_structure(d1), 'b': as_structure(d2)}
+        A = BlockDiagonalOperator(
+            {
+                'a': DiagonalOperator(d1, in_structure=structure['a']),
+                'b': DiagonalOperator(d2, in_structure=structure['b']),
+            }
+        )
+        b = {'a': jnp.ones(2), 'b': jnp.ones(2)}
+        x_true = {'a': jnp.array([1.0, 0.5]), 'b': jnp.array([1.0 / 3, 0.25])}
+
+        result = cg(A, b, max_steps=20)
+        assert tree_equal(result.solution, x_true, rtol=1e-4)
+
+
+class TestCGJit:
+    def test_jit_basic(self):
+        A, b, x_true = _diagonal_system()
+
+        @jax.jit
+        def solve(b):
+            return cg(A, b, max_steps=20)
+
+        result = solve(b)
+        assert_allclose(result.solution, x_true, rtol=1e-4)
+
+    def test_jit_with_preconditioner(self):
+        d = jnp.arange(1.0, 6.0)
+        A = DiagonalOperator(d, in_structure=as_structure(d))
+        M = DiagonalOperator(1.0 / d, in_structure=as_structure(d))
+        b = jnp.ones(5)
+        x_true = b / d
+
+        @jax.jit
+        def solve(b):
+            return cg(A, b, max_steps=20, preconditioner=M)
+
+        result = solve(b)
+        assert_allclose(result.solution, x_true, rtol=1e-4)
+
+    def test_jit_with_stabilise(self):
+        A, b, x_true = _diagonal_system(n=10)
+
+        @jax.jit
+        def solve(b):
+            return cg(A, b, max_steps=30, stabilise_every=3)
+
+        result = solve(b)
+        assert_allclose(result.solution, x_true, rtol=1e-4)
+
+    def test_jit_residuals_shape_preserved(self):
+        A, b, _ = _diagonal_system()
+
+        @jax.jit
+        def solve(b):
+            return cg(A, b, max_steps=13)
+
+        result = solve(b)
+        assert result.residuals.shape == (13,)
+
+    def test_jit_pytree(self):
+        d1 = jnp.array([1.0, 2.0])
+        d2 = jnp.array([3.0, 4.0])
+        structure = {'a': as_structure(d1), 'b': as_structure(d2)}
+        A = BlockDiagonalOperator(
+            {
+                'a': DiagonalOperator(d1, in_structure=structure['a']),
+                'b': DiagonalOperator(d2, in_structure=structure['b']),
+            }
+        )
+        b = {'a': jnp.ones(2), 'b': jnp.ones(2)}
+
+        @jax.jit
+        def solve(b):
+            return cg(A, b, max_steps=20)
+
+        result = solve(b)
+        x_true = {'a': jnp.array([1.0, 0.5]), 'b': jnp.array([1.0 / 3, 0.25])}
+        assert tree_equal(result.solution, x_true, rtol=1e-4)
+
+
+class TestCGGrad:
+    """Gradient tests for the CG solver.
+
+    The CG solver uses jax.lax.while_loop, which supports forward-mode AD
+    (jvp/jacfwd) but not reverse-mode AD (grad/vjp).
+
+    For f(b) = h(cg(A, b).solution), the Jacobian is A^{-1}: each column of
+    jacfwd(solve)(b) is A^{-1} applied to the corresponding standard basis
+    vector, by the implicit function theorem.
+    """
+
+    def test_jvp_wrt_b(self):
+        """Directional derivative of the solution w.r.t. b equals A^{-1} v."""
+        d = jnp.arange(1.0, 6.0)
+        A = DiagonalOperator(d, in_structure=as_structure(d))
+        b = jnp.ones(5)
+        v = jax.random.normal(jax.random.key(42), b.shape)
+
+        def solve(b):
+            return cg(A, b, max_steps=20).solution
+
+        _, jvp_val = jax.jvp(solve, (b,), (v,))
+        # d(A^{-1} b)/db · v = A^{-1} v = v / d
+        expected = v / d
+        assert_allclose(jvp_val, expected, rtol=1e-4)
+
+    def test_jacfwd_wrt_b_equals_inverse(self):
+        """Full Jacobian of the solution w.r.t. b is A^{-1}."""
+        d = jnp.arange(1.0, 6.0)
+        A = DiagonalOperator(d, in_structure=as_structure(d))
+        b = jnp.ones(5)
+
+        def solve(b):
+            return cg(A, b, max_steps=20).solution
+
+        jac = jax.jacfwd(solve)(b)
+        expected = jnp.diag(1.0 / d)
+        assert_allclose(jac, expected, atol=1e-4)
+
+    def test_jvp_with_preconditioner(self):
+        """JVP still equals A^{-1} v when using a preconditioner."""
+        d = jnp.arange(1.0, 6.0)
+        A = DiagonalOperator(d, in_structure=as_structure(d))
+        M = DiagonalOperator(1.0 / d, in_structure=as_structure(d))
+        b = jnp.ones(5)
+        v = jax.random.normal(jax.random.key(7), b.shape)
+
+        def solve(b):
+            return cg(A, b, max_steps=20, preconditioner=M).solution
+
+        _, jvp_val = jax.jvp(solve, (b,), (v,))
+        expected = v / d
+        assert_allclose(jvp_val, expected, rtol=1e-4)
+
+    def test_grad_raises_for_while_loop(self):
+        """Reverse-mode AD through while_loop is not supported."""
+
+        d = jnp.arange(1.0, 6.0)
+        A = DiagonalOperator(d, in_structure=as_structure(d))
+        b = jnp.ones(5)
+
+        def f(b):
+            return jnp.sum(cg(A, b, max_steps=20).solution)
+
+        with pytest.raises(ValueError, match='Reverse-mode differentiation'):
+            jax.grad(f)(b)

--- a/tests/linalg/test_cg.py
+++ b/tests/linalg/test_cg.py
@@ -28,7 +28,7 @@ class TestCGBasic:
         A, b, x_true = _diagonal_system()
         result = cg(A, b, max_steps=20)
         assert isinstance(result, CGResult)
-        assert_allclose(result.solution, x_true, rtol=1e-4)
+        assert_allclose(result.solution, x_true, rtol=1e-10)
 
     def test_residuals(self):
         A, b, _ = _diagonal_system(n=20)
@@ -41,7 +41,7 @@ class TestCGBasic:
         x0 = jax.random.normal(jax.random.key(0), b.shape, dtype=b.dtype)
         result_default = cg(A, b, max_steps=20)
         result_x0 = cg(A, b, x0, max_steps=20)
-        assert_allclose(result_x0.solution, result_default.solution, rtol=1e-5)
+        assert_allclose(result_x0.solution, result_default.solution, rtol=1e-10)
 
     def test_iterations_count_when_x0_is_solution(self):
         A, b, x_true = _diagonal_system(n=5)
@@ -88,7 +88,7 @@ class TestCGPyTree:
         x_true = {'a': jnp.array([1.0, 0.5]), 'b': jnp.array([1.0 / 3, 0.25])}
 
         result = cg(A, b, max_steps=20)
-        assert tree_equal(result.solution, x_true, rtol=1e-4)
+        assert tree_equal(result.solution, x_true, rtol=1e-10)
 
 
 class TestCGJit:
@@ -100,7 +100,7 @@ class TestCGJit:
             return cg(A, b, max_steps=20)
 
         result = solve(b)
-        assert_allclose(result.solution, x_true, rtol=1e-4)
+        assert_allclose(result.solution, x_true, rtol=1e-10)
 
     def test_jit_with_preconditioner(self):
         d = jnp.arange(1.0, 6.0)
@@ -114,7 +114,7 @@ class TestCGJit:
             return cg(A, b, max_steps=20, preconditioner=M)
 
         result = solve(b)
-        assert_allclose(result.solution, x_true, rtol=1e-4)
+        assert_allclose(result.solution, x_true, rtol=1e-10)
 
     def test_jit_with_stabilise(self):
         A, b, x_true = _diagonal_system(n=10)
@@ -124,7 +124,7 @@ class TestCGJit:
             return cg(A, b, max_steps=30, stabilise_every=3)
 
         result = solve(b)
-        assert_allclose(result.solution, x_true, rtol=1e-4)
+        assert_allclose(result.solution, x_true, rtol=1e-10)
 
     def test_jit_residuals_shape_preserved(self):
         A, b, _ = _diagonal_system()
@@ -154,7 +154,7 @@ class TestCGJit:
 
         result = solve(b)
         x_true = {'a': jnp.array([1.0, 0.5]), 'b': jnp.array([1.0 / 3, 0.25])}
-        assert tree_equal(result.solution, x_true, rtol=1e-4)
+        assert tree_equal(result.solution, x_true, rtol=1e-10)
 
 
 class TestCGGrad:
@@ -181,7 +181,7 @@ class TestCGGrad:
         _, jvp_val = jax.jvp(solve, (b,), (v,))
         # d(A^{-1} b)/db · v = A^{-1} v = v / d
         expected = v / d
-        assert_allclose(jvp_val, expected, rtol=1e-4)
+        assert_allclose(jvp_val, expected, rtol=1e-10)
 
     def test_jacfwd_wrt_b_equals_inverse(self):
         """Full Jacobian of the solution w.r.t. b is A^{-1}."""
@@ -194,7 +194,7 @@ class TestCGGrad:
 
         jac = jax.jacfwd(solve)(b)
         expected = jnp.diag(1.0 / d)
-        assert_allclose(jac, expected, atol=1e-4)
+        assert_allclose(jac, expected, atol=1e-10)
 
     def test_jvp_with_preconditioner(self):
         """JVP still equals A^{-1} v when using a preconditioner."""
@@ -209,7 +209,7 @@ class TestCGGrad:
 
         _, jvp_val = jax.jvp(solve, (b,), (v,))
         expected = v / d
-        assert_allclose(jvp_val, expected, rtol=1e-4)
+        assert_allclose(jvp_val, expected, rtol=1e-10)
 
     def test_grad_wrt_b(self):
         """Reverse-mode AD with loop_kind='bounded': grad sum(A^{-1} b) = A^{-T} 1 = 1/d."""
@@ -221,7 +221,7 @@ class TestCGGrad:
             return jnp.sum(cg(A, b, max_steps=20, loop_kind='bounded').solution)
 
         grad = jax.grad(f)(b)
-        assert_allclose(grad, 1.0 / d, rtol=1e-4)
+        assert_allclose(grad, 1.0 / d, rtol=1e-10)
 
     def test_jacrev_wrt_b_equals_inverse(self):
         """Full reverse-mode Jacobian of the solution w.r.t. b is A^{-1}."""
@@ -233,7 +233,7 @@ class TestCGGrad:
             return cg(A, b, max_steps=20, loop_kind='bounded').solution
 
         jac = jax.jacrev(solve)(b)
-        assert_allclose(jac, jnp.diag(1.0 / d), atol=1e-4)
+        assert_allclose(jac, jnp.diag(1.0 / d), atol=1e-10)
 
     def test_grad_raises_with_default_lax_loop(self):
         """The default loop_kind='lax' is forward-mode only; reverse-mode raises."""
@@ -278,7 +278,7 @@ class TestCGCurvature:
     def test_truncate_matches_default_when_positive_definite(self):
         A, b, x_true = _diagonal_system()
         result = cg(A, b, max_steps=20, negative_curvature='truncate')
-        assert_allclose(result.solution, x_true, rtol=1e-4)
+        assert_allclose(result.solution, x_true, rtol=1e-10)
 
     def test_invalid_negative_curvature_raises(self):
         A, b, _ = _diagonal_system()

--- a/tests/linalg/test_cg.py
+++ b/tests/linalg/test_cg.py
@@ -259,26 +259,31 @@ class TestCGCurvature:
         result = jax.block_until_ready(cg(A, b, max_steps=20))
         assert result.solution.shape == b.shape
 
-    def test_check_curvature_raises(self):
+    def test_error_mode_raises(self):
         d = jnp.arange(1.0, 6.0)
         A = DiagonalOperator(-d, in_structure=as_structure(d))  # negative definite
         b = jnp.ones(5)
         with pytest.raises(Exception, match='negative curvature'):
-            jax.block_until_ready(cg(A, b, max_steps=20, check_curvature=True))
+            jax.block_until_ready(cg(A, b, max_steps=20, negative_curvature='error'))
 
     def test_truncate_stops_instead_of_raising(self):
         d = jnp.arange(1.0, 6.0)
         A = DiagonalOperator(-d, in_structure=as_structure(d))  # negative definite
         b = jnp.ones(5)
         # Bad curvature hits on the first direction: no step taken, solution stays at x0 (zeros).
-        result = cg(A, b, max_steps=20, truncate=True)
+        result = cg(A, b, max_steps=20, negative_curvature='truncate')
         assert int(result.num_steps) == 1
         assert_allclose(result.solution, jnp.zeros(5), atol=0.0)
 
     def test_truncate_matches_default_when_positive_definite(self):
         A, b, x_true = _diagonal_system()
-        result = cg(A, b, max_steps=20, truncate=True)
+        result = cg(A, b, max_steps=20, negative_curvature='truncate')
         assert_allclose(result.solution, x_true, rtol=1e-4)
+
+    def test_invalid_negative_curvature_raises(self):
+        A, b, _ = _diagonal_system()
+        with pytest.raises(ValueError, match='negative_curvature'):
+            cg(A, b, max_steps=20, negative_curvature='nope')
 
 
 _AXIS_TYPES = {'explicit': AxisType.Explicit, 'auto': AxisType.Auto}

--- a/tests/linalg/test_cg.py
+++ b/tests/linalg/test_cg.py
@@ -160,8 +160,8 @@ class TestCGJit:
 class TestCGGrad:
     """Gradient tests for the CG solver.
 
-    The CG solver uses eqxi.while_loop(kind='bounded'), which supports both
-    forward-mode (jvp/jacfwd) and reverse-mode (grad/vjp) autodiff.
+    Forward-mode (jvp/jacfwd) works with the default loop; reverse-mode (grad/vjp)
+    needs loop_kind='bounded'.
 
     For f(b) = h(cg(A, b).solution), the Jacobian is A^{-1}: each column of
     jacfwd(solve)(b) is A^{-1} applied to the corresponding standard basis
@@ -212,13 +212,13 @@ class TestCGGrad:
         assert_allclose(jvp_val, expected, rtol=1e-4)
 
     def test_grad_wrt_b(self):
-        """Reverse-mode AD through the bounded while_loop: grad sum(A^{-1} b) = A^{-T} 1 = 1/d."""
+        """Reverse-mode AD with loop_kind='bounded': grad sum(A^{-1} b) = A^{-T} 1 = 1/d."""
         d = jnp.arange(1.0, 6.0)
         A = DiagonalOperator(d, in_structure=as_structure(d))
         b = jnp.ones(5)
 
         def f(b):
-            return jnp.sum(cg(A, b, max_steps=20).solution)
+            return jnp.sum(cg(A, b, max_steps=20, loop_kind='bounded').solution)
 
         grad = jax.grad(f)(b)
         assert_allclose(grad, 1.0 / d, rtol=1e-4)
@@ -230,21 +230,41 @@ class TestCGGrad:
         b = jnp.ones(5)
 
         def solve(b):
-            return cg(A, b, max_steps=20).solution
+            return cg(A, b, max_steps=20, loop_kind='bounded').solution
 
         jac = jax.jacrev(solve)(b)
         assert_allclose(jac, jnp.diag(1.0 / d), atol=1e-4)
+
+    def test_grad_raises_with_default_lax_loop(self):
+        """The default loop_kind='lax' is forward-mode only; reverse-mode raises."""
+        d = jnp.arange(1.0, 6.0)
+        A = DiagonalOperator(d, in_structure=as_structure(d))
+        b = jnp.ones(5)
+
+        def f(b):
+            return jnp.sum(cg(A, b, max_steps=20).solution)
+
+        with pytest.raises(ValueError, match='[Rr]everse-mode'):
+            jax.grad(f)(b)
 
 
 class TestCGCurvature:
     """Negative curvature p^T A p < 0, which a positive definite A never produces."""
 
-    def test_raises_on_negative_curvature(self):
+    def test_no_check_by_default(self):
+        # Default assumes A positive definite and does not check; negative curvature is silent.
+        d = jnp.arange(1.0, 6.0)
+        A = DiagonalOperator(-d, in_structure=as_structure(d))  # negative definite
+        b = jnp.ones(5)
+        result = jax.block_until_ready(cg(A, b, max_steps=20))
+        assert result.solution.shape == b.shape
+
+    def test_check_curvature_raises(self):
         d = jnp.arange(1.0, 6.0)
         A = DiagonalOperator(-d, in_structure=as_structure(d))  # negative definite
         b = jnp.ones(5)
         with pytest.raises(Exception, match='negative curvature'):
-            jax.block_until_ready(cg(A, b, max_steps=20))
+            jax.block_until_ready(cg(A, b, max_steps=20, check_curvature=True))
 
     def test_truncate_stops_instead_of_raising(self):
         d = jnp.arange(1.0, 6.0)

--- a/tests/obs/conftest.py
+++ b/tests/obs/conftest.py
@@ -1,0 +1,11 @@
+from typing import get_args
+
+import pytest
+
+from furax.obs.stokes import ValidStokesType
+
+
+@pytest.fixture(params=get_args(ValidStokesType))
+def stokes(request: pytest.FixtureRequest) -> ValidStokesType:
+    """Parametrized fixture for I, QU, IQU and IQUV."""
+    return request.param

--- a/tests/test_solver.py
+++ b/tests/test_solver.py
@@ -1,10 +1,12 @@
 import time
 
+import healpy as hp
 import jax
 import jax.numpy as jnp
 import lineax as lx
 import numpy as np
 import pytest
+from jaxtyping import Array, Float
 from numpy.random import PCG64, Generator
 
 from furax import Config, DiagonalOperator, OperatorTag
@@ -17,7 +19,42 @@ from furax._instruments.sat import (
 from furax.interfaces.lineax import as_lineax_operator
 from furax.obs._samplings import create_random_sampling
 from furax.obs.landscapes import HealpixLandscape
+from furax.obs.stokes import StokesIQU
 from furax.tree import as_structure
+from tests.helpers import TEST_DATA_PLANCK, TEST_DATA_SAT
+
+
+def load_planck(nside: int) -> np.ndarray:
+    PLANCK_URL = 'https://irsa.ipac.caltech.edu/data/Planck/release_3/all-sky-maps/maps/HFI_SkyMap_143_2048_R3.01_full.fits'
+    map_2048 = hp.read_map(PLANCK_URL, field=['I_STOKES', 'Q_STOKES', 'U_STOKES'])
+    return hp.ud_grade(map_2048, nside)
+
+
+@pytest.fixture(scope='module')
+def planck_iqu_256() -> StokesIQU:
+    nside = 256
+    path = TEST_DATA_PLANCK / f'HFI_SkyMap_143_{nside}_R3.01_full_IQU.fits'
+    if path.exists():
+        maps = hp.read_map(path, field=[0, 1, 2])
+    else:
+        maps = load_planck(nside)
+        TEST_DATA_PLANCK.mkdir(parents=True, exist_ok=True)
+        hp.write_map(path, maps)
+    i, q, u = maps.astype(float)
+    return StokesIQU(
+        i=jax.device_put(i),
+        q=jax.device_put(q),
+        u=jax.device_put(u),
+    )
+
+
+@pytest.fixture(scope='module')
+def sat_nhits() -> Float[Array, ' ...']:
+    nhits = hp.read_map(TEST_DATA_SAT / 'norm_nHits_SA_35FOV_G_nside512.fits').astype('<f8')
+    npixel = nhits.size
+    nhits[: npixel // 2] = 0
+    nhits /= np.sum(nhits)
+    return jax.device_put(nhits)
 
 
 def get_random_generator(seed: int) -> np.random.Generator:

--- a/uv.lock
+++ b/uv.lock
@@ -1821,8 +1821,8 @@ with-cuda = [
 
 [[package]]
 name = "jax-healpy"
-version = "0.6.post42+g0d31046"
-source = { git = "https://github.com/CMBSciPol/jax-healpy?branch=implement-alm2map#0d31046a49475291c6c2a872d0400a857e0f279f" }
+version = "0.7.dev46+gdc35463cf"
+source = { git = "https://github.com/CMBSciPol/jax-healpy?branch=implement-alm2map#dc35463cf2b3336445c71162f11039829f58918b" }
 dependencies = [
     { name = "jax" },
     { name = "jaxtyping" },


### PR DESCRIPTION
This adds our own implementation of a conjugate gradient solver.

Comparison with lineax's CG solver:
- Unlike lineax, we record the residual norm at every iteration to monitor convergence. (This is the main motivation for this implementation.)
- Unlike lineax, we only use the standard convergence criterion in the 'b' space (given Ay=b), i.e. we do not check if the solution is still updating. (This may change.)
- Like lineax, we stabilise the residual every 10 (by default) iteration steps to improve numerical stability.
- Unlike lineax, our inner products use a reduction rather than `vdot`, so vectors sharded along their contracting axis are solved directly (`vdot` fails under explicit-axis sharding). Tested on explicit/auto axes and 1D/2D meshes.
- Like lineax, we support reverse-mode autodiff, but it is opt-in via `loop_kind='bounded'` (forward-mode works by default).
- Unlike lineax, we do not check curvature by default (`A` is assumed positive definite). The `negative_curvature` parameter controls this behaviour (default is `ignore`, `error` raises, `truncate` stops the iteration).

A couple of notes on performance:
- Reverse-mode autodiff (`loop_kind='bounded'`) is noticeably slower than the default `lax` loop, because its checkpoint structure runs up to `max_steps` regardless of early convergence. That is why it is opt-in; the default forward-only path is unaffected.
- Checking curvature every iteration (via `equinox.error_if`) turned out to be surprisingly expensive, enough to dominate the per-step cost in some instances, which is why curvature is unchecked by default.