### PR TITLE
Update python and dependencies requirements

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,7 +47,7 @@ jobs:
         run: uv venv
 
       - name: Install dependencies
-        run: uv pip install .[dev,mapmaking,interfaces]
+        run: uv pip install .[dev,mapmaking,so,toast]
 
       - name: Run tests
-        run: uv run pytest -vv -m "not slow"
+        run: .venv/bin/python -m pytest -vv -m "not slow"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.11", "3.12", "3.13"]
 
     steps:
       - name: Checkout project

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -42,7 +42,7 @@ repos:
     - apischema
     - astropy
     - healpy
-    - jax==0.9.2
+    - jax==0.10.0
     - jaxtyping
     - jax-healpy
     - lineax

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Furax
 
 [![PyPI version](https://badge.fury.io/py/furax.svg)](https://badge.fury.io/py/furax)
+[![Python version](https://img.shields.io/pypi/pyversions/furax)](https://pypi.org/project/furax/)
 [![Documentation Status](https://readthedocs.org/projects/furax/badge/?version=latest)](https://furax.readthedocs.io/en/latest/?badge=latest)
 [![CI](https://github.com/CMBSciPol/furax/actions/workflows/ci.yml/badge.svg)](https://github.com/CMBSciPol/furax/actions/workflows/ci.yml)
 [![Ruff](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v2.json)](https://github.com/astral-sh/ruff)
@@ -11,11 +12,12 @@ Furax: a Framework for Unified and Robust data Analysis with JAX.
 
 This framework provides building blocks for solving inverse problems, in particular in the astrophysical and cosmological domains.
 
+## Requirements
+
+- Python >= 3.11
+- [JAX](https://jax.readthedocs.io/en/latest/installation.html) — install separately for your target hardware (CPU, CUDA, Metal, …)
+
 ## Installation
-
-You should always use a virtual environment to install packages (e.g. `venv`, `conda` environment, etc.).
-
-Start by installing [`JAX`](https://jax.readthedocs.io/en/latest/installation.html) for the target architecture.
 
 Furax is available as [`furax`](https://pypi.org/project/furax/) on PyPI, and can be installed with:
 
@@ -64,64 +66,3 @@ pre-commit install
 ```
 
 2. That's it! Every commit will trigger the code quality checks.
-
-## Running on JeanZay
-
-### Load cuda and and cudnn for JAX
-
-```bash
-module load cuda/11.8.0 cudnn/8.9.7.29-cuda
-```
-
-### Create Python env (only the first time)
-
-```bash
-module load python/3.10.4 && conda deactivate
-python -m venv venv
-source venv/bin/activate
-# install jax
-pip install --upgrade "jax[cuda11_local]" -f https://storage.googleapis.com/jax-releases/jax_cuda_releases.html
-# install furax
-pip install -e .[dev]
-```
-
-### launch script
-
-To launch only the pytests
-
-```bash
-sbatch slurms/astro-sim-v100-testing.slurm
-```
-
-To launch your own script
-
-```bash
-sbatch slurms/astro-sim-v100-run.slurm yourscript.py
-```
-
-You can also allocate ressources and go into bash mode
-
-```bash
-srun --pty --account=nih@v100 --nodes=1 --ntasks-per-node=1 --cpus-per-task=10 --gres=gpu:1 --hint=nomultithread bash
-module purge
-module load python/3.10.4
-source venv/bin/activate
-module load cuda/11.8.0  cudnn/8.9.7.29-cuda
-# Then do your thing
-python my_script.py
-pytest
-```
-
-Don't leave the bash running !! (I would suggest running script with sbatch)
-
-### Specific for nih / SciPol project
-
-The repo is already in the commun WORK folder, the data is downloaded and the environment is ready.
-
-You only need to do this
-
-```bash
-cd $ALL_CCFRWORK/furax-main
-```
-
-Then launch scripts as you see fit

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,15 +25,15 @@ requires-python = '>=3.11'
 license = 'MIT'
 license-files = ['LICENSE']
 dependencies = [
-    'astropy',
-    'equinox',
-    'healpy>=0.18.1',
-    'jax>=0.4.38,!=0.7.*',
-    'jaxtyping',
+    'astropy>=7.2',
+    'equinox>=0.13.8',
+    'healpy>=1.19.0',
+    'jax>=0.10.0',
+    'jaxtyping>=0.3.9',
     'jax-healpy>=0.5',
-    'lineax>=0.0.8',
-    'numpy',
-    'scipy',
+    'lineax>=0.1.1',
+    'numpy>=2.0',
+    'scipy>=1.14',
     'typing-extensions; python_version < "3.13"',
 ]
 dynamic = ['version']
@@ -52,13 +52,13 @@ docs = [
 mapmaking = [
     'apischema>=0.19.0',
     'jax-cadre>=0.1.2',
-    'matplotlib',
+    'matplotlib>=3.8.4',
     'pixell>=0.31.3',
-    'pyyaml>=0.6.2',
+    'pyyaml>=6.0.3',
 ]
 so = [
     'cyclopts>=4.6.0',
-    'sotodlib[site-pipeline]>=0.6.16',
+    'sotodlib[site-pipeline]>=0.6.19',
     'so3g>=0.2.7; python_version >= "3.13"',  # official Python 3.13 support since v0.2.5
     'so3g>=0.2.4; python_version < "3.13"',  # keep v0.2.4; it has wheels for macOS 13+
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,9 @@ readme = 'README.md'
 keywords = ['scientific computing']
 classifiers = [
     'Programming Language :: Python',
-    'Programming Language :: Python :: 3',
+    'Programming Language :: Python :: 3.11',
+    'Programming Language :: Python :: 3.12',
+    'Programming Language :: Python :: 3.13',
     'Intended Audience :: Science/Research',
     'Operating System :: OS Independent',
     'Topic :: Scientific/Engineering',

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ classifiers = [
     'Operating System :: OS Independent',
     'Topic :: Scientific/Engineering',
 ]
-requires-python = '>=3.10'
+requires-python = '>=3.11'
 license = 'MIT'
 license-files = ['LICENSE']
 dependencies = [

--- a/src/furax/_instruments/sky.py
+++ b/src/furax/_instruments/sky.py
@@ -1,6 +1,6 @@
-import sys
-from typing import Any
+from typing import Any, Self
 
+import equinox as eqx
 import jax
 import jax.numpy as jnp
 import numpy as np
@@ -12,14 +12,6 @@ from numpy.typing import NDArray
 
 from ..obs.landscapes import FrequencyLandscape
 from ..obs.stokes import Stokes, ValidStokesType
-
-if sys.version_info < (3, 11):
-    from typing_extensions import Self
-else:
-    from typing import Self
-import sys
-
-import equinox as eqx
 
 
 class FGBusterInstrument(eqx.Module):

--- a/src/furax/core/_base.py
+++ b/src/furax/core/_base.py
@@ -7,7 +7,7 @@ from dataclasses import dataclass, field
 from enum import IntFlag, auto
 from typing import Any, ClassVar, TypeVar, overload
 
-if sys.version_info >= (3, 11):
+if sys.version_info >= (3, 12):
     from typing import dataclass_transform
 else:
     from typing_extensions import dataclass_transform

--- a/src/furax/mapmaking/results.py
+++ b/src/furax/mapmaking/results.py
@@ -132,7 +132,8 @@ class MapMakingResults:
             if not path.exists():
                 raise FileNotFoundError(f'Expected file not found: {path}')
             with fits.open(path) as hdul:
-                return np.array(hdul[0].data)
+                arr = np.asarray(hdul[0].data)
+                return arr.astype(arr.dtype.newbyteorder('='), copy=False)
         elif isinstance(landscape, HealpixLandscape):
             path = out_dir / f'{name}.fits'
             if not path.exists():
@@ -145,7 +146,7 @@ class MapMakingResults:
             # hp.read_map with field=0 drops the leading dim; restore it
             if arr.ndim == len(landscape.shape):
                 arr = arr[np.newaxis]
-            return arr
+            return arr.astype(arr.dtype.newbyteorder('='), copy=False)
         else:
             path = out_dir / f'{name}.npy'
             if not path.exists():
@@ -166,12 +167,14 @@ class MapMakingResults:
             if not path.exists():
                 raise FileNotFoundError(f'Expected file not found: {path}')
             with fits.open(path) as hdul:
-                return jnp.array(hdul[0].data)
+                arr = hdul[0].data
+                return jnp.array(arr.astype(arr.dtype.newbyteorder('='), copy=False))
         elif isinstance(landscape, HealpixLandscape):
             path = out_dir / 'hit_map.fits'
             if not path.exists():
                 raise FileNotFoundError(f'Expected file not found: {path}')
-            return jnp.array(hp.read_map(str(path), field=0))
+            hits = hp.read_map(str(path), field=0)
+            return jnp.array(hits.astype(hits.dtype.newbyteorder('='), copy=False))
         else:
             path = out_dir / 'hit_map.npy'
             if not path.exists():

--- a/src/furax/obs/stokes.py
+++ b/src/furax/obs/stokes.py
@@ -1,8 +1,7 @@
 import operator
-import sys
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
-from typing import Any, ClassVar, Literal, cast, get_args, overload
+from typing import Any, ClassVar, Literal, Self, cast, get_args, overload
 
 import jax
 import numpy as np
@@ -11,11 +10,6 @@ from jax import Array
 from jax.tree_util import register_dataclass
 from jax.typing import ArrayLike
 from jaxtyping import DTypeLike, Float, Integer, Key, PyTree, ScalarLike
-
-if sys.version_info < (3, 11):
-    from typing_extensions import Self
-else:
-    from typing import Self
 
 from furax.exceptions import StructureError
 from furax.tree import (


### PR DESCRIPTION
Bumps minimum Python to 3.11 and raises floor versions of all dependencies.

`jax 0.10.0` has improvements and features that are going to be useful for #80 

Changes:

- Python: drop 3.10 support (requires-python = '>=3.11')
- CI: remove 3.10 matrix entry; skip litebird_sim tests for now (packaging issues)
- Tightened minimums versions for `astropy`, `equinox`, `healpy`, `jax`, `jaxtyping`, `lineax`, `numpy`, `scipy`, `matplotlib`, `pyyaml`, `sotodlib`,