### PR TITLE
Distributed multi-observation mapmaking

### DIFF
--- a/src/furax/distributed.py
+++ b/src/furax/distributed.py
@@ -1,0 +1,9 @@
+import jax
+
+
+def maybe_init() -> bool:
+    try:
+        jax.distributed.initialize()
+        return True
+    except ValueError:
+        return False

--- a/src/furax/interfaces/sotodlib/__init__.py
+++ b/src/furax/interfaces/sotodlib/__init__.py
@@ -1,0 +1,8 @@
+# Intentionally empty: no eager re-exports.
+#
+# Re-exporting SOTODLibObservation / LazySOTODLibObservation here would force
+# `observation.py` (and its jax-using transitive imports) to load at package
+# import time, which initializes the JAX backend before
+# `jax.distributed.initialize()` can run in distributed entrypoints.
+# Import the concrete classes from `furax.interfaces.sotodlib.observation`
+# directly.

--- a/src/furax/interfaces/sotodlib/__init__.py
+++ b/src/furax/interfaces/sotodlib/__init__.py
@@ -1,6 +1,0 @@
-from .observation import LazySOTODLibObservation, SOTODLibObservation
-
-__all__ = [
-    'SOTODLibObservation',
-    'LazySOTODLibObservation',
-]

--- a/src/furax/interfaces/sotodlib/multi_observation/__main__.py
+++ b/src/furax/interfaces/sotodlib/multi_observation/__main__.py
@@ -1,3 +1,11 @@
+import os
+
+import jax
+
+if 'SLURM_JOB_ID' in os.environ:
+    jax.distributed.initialize()
+
+
 from cyclopts import App
 
 from .prepare import prepare

--- a/src/furax/interfaces/sotodlib/multi_observation/__main__.py
+++ b/src/furax/interfaces/sotodlib/multi_observation/__main__.py
@@ -1,11 +1,9 @@
-import os
+from furax.distributed import maybe_init
 
-import jax
+# Must run before import that touches the JAX backend
+maybe_init()
 
-if 'SLURM_JOB_ID' in os.environ:
-    jax.distributed.initialize()
-
-
+# ruff: noqa: E402
 from cyclopts import App
 
 from .prepare import prepare

--- a/src/furax/interfaces/sotodlib/multi_observation/run.py
+++ b/src/furax/interfaces/sotodlib/multi_observation/run.py
@@ -1,5 +1,7 @@
 from pathlib import Path
 
+import jax
+
 from furax.interfaces.sotodlib.observation import LazySOTODLibObservation
 from furax.mapmaking import MapMakingConfig, MultiObservationMapMaker
 
@@ -26,7 +28,7 @@ def run(  # type: ignore[no-untyped-def]
         loglevel: Logging level (debug, info, warning, error).
         log_path: Log output path.
     """
-    logger = setup_logger(loglevel, log_path)
+    logger = setup_logger(loglevel, log_path, process_index=jax.process_index())
 
     obsids = resolve_obsids(obsid, obsids_file)
     if obsids:

--- a/src/furax/interfaces/sotodlib/multi_observation/run.py
+++ b/src/furax/interfaces/sotodlib/multi_observation/run.py
@@ -1,6 +1,6 @@
 from pathlib import Path
 
-from furax.interfaces.sotodlib import LazySOTODLibObservation
+from furax.interfaces.sotodlib.observation import LazySOTODLibObservation
 from furax.mapmaking import MapMakingConfig, MultiObservationMapMaker
 
 from .util import resolve_obsids, setup_logger

--- a/src/furax/interfaces/sotodlib/multi_observation/util.py
+++ b/src/furax/interfaces/sotodlib/multi_observation/util.py
@@ -2,16 +2,20 @@ import logging
 from pathlib import Path
 
 
-def setup_logger(loglevel: str, log_path: Path | None) -> logging.Logger:
+def setup_logger(loglevel: str, log_path: Path | None, process_index: int = 0) -> logging.Logger:
     level = logging.getLevelName(loglevel.upper())
     logger = logging.getLogger('furax.mapmaker')
     logger.setLevel(level)
-    formatter = logging.Formatter('%(asctime)s - %(levelname)s - %(message)s')
+    logger.propagate = False
+    formatter = logging.Formatter(
+        f'%(asctime)s - [rank {process_index}] - %(levelname)s - %(message)s'
+    )
     ch = logging.StreamHandler()
     ch.setLevel(level)
     ch.setFormatter(formatter)
     logger.addHandler(ch)
-    if log_path is not None:
+    # Only rank 0 writes to the final logfile
+    if process_index == 0 and log_path is not None:
         log_path.parent.mkdir(parents=True, exist_ok=True)
         fh = logging.FileHandler(log_path)
         fh.setLevel(logging.DEBUG)

--- a/src/furax/interfaces/sotodlib/multi_observation/util.py
+++ b/src/furax/interfaces/sotodlib/multi_observation/util.py
@@ -14,8 +14,8 @@ def setup_logger(loglevel: str, log_path: Path | None, process_index: int = 0) -
     ch.setLevel(level)
     ch.setFormatter(formatter)
     logger.addHandler(ch)
-    # Only rank 0 writes to the final logfile
-    if process_index == 0 and log_path is not None:
+    if log_path is not None:
+        log_path = log_path.with_stem(f'{log_path.stem}.rank{process_index}')
         log_path.parent.mkdir(parents=True, exist_ok=True)
         fh = logging.FileHandler(log_path)
         fh.setLevel(logging.DEBUG)

--- a/src/furax/io/readers.py
+++ b/src/furax/io/readers.py
@@ -39,10 +39,8 @@ class AbstractReader(ABC):
         Args:
             *args: One list per positional argument to the read function, one element per data item.
             common_keywords: Keyword arguments shared by all data items.
-            structures: Pre-computed per-item output structures.  When provided the
-                constructor skips all I/O and uses them directly; when ``None``
-                (the default) structures are inferred by calling
-                ``_read_structure_impure`` on each item.
+            structures: Pre-computed per-item output structures.
+                When provided, constructor skips all I/O and uses them directly.
             **keywords: One list per keyword argument to the read function, one element per data item.
         """
         self.args, self.keywords = self._normalize_args_keywords(args, keywords)
@@ -50,6 +48,10 @@ class AbstractReader(ABC):
         self.common_keywords = common_keywords or {}
         if structures is None:
             structures = self._read_structures()
+        elif len(structures) != self.count:
+            raise ValueError(
+                f'structures length {len(structures)} does not match data count {self.count}'
+            )
         self._infer_structure_and_paddings(structures)
 
     def _infer_structure_and_paddings(self, structures: list[PyTree[jax.ShapeDtypeStruct]]) -> None:

--- a/src/furax/io/readers.py
+++ b/src/furax/io/readers.py
@@ -32,21 +32,35 @@ class AbstractReader(ABC):
         self,
         *args: Sequence[Any],
         common_keywords: Mapping[str, Any] | None = None,
+        structures: list[PyTree[jax.ShapeDtypeStruct]] | None = None,
         **keywords: Sequence[Any],
     ) -> None:
+        """
+        Args:
+            *args: One list per positional argument to the read function, one element per data item.
+            common_keywords: Keyword arguments shared by all data items.
+            structures: Pre-computed per-item output structures.  When provided the
+                constructor skips all I/O and uses them directly; when ``None``
+                (the default) structures are inferred by calling
+                ``_read_structure_impure`` on each item.
+            **keywords: One list per keyword argument to the read function, one element per data item.
+        """
         self.args, self.keywords = self._normalize_args_keywords(args, keywords)
         self.count = len(self.args)
-        if common_keywords is None:
-            common_keywords = {}
-        self.common_keywords = common_keywords
-        structures = self._read_structures()
+        self.common_keywords = common_keywords or {}
+        if structures is None:
+            structures = self._read_structures()
+        self._infer_structure_and_paddings(structures)
+
+    def _infer_structure_and_paddings(self, structures: list[PyTree[jax.ShapeDtypeStruct]]) -> None:
         self.out_structure = self._get_common_structure(structures)
         self.paddings: list[PyTree[tuple[int, ...]]] = [
             self._get_padding(structures[i]) for i in range(self.count)
         ]
 
+    @staticmethod
     def _normalize_args_keywords(
-        self, args: Sequence[Any], keywords: dict[str, Sequence[Any]]
+        args: Sequence[Any], keywords: dict[str, Sequence[Any]]
     ) -> tuple[list[Any], list[dict[str, Any]]]:
         """Normalize the arguments and keywords to ensure they are lists of the same length."""
         invalid_args = [i for i, v in enumerate(args) if not isinstance(v, Sequence)]

--- a/src/furax/mapmaking/_model.py
+++ b/src/furax/mapmaking/_model.py
@@ -1,6 +1,6 @@
-import functools
 from dataclasses import dataclass, field
-from typing import Any, TypeVar
+from functools import partial
+from typing import Any, Self, TypeVar
 
 import jax
 import jax.numpy as jnp
@@ -48,7 +48,7 @@ class ObservationModel:
     @classmethod
     def create(
         cls, data: Any, padding: Any, config: MapMakingConfig, landscape: StokesLandscape
-    ) -> 'ObservationModel':
+    ) -> Self:
         H = build_acquisition_operator(
             landscape,
             data['boresight_quaternions'],
@@ -137,7 +137,7 @@ class ObservationModel:
             )
             key = jax.random.key(config.gaps.fill_options.seed)
             tod = gapfill(key, tod)
-        rhs: Stokes = (self.H.T @ self.masker @ self.W)(tod)
+        rhs: Stokes = self.H.T(self.masker(self.W(tod)))
         return rhs
 
     def _get_indexer(self) -> IndexOperator:
@@ -151,26 +151,74 @@ class ObservationModel:
         return IndexOperator(mask, in_structure=self.tod_structure)
 
 
+def pad_model(models: ObservationModel, n_pad: int) -> ObservationModel:
+    """Pad models with n_pad dummy observations that contribute nothing to sums.
+
+    The dummy observations are copies of the last real observation with their
+    masker array leaves zeroed out, so masker(x) = 0 for any x.
+    """
+    last = jax.tree.map(lambda a: jnp.repeat(a[-1:], n_pad, axis=0), models)
+    zero_masker = jax.tree.map(jnp.zeros_like, last.masker)
+    padded = ObservationModel(
+        H=last.H,
+        W=last.W,
+        masker=zero_masker,
+        noise_model=last.noise_model,
+        sample_rate=last.sample_rate,
+    )
+    return jax.tree.map(lambda a, b: jnp.concatenate([a, b], axis=0), models, padded)  # type: ignore[no-any-return]
+
+
 _StokesPyTree = TypeVar('_StokesPyTree', bound=StokesPyTreeType)
 
 
-@functools.partial(jax.jit, static_argnames=['diag'])
-def _system_scan(model: ObservationModel, x: _StokesPyTree, *, diag: bool = False) -> _StokesPyTree:
-    """Apply H^T W H to x, summed over the batch of observations in model.
+@partial(jax.jit, static_argnames=['diag', 'mesh'])
+def _system_scan(
+    model: ObservationModel,
+    x: _StokesPyTree,
+    *,
+    diag: bool = False,
+    mesh: jax.sharding.Mesh | None = None,
+) -> _StokesPyTree:
+    """Apply H^T W H to x, summed over all observations in model.
 
     `model` is an explicit JIT argument so it is never captured as an XLA constant.
 
     Args:
-        model: Stacked ObservationModel with a leading batch dimension over observations.
+        model: Stacked ObservationModel with a flat leading obs axis sharded across
+            devices. Each device scans its slice sequentially; psum reduces globally.
         x: Input sky map pytree.
         diag: If True, use the diagonal white-noise approximation for W.
+        mesh: The concrete Mesh on which `model` is sharded. When set, shard_map is
+            used to parallelise the scan across devices. Must be the same Mesh object
+            that was used when sharding the model arrays.
     """
 
-    def accumulate(lhs, obs):  # type: ignore[no-untyped-def]
-        return tree.add(lhs, obs.apply_system(x, white_noise=diag)), None
+    if mesh is None:
 
-    lhs, _ = jax.lax.scan(accumulate, tree.zeros_like(x), model)
-    return lhs
+        def step(lhs: _StokesPyTree, obs: ObservationModel) -> tuple[_StokesPyTree, None]:
+            return tree.add(lhs, obs.apply_system(x, white_noise=diag)), None
+
+        lhs, _ = jax.lax.scan(step, tree.zeros_like(x), model)
+        return lhs
+
+    from jax.sharding import NamedSharding
+    from jax.sharding import PartitionSpec as P
+
+    # Re-impose 'obs' sharding on the model in case its annotation was stripped
+    # (e.g. closure capture during lineax abstract eval drops sharding metadata).
+    obs_sharding = NamedSharding(mesh, P('obs'))
+    model = jax.tree.map(lambda a: jax.reshard(a, obs_sharding), model)
+
+    @jax.shard_map(mesh=mesh, in_specs=(P('obs'), P()), out_specs=P(), check_vma=False)
+    def local_scan(local_model: ObservationModel, local_x: _StokesPyTree) -> _StokesPyTree:
+        def step(lhs: _StokesPyTree, obs: ObservationModel) -> tuple[_StokesPyTree, None]:
+            return tree.add(lhs, obs.apply_system(local_x, white_noise=diag)), None
+
+        lhs, _ = jax.lax.scan(step, tree.zeros_like(local_x), local_model)
+        return jax.lax.psum(lhs, axis_name='obs')  # type: ignore[no-any-return]
+
+    return local_scan(model, x)
 
 
 @symmetric
@@ -179,14 +227,22 @@ class SystemOperator(AbstractLinearOperator):
 
     models: ObservationModel
     diag: bool = field(metadata={'static': True})
+    mesh: jax.sharding.Mesh | None = field(metadata={'static': True})
 
-    def __init__(self, models: ObservationModel, *, diag: bool = False):
+    def __init__(
+        self,
+        models: ObservationModel,
+        *,
+        diag: bool = False,
+        mesh: jax.sharding.Mesh | None = None,
+    ):
         object.__setattr__(self, 'models', models)
         object.__setattr__(self, 'diag', diag)
+        object.__setattr__(self, 'mesh', mesh)
         object.__setattr__(self, 'in_structure', models.map_structure)
 
     def mv(self, x: _StokesPyTree) -> _StokesPyTree:
-        return _system_scan(self.models, x, diag=self.diag)  # type: ignore[no-any-return]
+        return _system_scan(self.models, x, diag=self.diag, mesh=self.mesh)  # type: ignore[no-any-return]
 
 
 def _noise_model(data: Any, config: MapMakingConfig) -> tuple[PyTree[NoiseModel], Array]:

--- a/src/furax/mapmaking/_model.py
+++ b/src/furax/mapmaking/_model.py
@@ -4,6 +4,8 @@ from typing import Any, Self, TypeVar
 
 import jax
 import jax.numpy as jnp
+from jax.sharding import NamedSharding
+from jax.sharding import PartitionSpec as P
 from jax.tree_util import register_dataclass
 from jaxtyping import Array, Float, Int64, PyTree
 
@@ -201,9 +203,6 @@ def _system_scan(
 
         lhs, _ = jax.lax.scan(step, tree.zeros_like(x), model)
         return lhs
-
-    from jax.sharding import NamedSharding
-    from jax.sharding import PartitionSpec as P
 
     # Re-impose 'obs' sharding on the model in case its annotation was stripped
     # (e.g. closure capture during lineax abstract eval drops sharding metadata).

--- a/src/furax/mapmaking/_model.py
+++ b/src/furax/mapmaking/_model.py
@@ -204,11 +204,13 @@ def _system_scan(
         lhs, _ = jax.lax.scan(step, tree.zeros_like(x), model)
         return lhs
 
-    # Re-impose 'obs' sharding on the model in case its annotation was stripped
-    # (e.g. closure capture during lineax abstract eval drops sharding metadata).
+    # lineax's abstract eval drops the NamedSharding on closure-captured arrays,
+    # so shard_map sees replicated leaves and rejects the P('obs') in_specs.
+    # Reshard restores it (the fix JAX's error message points to).
     obs_sharding = NamedSharding(mesh, P('obs'))
     model = jax.tree.map(lambda a: jax.reshard(a, obs_sharding), model)
 
+    # check_vma=False: furax operator chain inside the body lacks manual-axis annotations.
     @jax.shard_map(mesh=mesh, in_specs=(P('obs'), P()), out_specs=P(), check_vma=False)
     def local_scan(local_model: ObservationModel, local_x: _StokesPyTree) -> _StokesPyTree:
         def step(lhs: _StokesPyTree, obs: ObservationModel) -> tuple[_StokesPyTree, None]:

--- a/src/furax/mapmaking/_model.py
+++ b/src/furax/mapmaking/_model.py
@@ -159,6 +159,8 @@ def pad_model(models: ObservationModel, n_pad: int) -> ObservationModel:
     The dummy observations are copies of the last real observation with their
     masker array leaves zeroed out, so masker(x) = 0 for any x.
     """
+    if n_pad == 0:
+        return models
     last = jax.tree.map(lambda a: jnp.repeat(a[-1:], n_pad, axis=0), models)
     zero_masker = jax.tree.map(jnp.zeros_like, last.masker)
     padded = ObservationModel(

--- a/src/furax/mapmaking/_reader.py
+++ b/src/furax/mapmaking/_reader.py
@@ -73,24 +73,89 @@ class ObservationReader(AbstractReader, Generic[T]):
             demodulated: Whether to read demodulated TODs.
             stokes: Stokes components to read when demodulated.
         """
+        fields = cls._resolve_fields(observations, requested_fields)
+        return cls(
+            list(observations),
+            common_keywords={'data_field_names': fields},
+            demodulated=demodulated,
+            stokes=stokes,
+        )
+
+    @classmethod
+    def from_observations_distributed(
+        cls,
+        observations: Sequence[AbstractLazyObservation[T]],
+        local_indices: Sequence[int],
+        *,
+        requested_fields: list[str] | None = None,
+        demodulated: bool = False,
+        stokes: ValidStokesType = 'IQU',
+    ) -> Self:
+        """Create a reader for distributed mapmaking.
+
+        Each process opens only its local observation files to read their shapes, then
+        an all-gather synchronises the shapes so every process can build structures for
+        all observations without duplicate I/O.  Requires a JAX distributed context.
+
+        Args:
+            observations: Full list of observations across all processes.
+            local_indices: Indices into ``observations`` owned by this process.
+            requested_fields: Optional list of fields to load.
+            demodulated: Whether to read demodulated TODs.
+            stokes: Stokes components to read when demodulated.
+        """
+        from jax.experimental import multihost_utils as mhu
+
+        fields = cls._resolve_fields(observations, requested_fields)
+
+        # Each process reads shapes only for its local observations
+        def _shape(idx: int) -> tuple[int, int, int]:
+            data = observations[idx].get_data([])
+            return idx, data.n_detectors, data.n_samples
+
+        local_shapes = np.array([_shape(idx) for idx in local_indices], dtype=np.int32)
+
+        # All-gather → (n_procs * n_local, 3), sort by global index
+        all_shapes = mhu.process_allgather(local_shapes).reshape(-1, 3)
+        all_shapes = all_shapes[np.argsort(all_shapes[:, 0])]
+
+        structures = [
+            {
+                field: all_field_structures[field]
+                for field in fields
+                for all_field_structures in [
+                    cls._get_data_field_structures_for(
+                        int(n_det), int(n_samp), demodulated=demodulated, stokes=stokes
+                    )
+                ]
+            }
+            for _, n_det, n_samp in all_shapes
+        ]
+
+        return cls(
+            list(observations),
+            common_keywords={'data_field_names': fields},
+            demodulated=demodulated,
+            stokes=stokes,
+            structures=structures,
+        )
+
+    @staticmethod
+    def _resolve_fields(
+        observations: Sequence[AbstractLazyObservation[T]],
+        requested_fields: list[str] | None,
+    ) -> list[str]:
         interface = observations[0].interface_class
         available = set(interface.AVAILABLE_READER_FIELDS)
         optional = set(interface.OPTIONAL_READER_FIELDS)
         if requested_fields is None:
-            fields = available - optional
-        else:
-            fields = set(requested_fields)
-            unsupported = fields - available
-            if len(unsupported) > 0:
-                msg = f'Requested data fields {unsupported} are not supported by the interface.'
-                raise ValueError(msg)
-
-        return cls(
-            list(observations),
-            common_keywords={'data_field_names': list(fields)},
-            demodulated=demodulated,
-            stokes=stokes,
-        )
+            return sorted(available - optional)
+        unsupported = set(requested_fields) - available
+        if unsupported:
+            raise ValueError(
+                f'Requested data fields {unsupported} are not supported by the interface.'
+            )
+        return list(requested_fields)
 
     def read(self, data_index: int) -> tuple[PyTree[Array], PyTree[Array]]:  # type: ignore[override]
         """Reads one ground observation from the list of filenames specified in the reader.

--- a/src/furax/mapmaking/_reader.py
+++ b/src/furax/mapmaking/_reader.py
@@ -87,7 +87,7 @@ class ObservationReader(AbstractReader, Generic[T]):
         observations: Sequence[AbstractLazyObservation[T]],
         local_indices: Sequence[int],
         *,
-        requested_fields: list[str] | None = None,
+        requested_fields: Sequence[str] | None = None,
         demodulated: bool = False,
         stokes: ValidStokesType = 'IQU',
     ) -> Self:
@@ -143,7 +143,7 @@ class ObservationReader(AbstractReader, Generic[T]):
     @staticmethod
     def _resolve_fields(
         observations: Sequence[AbstractLazyObservation[T]],
-        requested_fields: list[str] | None,
+        requested_fields: Sequence[str] | None,
     ) -> list[str]:
         interface = observations[0].interface_class
         available = set(interface.AVAILABLE_READER_FIELDS)

--- a/src/furax/mapmaking/_reader.py
+++ b/src/furax/mapmaking/_reader.py
@@ -1,6 +1,6 @@
 from collections.abc import Sequence
 from hashlib import sha1
-from typing import Any, Generic, TypeVar
+from typing import Any, Generic, Self, TypeVar
 
 import jax
 import jax.numpy as jnp
@@ -44,22 +44,35 @@ class ObservationReader(AbstractReader, Generic[T]):
 
     def __init__(
         self,
+        *args: Sequence[Any],
+        demodulated: bool,
+        stokes: ValidStokesType,
+        common_keywords: dict[str, Any] | None = None,
+        structures: list[PyTree[jax.ShapeDtypeStruct]] | None = None,
+        **keywords: Sequence[Any],
+    ) -> None:
+        # Set before super().__init__ so _read_structure_impure can use them
+        self.demodulated = demodulated
+        self.stokes = stokes
+        super().__init__(*args, common_keywords=common_keywords, structures=structures, **keywords)
+
+    @classmethod
+    def from_observations(
+        cls,
         observations: Sequence[AbstractLazyObservation[T]],
         *,
         requested_fields: list[str] | None = None,
         demodulated: bool = False,
         stokes: ValidStokesType = 'IQU',
-    ) -> None:
-        """Initializes the reader with a list of filenames and optional list of field names.
+    ) -> Self:
+        """Create a reader, performing I/O to infer data structures.
 
         Args:
-            filenames: A list of filenames. Each filename can be a string or a Path object.
+            observations: List of lazy observations to read.
             requested_fields: Optional list of fields to load. If None, read all non-optional fields.
             demodulated: Whether to read demodulated TODs.
             stokes: Stokes components to read when demodulated.
         """
-        self.demodulated = demodulated
-        self.stokes = stokes
         interface = observations[0].interface_class
         available = set(interface.AVAILABLE_READER_FIELDS)
         optional = set(interface.OPTIONAL_READER_FIELDS)
@@ -72,7 +85,12 @@ class ObservationReader(AbstractReader, Generic[T]):
                 msg = f'Requested data fields {unsupported} are not supported by the interface.'
                 raise ValueError(msg)
 
-        super().__init__(observations, common_keywords={'data_field_names': list(fields)})
+        return cls(
+            list(observations),
+            common_keywords={'data_field_names': list(fields)},
+            demodulated=demodulated,
+            stokes=stokes,
+        )
 
     def read(self, data_index: int) -> tuple[PyTree[Array], PyTree[Array]]:  # type: ignore[override]
         """Reads one ground observation from the list of filenames specified in the reader.
@@ -152,12 +170,14 @@ class ObservationReader(AbstractReader, Generic[T]):
 
         return data, padding
 
+    @staticmethod
     def _get_data_field_structures_for(
-        self, n_detectors: int, n_samples: int
+        n_detectors: int,
+        n_samples: int,
+        *,
+        demodulated: bool,
+        stokes: ValidStokesType,
     ) -> PyTree[jax.ShapeDtypeStruct]:
-        demodulated = self.demodulated
-        stokes = self.stokes
-
         tod_shape = (n_detectors, n_samples)
         sample_data_structure = (
             Stokes.class_for(stokes).structure_for(tod_shape, jnp.float64)
@@ -230,13 +250,11 @@ class ObservationReader(AbstractReader, Generic[T]):
         # request an empty list
         # this loads sufficient info to determine the structure
         data = observation.get_data([])
-
-        # find the data shape
-        n_detectors = data.n_detectors
-        n_samples = data.n_samples
-
         field_structure = self._get_data_field_structures_for(
-            n_detectors=n_detectors, n_samples=n_samples
+            data.n_detectors,
+            data.n_samples,
+            demodulated=self.demodulated,
+            stokes=self.stokes,
         )
         return {field: field_structure[field] for field in data_field_names}
 

--- a/src/furax/mapmaking/_reader.py
+++ b/src/furax/mapmaking/_reader.py
@@ -62,7 +62,7 @@ class ObservationReader(AbstractReader, Generic[T]):
         cls,
         observations: Sequence[AbstractLazyObservation[T]],
         *,
-        subset_indices: Sequence[int] | None = None,
+        read_indices: Sequence[int] | None = None,
         requested_fields: Sequence[str] | None = None,
         demodulated: bool = False,
         stokes: ValidStokesType = 'IQU',
@@ -80,7 +80,7 @@ class ObservationReader(AbstractReader, Generic[T]):
         """
         fields = cls._resolve_fields(observations, requested_fields)
         common_keywords = {'data_field_names': fields}
-        if subset_indices is None:
+        if read_indices is None:
             # Default path: AbstractReader.__init__ will call _read_structures(),
             # opening every observation on this process to infer its structure.
             return cls(
@@ -98,7 +98,7 @@ class ObservationReader(AbstractReader, Generic[T]):
             data = observations[idx].get_data([])
             return idx, data.n_detectors, data.n_samples
 
-        local_shapes = np.array([_shape(idx) for idx in subset_indices], dtype=np.int64)
+        local_shapes = np.array([_shape(idx) for idx in read_indices], dtype=np.int64)
 
         # All-gather → (n_procs * n_local, 3). Padding (see ``get_padded_indices``,
         # which uses ``np.pad(..., mode='edge')``) makes some indices repeat across

--- a/src/furax/mapmaking/_reader.py
+++ b/src/furax/mapmaking/_reader.py
@@ -115,9 +115,11 @@ class ObservationReader(AbstractReader, Generic[T]):
 
         local_shapes = np.array([_shape(idx) for idx in local_indices], dtype=np.int32)
 
-        # All-gather → (n_procs * n_local, 3), sort by global index
+        # All-gather → (n_procs * n_local, 3), sort and deduplicate (padding repeats indices)
         all_shapes = mhu.process_allgather(local_shapes).reshape(-1, 3)
-        all_shapes = all_shapes[np.argsort(all_shapes[:, 0])]
+        all_shapes = all_shapes[np.argsort(all_shapes[:, 0], kind='stable')]
+        _, first = np.unique(all_shapes[:, 0], return_index=True)
+        all_shapes = all_shapes[first]
 
         structures = [
             {

--- a/src/furax/mapmaking/_reader.py
+++ b/src/furax/mapmaking/_reader.py
@@ -6,6 +6,7 @@ import jax
 import jax.numpy as jnp
 import numpy as np
 from jax import Array
+from jax.experimental import multihost_utils as mhu
 from jax.tree_util import register_static
 from jaxtyping import PyTree, UInt32
 
@@ -61,82 +62,60 @@ class ObservationReader(AbstractReader, Generic[T]):
         cls,
         observations: Sequence[AbstractLazyObservation[T]],
         *,
-        requested_fields: list[str] | None = None,
+        subset_indices: Sequence[int] | None = None,
+        requested_fields: Sequence[str] | None = None,
         demodulated: bool = False,
         stokes: ValidStokesType = 'IQU',
     ) -> Self:
         """Create a reader, performing I/O to infer data structures.
 
         Args:
-            observations: List of lazy observations to read.
+            observations: Full list of lazy observations.
+            subset_indices: Optional indices into ``observations``; when set, only
+                those are opened on this process to infer shapes, and shapes are
+                synchronised across processes (distributed-mode shortcut).
             requested_fields: Optional list of fields to load. If None, read all non-optional fields.
             demodulated: Whether to read demodulated TODs.
             stokes: Stokes components to read when demodulated.
         """
         fields = cls._resolve_fields(observations, requested_fields)
-        return cls(
-            list(observations),
-            common_keywords={'data_field_names': fields},
-            demodulated=demodulated,
-            stokes=stokes,
-        )
+        common_keywords = {'data_field_names': fields}
+        if subset_indices is None:
+            # Default path: AbstractReader.__init__ will call _read_structures(),
+            # opening every observation on this process to infer its structure.
+            return cls(
+                list(observations),
+                common_keywords=common_keywords,
+                demodulated=demodulated,
+                stokes=stokes,
+            )
 
-    @classmethod
-    def from_observations_distributed(
-        cls,
-        observations: Sequence[AbstractLazyObservation[T]],
-        local_indices: Sequence[int],
-        *,
-        requested_fields: Sequence[str] | None = None,
-        demodulated: bool = False,
-        stokes: ValidStokesType = 'IQU',
-    ) -> Self:
-        """Create a reader for distributed mapmaking.
-
-        Each process opens only its local observation files to read their shapes, then
-        an all-gather synchronises the shapes so every process can build structures for
-        all observations without duplicate I/O.  Requires a JAX distributed context.
-
-        Args:
-            observations: Full list of observations across all processes.
-            local_indices: Indices into ``observations`` owned by this process.
-            requested_fields: Optional list of fields to load.
-            demodulated: Whether to read demodulated TODs.
-            stokes: Stokes components to read when demodulated.
-        """
-        from jax.experimental import multihost_utils as mhu
-
-        fields = cls._resolve_fields(observations, requested_fields)
-
-        # Each process reads shapes only for its local observations
+        # Distributed-mode shortcut. Each process opens only its subset; an
+        # all-gather then makes every rank agree on the full structures list so
+        # padding / out_structure / etc. are consistent. Bypasses the superclass's
+        # per-item I/O by passing the assembled `structures` directly.
         def _shape(idx: int) -> tuple[int, int, int]:
             data = observations[idx].get_data([])
             return idx, data.n_detectors, data.n_samples
 
-        local_shapes = np.array([_shape(idx) for idx in local_indices], dtype=np.int32)
+        local_shapes = np.array([_shape(idx) for idx in subset_indices], dtype=np.int64)
 
-        # All-gather → (n_procs * n_local, 3), sort and deduplicate (padding repeats indices)
+        # All-gather → (n_procs * n_local, 3). Padding (see ``get_padded_indices``,
+        # which uses ``np.pad(..., mode='edge')``) makes some indices repeat across
+        # ranks; keep only one entry per obs index.
         all_shapes = mhu.process_allgather(local_shapes).reshape(-1, 3)
-        all_shapes = all_shapes[np.argsort(all_shapes[:, 0], kind='stable')]
-        _, first = np.unique(all_shapes[:, 0], return_index=True)
-        all_shapes = all_shapes[first]
+        by_idx = {int(idx): (int(n_det), int(n_samp)) for idx, n_det, n_samp in all_shapes}
 
-        structures = [
-            {
-                field: all_field_structures[field]
-                for field in fields
-                for all_field_structures in [
-                    cls._get_data_field_structures_for(
-                        int(n_det), int(n_samp), demodulated=demodulated, stokes=stokes
-                    )
-                ]
-            }
-            for _, n_det, n_samp in all_shapes
-        ]
+        def _struct_for(n_det: int, n_samp: int) -> PyTree[jax.ShapeDtypeStruct]:
+            field_struct = cls._get_data_field_structures_for(
+                n_det, n_samp, demodulated=demodulated, stokes=stokes
+            )
+            return {field: field_struct[field] for field in fields}
 
+        structures = [_struct_for(*by_idx[idx]) for idx in sorted(by_idx)]
         return cls(
             list(observations),
-            common_keywords={'data_field_names': fields},
+            common_keywords=common_keywords,
             demodulated=demodulated,
             stokes=stokes,
             structures=structures,

--- a/src/furax/mapmaking/mapmaker.py
+++ b/src/furax/mapmaking/mapmaker.py
@@ -302,9 +302,6 @@ class MultiObservationMapMaker(Generic[T]):
         _, model = jax.lax.scan(build_one, None, self.get_indices())
 
         _, _, n_pad = self.obs_distribution
-        if n_pad == 0:
-            return model  # type: ignore[no-any-return]
-
         return pad_model(model, n_pad)
 
     def accumulate_hits(self, models: ObservationModel) -> Int64[Array, ' pixels']:

--- a/src/furax/mapmaking/mapmaker.py
+++ b/src/furax/mapmaking/mapmaker.py
@@ -276,6 +276,49 @@ class MultiObservationMapMaker(Generic[T]):
         return valid
 
 
+def get_obs_distribution_to_process(n_obs: int) -> tuple[int, int, int]:
+    """Compute this process's observation slice for distributed mapmaking.
+
+    Distributes ``n_obs`` observations across processes as evenly as possible
+    (first ``n_obs % n_proc`` processes get one extra), then pads each process's
+    share to the next multiple of ``local_device_count`` so every device has a
+    uniform workload.  All processes end up with the same number of total slots
+    (``n_owned + n_pad``), which is required for multi-process sharding.
+
+    Args:
+        n_obs: Total number of observations across all processes.
+
+    Returns:
+        A tuple ``(start, n_owned, n_pad)`` where ``start`` is the index of the
+        first real observation owned by this process, ``n_owned`` is the number
+        of real observations, and ``n_pad`` is the number of padding slots so that
+        ``n_owned + n_pad`` is a multiple of ``local_device_count``.
+
+    Raises:
+        ValueError: If ``n_obs < n_proc``.
+    """
+    rank = jax.process_index()
+    n_proc = jax.process_count()
+    n_local = jax.local_device_count()
+
+    if n_obs < n_proc:
+        raise ValueError(
+            f'Not enough observations ({n_obs}) for {n_proc} processes. '
+            f'Use fewer SLURM tasks or provide more observations.'
+        )
+
+    base = n_obs // n_proc
+    remainder = n_obs % n_proc
+    max_owned = base + (1 if remainder > 0 else 0)
+    n_per_proc = max_owned + (-max_owned) % n_local  # ceil to next multiple of n_local
+
+    n_owned = base + (1 if rank < remainder else 0)
+    start = rank * base + min(rank, remainder)
+    n_pad = n_per_proc - n_owned
+
+    return start, n_owned, n_pad
+
+
 def _static_landscape(lc: LandscapeConfig, dtype: DTypeLike) -> StokesLandscape | None:
     """Build a landscape from config alone, without observation data.
 

--- a/src/furax/mapmaking/mapmaker.py
+++ b/src/furax/mapmaking/mapmaker.py
@@ -2,7 +2,6 @@ import pickle
 from abc import abstractmethod
 from collections.abc import Sequence
 from dataclasses import asdict, dataclass
-from functools import cached_property
 from logging import Logger
 from math import prod
 from pathlib import Path
@@ -17,6 +16,7 @@ import pixell.utils
 from astropy.io import fits
 from astropy.wcs import WCS
 from jax import ShapeDtypeStruct
+from jax.experimental import multihost_utils as mhu
 from jax.sharding import Mesh, NamedSharding
 from jax.sharding import PartitionSpec as P
 from jaxtyping import Array, Bool, DTypeLike, Float, Int64, Integer, PyTree
@@ -93,7 +93,7 @@ class MultiObservationMapMaker(Generic[T]):
                 )
                 self.config.landscape.stokes = 'QU'
 
-    @cached_property
+    @property
     def mesh(self) -> Mesh:
         return jax.make_mesh((jax.device_count(),), ('obs',))
 
@@ -103,13 +103,9 @@ class MultiObservationMapMaker(Generic[T]):
 
     def distribute(self, x: PyTree) -> PyTree:
         """Shard a pytree of process-local arrays along the leading 'obs' axis."""
-        if jax.process_count() > 1:
-            return jax.tree.map(
-                lambda a: jax.make_array_from_process_local_data(self.sharding, a), x
-            )
-        return jax.device_put(x, self.sharding)
+        return jax.tree.map(lambda a: jax.make_array_from_process_local_data(self.sharding, a), x)
 
-    @cached_property
+    @property
     def obs_distribution(self) -> tuple[int, int, int]:
         """``(start, n_owned, n_pad)`` for this process."""
         return get_obs_distribution_to_process(self.n_observations)
@@ -182,6 +178,9 @@ class MultiObservationMapMaker(Generic[T]):
             self.config.dump_yaml(out_dir / 'mapmaking_config.yaml')
             self.logger.info('saved mapmaking configuration to file')
 
+        # Barrier so other ranks don't race ahead while rank 0 is still writing.
+        mhu.sync_global_devices('mapmaker.run.save_done')
+
         return results
 
     @property
@@ -220,7 +219,8 @@ class MultiObservationMapMaker(Generic[T]):
         hits = jax.jit(self.accumulate_hits)(model).block_until_ready()
         logger_info('Computed hit map')
 
-        rhs = jax.block_until_ready(self.accumulate_rhs(model, indices))
+        rhs_reader = self.get_reader(['metadata', 'sample_data'])
+        rhs = jax.block_until_ready(jax.jit(self.accumulate_rhs)(model, indices, rhs_reader))
         logger_info('Accumulated RHS vector')
 
         # Preconditioning
@@ -325,14 +325,20 @@ class MultiObservationMapMaker(Generic[T]):
 
         return local_hits(models)
 
-    def accumulate_rhs(self, models: ObservationModel, indices: Array) -> StokesPyTreeType:
+    def accumulate_rhs(
+        self,
+        models: ObservationModel,
+        indices: Array,
+        reader: ObservationReader[T],
+    ) -> StokesPyTreeType:
         """Accumulate the RHS vector across all observations.
 
         Uses shard_map + scan with psum for multi-device execution. ``indices``
         must be sharded along the same 'obs' axis as ``models`` (see
-        :meth:`shard_obs`).
+        :meth:`distribute`). ``reader`` is passed in (rather than built here)
+        so this method stays jit-friendly — building the reader triggers an
+        all-gather that must run outside ``jax.jit``.
         """
-        reader = self.get_reader(['metadata', 'sample_data'])
 
         def step(carry: StokesPyTreeType, args: Any) -> tuple[StokesPyTreeType, None]:
             obs, i = args
@@ -367,35 +373,46 @@ class MultiObservationMapMaker(Generic[T]):
         return valid
 
 
-def get_obs_distribution_to_process(n_obs: int) -> tuple[int, int, int]:
-    """Compute this process's observation slice for distributed mapmaking.
+def get_obs_distribution_to_process(
+    n_obs: int,
+    rank: int | None = None,
+    n_proc: int | None = None,
+    n_local: int | None = None,
+) -> tuple[int, int, int]:
+    """Compute this process's slice for distributed mapmaking.
 
     Distributes ``n_obs`` observations across processes as evenly as possible
     (first ``n_obs % n_proc`` processes get one extra), then pads each process's
-    share to the next multiple of ``local_device_count`` so every device has a
-    uniform workload.  All processes end up with the same number of total slots
+    share to the next multiple of ``n_local`` so every device has a uniform
+    workload.  All processes end up with the same number of total slots
     (``n_owned + n_pad``), which is required for multi-process sharding.
 
     Args:
         n_obs: Total number of observations across all processes.
+        rank: Process index. Defaults to ``jax.process_index()``.
+        n_proc: Process count. Defaults to ``jax.process_count()``.
+        n_local: Local device count. Defaults to ``jax.local_device_count()``.
 
     Returns:
         A tuple ``(start, n_owned, n_pad)`` where ``start`` is the index of the
         first real observation owned by this process, ``n_owned`` is the number
         of real observations, and ``n_pad`` is the number of padding slots so that
-        ``n_owned + n_pad`` is a multiple of ``local_device_count``.
+        ``n_owned + n_pad`` is a multiple of ``n_local``.
 
     Raises:
         ValueError: If ``n_obs < n_proc``.
     """
-    rank = jax.process_index()
-    n_proc = jax.process_count()
-    n_local = jax.local_device_count()
+    if rank is None:
+        rank = jax.process_index()
+    if n_proc is None:
+        n_proc = jax.process_count()
+    if n_local is None:
+        n_local = jax.local_device_count()
 
     if n_obs < n_proc:
         raise ValueError(
             f'Not enough observations ({n_obs}) for {n_proc} processes. '
-            f'Use fewer SLURM tasks or provide more observations.'
+            f'Provide more observations or run with fewer processes.'
         )
 
     base = n_obs // n_proc

--- a/src/furax/mapmaking/mapmaker.py
+++ b/src/furax/mapmaking/mapmaker.py
@@ -126,7 +126,7 @@ class MultiObservationMapMaker(Generic[T]):
         """Build an ObservationReader for this process's local observations."""
         return ObservationReader.from_observations_distributed(
             self.observations,
-            tuple(self.get_indices()),
+            tuple(self.get_padded_indices()),
             requested_fields=required_fields,
             demodulated=self.config.demodulated,
             stokes=self.config.landscape.stokes,

--- a/src/furax/mapmaking/mapmaker.py
+++ b/src/furax/mapmaking/mapmaker.py
@@ -315,6 +315,7 @@ class MultiObservationMapMaker(Generic[T]):
         def step(carry, model):  # type: ignore[no-untyped-def]
             return carry + model.hits(), None
 
+        # check_vma=False: furax operator chain inside the body lacks manual-axis annotations.
         @jax.shard_map(mesh=self.mesh, in_specs=P('obs'), out_specs=P(), check_vma=False)
         def local_hits(local_models: ObservationModel) -> Int64[Array, ' pixels']:
             hits, _ = jax.lax.scan(step, init, local_models)
@@ -336,6 +337,7 @@ class MultiObservationMapMaker(Generic[T]):
             data, _ = reader.read(i)
             return furax.tree.add(carry, obs.rhs(data, self.config)), None
 
+        # check_vma=False: furax operator chain inside the body lacks manual-axis annotations.
         @jax.shard_map(
             mesh=self.mesh, in_specs=(P('obs'), P('obs')), out_specs=P(), check_vma=False
         )

--- a/src/furax/mapmaking/mapmaker.py
+++ b/src/furax/mapmaking/mapmaker.py
@@ -2,6 +2,7 @@ import pickle
 from abc import abstractmethod
 from collections.abc import Sequence
 from dataclasses import asdict, dataclass
+from functools import cached_property
 from logging import Logger
 from math import prod
 from pathlib import Path
@@ -16,10 +17,12 @@ import pixell.utils
 from astropy.io import fits
 from astropy.wcs import WCS
 from jax import ShapeDtypeStruct
-from jaxtyping import Array, Bool, DTypeLike, Float, Int64, Integer
+from jax.sharding import Mesh, NamedSharding
+from jax.sharding import PartitionSpec as P
+from jaxtyping import Array, Bool, DTypeLike, Float, Int64, Integer, PyTree
 
 import furax.linalg
-import furax.tree as tree
+import furax.tree
 from furax import (
     AbstractLinearOperator,
     Config,
@@ -44,7 +47,7 @@ from furax.obs.stokes import Stokes, StokesIQU, StokesPyTreeType, ValidStokesTyp
 from . import templates
 from ._geometry import minimum_enclosing_arc
 from ._logger import logger as furax_logger
-from ._model import ObservationModel, SystemOperator
+from ._model import ObservationModel, SystemOperator, pad_model
 from ._observation import AbstractGroundObservation, AbstractLazyObservation
 from ._reader import ObservationReader
 from .config import LandscapeConfig, MapMakingConfig, Methods, WCSConfig
@@ -90,6 +93,45 @@ class MultiObservationMapMaker(Generic[T]):
                 )
                 self.config.landscape.stokes = 'QU'
 
+    @cached_property
+    def mesh(self) -> Mesh:
+        return jax.make_mesh((jax.device_count(),), ('obs',))
+
+    @property
+    def sharding(self) -> NamedSharding:
+        return NamedSharding(self.mesh, P('obs'))
+
+    def distribute(self, x: PyTree) -> PyTree:
+        """Shard a pytree of process-local arrays along the leading 'obs' axis."""
+        if jax.process_count() > 1:
+            return jax.tree.map(
+                lambda a: jax.make_array_from_process_local_data(self.sharding, a), x
+            )
+        return jax.device_put(x, self.sharding)
+
+    @cached_property
+    def obs_distribution(self) -> tuple[int, int, int]:
+        """``(start, n_owned, n_pad)`` for this process."""
+        return get_obs_distribution_to_process(self.n_observations)
+
+    def get_indices(self) -> np.ndarray:
+        start, n_owned, _ = self.obs_distribution
+        return np.arange(start, start + n_owned)
+
+    def get_padded_indices(self) -> np.ndarray:
+        _, _, n_pad = self.obs_distribution
+        return np.pad(self.get_indices(), (0, n_pad), mode='edge')
+
+    def get_reader(self, required_fields: Sequence[str]) -> ObservationReader[T]:
+        """Build an ObservationReader for this process's local observations."""
+        return ObservationReader.from_observations_distributed(
+            self.observations,
+            tuple(self.get_indices()),
+            requested_fields=required_fields,
+            demodulated=self.config.demodulated,
+            stokes=self.config.landscape.stokes,
+        )
+
     def _scan_wcs_footprint(self) -> WCSLandscape:
         """Scan observations to determine the combined WCS footprint and build a WCSLandscape.
 
@@ -130,8 +172,8 @@ class MultiObservationMapMaker(Generic[T]):
         """Runs the mapmaker and return results after saving them to the given directory."""
         results = self.make_maps()
 
-        # Save outputs
-        if out_dir is not None:
+        # Save outputs on process 0 only (all processes hold the same replicated result)
+        if out_dir is not None and jax.process_index() == 0:
             out_dir = Path(out_dir)
             results.save(out_dir)
             self.logger.info(f'saved results to {out_dir}')
@@ -140,46 +182,63 @@ class MultiObservationMapMaker(Generic[T]):
 
         return results
 
-    def get_reader(self, data_field_names: list[str]) -> ObservationReader[T]:
-        """Returns a reader for a list of requested fields."""
-        return ObservationReader(
-            self.observations,
-            requested_fields=data_field_names,
-            demodulated=self.config.demodulated,
-            stokes=self.config.landscape.stokes,
-        )
+    @property
+    def n_observations(self) -> int:
+        """Total number of observations across all processes."""
+        return len(self.observations)
 
     def make_maps(self) -> MapMakingResults:
         """Computes the mapmaker results (maps and other products)."""
         logger_info = lambda msg: self.logger.info(f'MultiObsMapMaker: {msg}')
 
-        # Build system matrix from stacked ObservationModel
-        model = self.build_model()
-        A = SystemOperator(model)
+        n_processes = jax.process_count()
+        rank = jax.process_index()
+        n_local_devices = jax.local_device_count()
+        n_devices = jax.device_count()
+        start, n_owned, n_pad = self.obs_distribution
+        n_per_proc = n_owned + n_pad
+        n_per_dev = n_per_proc // n_local_devices
+        logger_info(
+            f'Layout: {n_processes} process(es) x {n_local_devices} local device(s) = {n_devices} total'
+        )
+        logger_info(
+            f'Observations: {self.n_observations} real, {n_per_proc * n_processes} after padding '
+            f'({n_per_proc} per process, {n_per_dev} per device)'
+        )
+        logger_info(
+            f'Rank {rank}: owns obs[{start}:{start + n_owned}] ({n_owned} real + {n_pad} padding)'
+        )
+
+        model = self.distribute(self.build_model())
+        indices = self.distribute(self.get_padded_indices())
+
+        A = SystemOperator(model, mesh=self.mesh)
         logger_info('Created system operator')
 
-        hits = self.accumulate_hits(model).block_until_ready()
+        hits = jax.jit(self.accumulate_hits)(model).block_until_ready()
         logger_info('Computed hit map')
 
-        rhs = self.accumulate_rhs(model)
+        rhs = jax.block_until_ready(self.accumulate_rhs(model, indices))
         logger_info('Accumulated RHS vector')
 
         # Preconditioning
-        sysdiag = A if self.config.binned else SystemOperator(model, diag=True)
+        sysdiag = A if self.config.binned else SystemOperator(model, diag=True, mesh=self.mesh)
         BJ = BJPreconditioner.create(sysdiag)
         icov = BJ.get_blocks().block_until_ready()
         logger_info('Computed white noise inverse covariance')
 
-        # Pixel selection
-        valid_pixels = self.pixel_selection(hits, icov)
-        selector = IndexOperator(jnp.where(valid_pixels), in_structure=model.map_structure)
-        n_selected = jnp.sum(valid_pixels)
-        n_observed = jnp.sum(hits > 0)
-        n_total = valid_pixels.size
-        logger_info(f'Selected {n_selected} pixels ({n_observed} seen, {n_total} total)')
+        # Pixel selection (post-processing under the mesh so eager ops on
+        # explicit-sharded arrays can dispatch in multi-process runs).
+        with jax.set_mesh(self.mesh):
+            valid_pixels = self.pixel_selection(hits, icov)
+            selector = IndexOperator(jnp.where(valid_pixels), in_structure=model.map_structure)
+            n_selected = jnp.sum(valid_pixels)
+            n_observed = jnp.sum(hits > 0)
+            n_total = valid_pixels.size
+            logger_info(f'Selected {n_selected} pixels ({n_observed} seen, {n_total} total)')
 
-        hits = hits.at[~valid_pixels].set(0)  # excluded pixels have zero hits
-        icov = jnp.moveaxis(icov, [-2, -1], [0, 1])  # (*pixels, ns, ns) → (ns, ns, *pixels)
+            hits = hits.at[~valid_pixels].set(0)  # excluded pixels have zero hits
+            icov = jnp.moveaxis(icov, [-2, -1], [0, 1])  # (*pixels, ns, ns) → (ns, ns, *pixels)
 
         # Solve the mapmaking system
         solver = lineax.CG(**asdict(self.config.solver))
@@ -209,7 +268,11 @@ class MultiObservationMapMaker(Generic[T]):
         )
 
     def build_model(self) -> ObservationModel:
-        # Only read necessary fields
+        """Build the local ObservationModel for this process.
+
+        Each process reads its owned observations and pads up to the uniform
+        per-process count.
+        """
         required_fields = [
             'boresight_quaternions',
             'detector_quaternions',
@@ -227,36 +290,60 @@ class MultiObservationMapMaker(Generic[T]):
             required_fields.append('noise_model_fits')
         if self.config.gaps.fill and not self.config.binned:
             required_fields.append('metadata')
+
         reader = self.get_reader(required_fields)
 
         def build_one(_, i):  # type: ignore[no-untyped-def]
             data, padding = reader.read(i)
             return None, ObservationModel.create(data, padding, self.config, self.landscape)
 
-        _, model = jax.lax.scan(build_one, None, jnp.arange(reader.count))
-        return model  # type: ignore[no-any-return]
+        _, model = jax.lax.scan(build_one, None, self.get_indices())
+
+        _, _, n_pad = self.obs_distribution
+        if n_pad == 0:
+            return model  # type: ignore[no-any-return]
+
+        return pad_model(model, n_pad)
 
     def accumulate_hits(self, models: ObservationModel) -> Int64[Array, ' pixels']:
-        def acc(carry, model):  # type: ignore[no-untyped-def]
+        """Accumulate hit map across all observations.
+
+        Uses shard_map + scan with psum for multi-device execution.
+        """
+        init = jnp.zeros(self.landscape.shape, dtype=jnp.int64)
+
+        def step(carry, model):  # type: ignore[no-untyped-def]
             return carry + model.hits(), None
 
-        init = jnp.zeros(self.landscape.shape, dtype=jnp.int64)
-        total, _ = jax.lax.scan(acc, init, models)
-        return total
+        @jax.shard_map(mesh=self.mesh, in_specs=P('obs'), out_specs=P(), check_vma=False)
+        def local_hits(local_models: ObservationModel) -> Int64[Array, ' pixels']:
+            hits, _ = jax.lax.scan(step, init, local_models)
+            return jax.lax.psum(hits, axis_name='obs')  # type: ignore[no-any-return]
 
-    def accumulate_rhs(self, models: ObservationModel) -> StokesPyTreeType:
-        """Accumulate the RHS vector across all observations"""
+        return local_hits(models)
+
+    def accumulate_rhs(self, models: ObservationModel, indices: Array) -> StokesPyTreeType:
+        """Accumulate the RHS vector across all observations.
+
+        Uses shard_map + scan with psum for multi-device execution. ``indices``
+        must be sharded along the same 'obs' axis as ``models`` (see
+        :meth:`shard_obs`).
+        """
         reader = self.get_reader(['metadata', 'sample_data'])
 
-        def acc(carry, args):  # type: ignore[no-untyped-def]
-            i, model = args
+        def step(carry: StokesPyTreeType, args: Any) -> tuple[StokesPyTreeType, None]:
+            obs, i = args
             data, _ = reader.read(i)
-            carry = carry + model.rhs(data, self.config)
-            return carry, None
+            return furax.tree.add(carry, obs.rhs(data, self.config)), None
 
-        init = tree.zeros_like(models.map_structure)
-        total, _ = jax.lax.scan(acc, init, (jnp.arange(reader.count), models))
-        return total  # type: ignore[no-any-return]
+        @jax.shard_map(
+            mesh=self.mesh, in_specs=(P('obs'), P('obs')), out_specs=P(), check_vma=False
+        )
+        def local_rhs(local_models: ObservationModel, local_indices: Any) -> StokesPyTreeType:
+            rhs, _ = jax.lax.scan(step, self.landscape.zeros(), (local_models, local_indices))
+            return jax.lax.psum(rhs, axis_name='obs')  # type: ignore[no-any-return]
+
+        return local_rhs(models, indices)
 
     def pixel_selection(
         self, hits: Integer[Array, ' pixels'], weights: Float[Array, 'pixels stokes stokes']

--- a/src/furax/mapmaking/mapmaker.py
+++ b/src/furax/mapmaking/mapmaker.py
@@ -110,13 +110,13 @@ class MultiObservationMapMaker(Generic[T]):
         """``(start, n_owned, n_pad)`` for this process."""
         return get_obs_distribution_to_process(self.n_observations)
 
-    def get_indices(self) -> np.ndarray:
+    def get_read_indices(self) -> np.ndarray:
         start, n_owned, _ = self.obs_distribution
         return np.arange(start, start + n_owned)
 
-    def get_padded_indices(self) -> np.ndarray:
+    def get_padded_read_indices(self) -> np.ndarray:
         _, _, n_pad = self.obs_distribution
-        return np.pad(self.get_indices(), (0, n_pad), mode='edge')
+        return np.pad(self.get_read_indices(), (0, n_pad), mode='edge')
 
     def get_reader(self, required_fields: Sequence[str]) -> ObservationReader[T]:
         """Build an ObservationReader for this process's local observations."""
@@ -124,7 +124,7 @@ class MultiObservationMapMaker(Generic[T]):
         # rank to send the same shape, so all ranks must report the same obs count.
         return ObservationReader.from_observations(
             self.observations,
-            subset_indices=tuple(self.get_padded_indices()),
+            read_indices=tuple(self.get_padded_read_indices()),
             requested_fields=required_fields,
             demodulated=self.config.demodulated,
             stokes=self.config.landscape.stokes,
@@ -211,7 +211,7 @@ class MultiObservationMapMaker(Generic[T]):
         )
 
         model = self.distribute(self.build_model())
-        indices = self.distribute(self.get_padded_indices())
+        read_indices = self.distribute(self.get_padded_read_indices())
 
         A = SystemOperator(model, mesh=self.mesh)
         logger_info('Created system operator')
@@ -220,7 +220,7 @@ class MultiObservationMapMaker(Generic[T]):
         logger_info('Computed hit map')
 
         rhs_reader = self.get_reader(['metadata', 'sample_data'])
-        rhs = jax.block_until_ready(jax.jit(self.accumulate_rhs)(model, indices, rhs_reader))
+        rhs = jax.block_until_ready(jax.jit(self.accumulate_rhs)(model, read_indices, rhs_reader))
         logger_info('Accumulated RHS vector')
 
         # Preconditioning
@@ -299,7 +299,7 @@ class MultiObservationMapMaker(Generic[T]):
             data, padding = reader.read(i)
             return None, ObservationModel.create(data, padding, self.config, self.landscape)
 
-        _, model = jax.lax.scan(build_one, None, self.get_indices())
+        _, model = jax.lax.scan(build_one, None, self.get_read_indices())
 
         _, _, n_pad = self.obs_distribution
         return pad_model(model, n_pad)
@@ -325,12 +325,12 @@ class MultiObservationMapMaker(Generic[T]):
     def accumulate_rhs(
         self,
         models: ObservationModel,
-        indices: Array,
+        read_indices: Array,
         reader: ObservationReader[T],
     ) -> StokesPyTreeType:
         """Accumulate the RHS vector across all observations.
 
-        Uses shard_map + scan with psum for multi-device execution. ``indices``
+        Uses shard_map + scan with psum for multi-device execution.  ``read_indices``
         must be sharded along the same 'obs' axis as ``models`` (see
         :meth:`distribute`). ``reader`` is passed in (rather than built here)
         so this method stays jit-friendly — building the reader triggers an
@@ -350,7 +350,7 @@ class MultiObservationMapMaker(Generic[T]):
             rhs, _ = jax.lax.scan(step, self.landscape.zeros(), (local_models, local_indices))
             return jax.lax.psum(rhs, axis_name='obs')  # type: ignore[no-any-return]
 
-        return local_rhs(models, indices)
+        return local_rhs(models, read_indices)
 
     def pixel_selection(
         self, hits: Integer[Array, ' pixels'], weights: Float[Array, 'pixels stokes stokes']

--- a/src/furax/mapmaking/mapmaker.py
+++ b/src/furax/mapmaking/mapmaker.py
@@ -124,9 +124,11 @@ class MultiObservationMapMaker(Generic[T]):
 
     def get_reader(self, required_fields: Sequence[str]) -> ObservationReader[T]:
         """Build an ObservationReader for this process's local observations."""
-        return ObservationReader.from_observations_distributed(
+        # Pass padded indices: process_allgather inside from_observations needs every
+        # rank to send the same shape, so all ranks must report the same obs count.
+        return ObservationReader.from_observations(
             self.observations,
-            tuple(self.get_padded_indices()),
+            subset_indices=tuple(self.get_padded_indices()),
             requested_fields=required_fields,
             demodulated=self.config.demodulated,
             stokes=self.config.landscape.stokes,

--- a/src/furax/mapmaking/preconditioner.py
+++ b/src/furax/mapmaking/preconditioner.py
@@ -76,8 +76,9 @@ class BJPreconditioner(TreeOperator):
         return cls(tree, in_structure=in_struct)
 
     def inverse(self) -> 'BJPreconditioner':
-        # FIXME: we override the parent implementation so that the symmetric tag is preserved
-        # there might be a better way of doing that
+        # Override the parent inverse so the result stays a BJPreconditioner and
+        # keeps the @symmetric tag; the generic TreeOperator inverse would
+        # downgrade to a plain operator.
         dense = _tree_to_dense(self.outer_treedef, self.inner_treedef, self.tree)
         dense_inv = jnp.linalg.inv(dense)
         tree = _dense_to_tree(self.inner_treedef, self.outer_treedef, dense_inv)

--- a/src/furax/mapmaking/preconditioner.py
+++ b/src/furax/mapmaking/preconditioner.py
@@ -6,7 +6,7 @@ from jaxtyping import Array, PyTree
 
 from furax import AbstractLinearOperator, TreeOperator, symmetric
 from furax.obs.stokes import Stokes
-from furax.tree import _get_outer_treedef, _tree_to_dense, zeros_like
+from furax.tree import _dense_to_tree, _get_outer_treedef, _tree_to_dense, zeros_like
 
 
 @symmetric
@@ -74,6 +74,14 @@ class BJPreconditioner(TreeOperator):
             }
         )
         return cls(tree, in_structure=in_struct)
+
+    def inverse(self) -> 'BJPreconditioner':
+        # FIXME: we override the parent implementation so that the symmetric tag is preserved
+        # there might be a better way of doing that
+        dense = _tree_to_dense(self.outer_treedef, self.inner_treedef, self.tree)
+        dense_inv = jnp.linalg.inv(dense)
+        tree = _dense_to_tree(self.inner_treedef, self.outer_treedef, dense_inv)
+        return BJPreconditioner(tree, in_structure=self.in_structure)
 
     def get_blocks(self) -> Array:
         """Convert the preconditioner blocks as a dense matrix."""

--- a/tests/interfaces/litebird_sim/test_io.py
+++ b/tests/interfaces/litebird_sim/test_io.py
@@ -25,7 +25,7 @@ def observations():
 
 def test_reader_all_fields(observations) -> None:
     """Test consistency for all available fields."""
-    reader = ObservationReader(
+    reader = ObservationReader.from_observations(
         observations, requested_fields=AbstractSatelliteObservation.AVAILABLE_READER_FIELDS
     )
     ndet_max, nsample_max = max(OBS_NDET), max(OBS_NSAMPLE)
@@ -72,11 +72,13 @@ def test_reader_invalid_data_field_name(observations) -> None:
     with pytest.raises(
         ValueError, match="Requested data fields {'invalid_field'} are not supported"
     ):
-        ObservationReader(observations, requested_fields=['invalid_field'])
+        ObservationReader.from_observations(observations, requested_fields=['invalid_field'])
 
     # Test with mix of valid and invalid field names
     with pytest.raises(ValueError, match="Requested data fields {'bad_field'} are not supported"):
-        ObservationReader(observations, requested_fields=['sample_data', 'bad_field'])
+        ObservationReader.from_observations(
+            observations, requested_fields=['sample_data', 'bad_field']
+        )
 
 
 @pytest.mark.parametrize(
@@ -96,5 +98,5 @@ def test_reader_invalid_data_field_name(observations) -> None:
 )
 def test_reader_subset_of_data_fields(observations, requested_fields: list[str]) -> None:
     """Test that passing a subset of data fields loads only those fields."""
-    reader = ObservationReader(observations, requested_fields=requested_fields)
+    reader = ObservationReader.from_observations(observations, requested_fields=requested_fields)
     assert set(reader.out_structure.keys()) == set(requested_fields)

--- a/tests/interfaces/sotodlib/test_acquisition.py
+++ b/tests/interfaces/sotodlib/test_acquisition.py
@@ -7,7 +7,7 @@ from numpy.testing import assert_allclose, assert_array_equal
 from sotodlib import coords
 from sotodlib.mapmaking.demod_mapmaker import project_rhs_demod
 
-from furax.interfaces.sotodlib import LazySOTODLibObservation
+from furax.interfaces.sotodlib.observation import LazySOTODLibObservation
 from furax.mapmaking.acquisition import build_acquisition_operator
 from furax.obs.landscapes import HealpixLandscape
 from furax.obs.stokes import StokesI

--- a/tests/interfaces/sotodlib/test_io.py
+++ b/tests/interfaces/sotodlib/test_io.py
@@ -29,7 +29,7 @@ def demod_observations():
 
 def test_reader_all_fields(observations) -> None:
     """Test consistency for all available fields."""
-    reader = ObservationReader(
+    reader = ObservationReader.from_observations(
         observations, requested_fields=AbstractGroundObservation.AVAILABLE_READER_FIELDS
     )
     ndet_max, nsample_max = max(OBS_NDET), max(OBS_NSAMPLE)
@@ -78,11 +78,13 @@ def test_reader_invalid_data_field_name(observations) -> None:
     with pytest.raises(
         ValueError, match="Requested data fields {'invalid_field'} are not supported"
     ):
-        ObservationReader(observations, requested_fields=['invalid_field'])
+        ObservationReader.from_observations(observations, requested_fields=['invalid_field'])
 
     # Test with mix of valid and invalid field names
     with pytest.raises(ValueError, match="Requested data fields {'bad_field'} are not supported"):
-        ObservationReader(observations, requested_fields=['sample_data', 'bad_field'])
+        ObservationReader.from_observations(
+            observations, requested_fields=['sample_data', 'bad_field']
+        )
 
 
 @pytest.mark.parametrize(
@@ -103,14 +105,14 @@ def test_reader_invalid_data_field_name(observations) -> None:
 )
 def test_reader_subset_of_data_fields(observations, requested_fields: list[str]) -> None:
     """Test that passing a subset of data fields loads only those fields."""
-    reader = ObservationReader(observations, requested_fields=requested_fields)
+    reader = ObservationReader.from_observations(observations, requested_fields=requested_fields)
     assert set(reader.out_structure.keys()) == set(requested_fields)
 
 
 def test_reader_all_fields_demod(demod_observations) -> None:
     """Test consistency for all available fields in demodulated mode."""
     stokes = 'IQU'
-    reader = ObservationReader(
+    reader = ObservationReader.from_observations(
         demod_observations,
         requested_fields=AbstractGroundObservation.AVAILABLE_READER_FIELDS,
         demodulated=True,
@@ -171,7 +173,7 @@ def test_reader_subset_of_data_fields_demod(
     demod_observations, requested_fields: list[str]
 ) -> None:
     """Test that passing a subset of data fields loads only those fields in demodulated mode."""
-    reader = ObservationReader(
+    reader = ObservationReader.from_observations(
         demod_observations, requested_fields=requested_fields, demodulated=True
     )
     assert set(reader.out_structure.keys()) == set(requested_fields)

--- a/tests/interfaces/sotodlib/test_io.py
+++ b/tests/interfaces/sotodlib/test_io.py
@@ -4,7 +4,7 @@ import jax
 import jax.numpy as jnp
 import pytest
 
-from furax.interfaces.sotodlib import LazySOTODLibObservation
+from furax.interfaces.sotodlib.observation import LazySOTODLibObservation
 from furax.mapmaking import AbstractGroundObservation, HashedObservationMetadata, ObservationReader
 from furax.mapmaking.config import SotodlibConfig
 from furax.obs.stokes import Stokes

--- a/tests/interfaces/sotodlib/test_observation.py
+++ b/tests/interfaces/sotodlib/test_observation.py
@@ -3,7 +3,7 @@ from pathlib import Path
 import pytest
 from numpy.testing import assert_allclose
 
-from furax.interfaces.sotodlib import SOTODLibObservation
+from furax.interfaces.sotodlib.observation import SOTODLibObservation
 
 FOLDER = Path(__file__).parents[2] / 'data/sotodlib'
 FILE = FOLDER / 'test_obs.h5'

--- a/tests/interfaces/toast/test_io.py
+++ b/tests/interfaces/toast/test_io.py
@@ -25,7 +25,7 @@ def observations():
 
 def test_reader_all_fields(observations) -> None:
     """Test consistency for all available fields."""
-    reader = ObservationReader(
+    reader = ObservationReader.from_observations(
         observations, requested_fields=AbstractGroundObservation.AVAILABLE_READER_FIELDS
     )
     ndet_max, nsample_max = max(OBS_NDET), max(OBS_NSAMPLE)
@@ -74,11 +74,13 @@ def test_reader_invalid_data_field_name(observations) -> None:
     with pytest.raises(
         ValueError, match="Requested data fields {'invalid_field'} are not supported"
     ):
-        ObservationReader(observations, requested_fields=['invalid_field'])
+        ObservationReader.from_observations(observations, requested_fields=['invalid_field'])
 
     # Test with mix of valid and invalid field names
     with pytest.raises(ValueError, match="Requested data fields {'bad_field'} are not supported"):
-        ObservationReader(observations, requested_fields=['sample_data', 'bad_field'])
+        ObservationReader.from_observations(
+            observations, requested_fields=['sample_data', 'bad_field']
+        )
 
 
 @pytest.mark.parametrize(
@@ -99,5 +101,5 @@ def test_reader_invalid_data_field_name(observations) -> None:
 )
 def test_reader_subset_of_data_fields(observations, requested_fields: list[str]) -> None:
     """Test that passing a subset of data fields loads only those fields."""
-    reader = ObservationReader(observations, requested_fields=requested_fields)
+    reader = ObservationReader.from_observations(observations, requested_fields=requested_fields)
     assert set(reader.out_structure.keys()) == set(requested_fields)

--- a/tests/mapmaking/test_mapmaker.py
+++ b/tests/mapmaking/test_mapmaker.py
@@ -1,7 +1,6 @@
 import importlib.util
 from pathlib import Path
 from typing import Literal
-from unittest.mock import patch
 
 import jax
 import jax.numpy as jnp
@@ -32,71 +31,47 @@ from furax.obs.pointing import PointingOperator
 from furax.obs.stokes import Stokes, ValidStokesType
 
 
-def _mock_jax(process_count: int, process_index: int, local_device_count: int):
-    """Context manager patching JAX distributed state for _process_chunk tests."""
-    return patch.multiple(
-        'furax.mapmaking.mapmaker.jax',
-        process_count=lambda: process_count,
-        process_index=lambda: process_index,
-        local_device_count=lambda: local_device_count,
-        device_count=lambda: process_count * local_device_count,
-    )
-
-
-class TestProcessChunk:
+class TestObsDistribution:
     def test_single_process_divisible(self):
         # 8 obs, 1 proc, 4 local devs → no padding needed
-        with _mock_jax(1, 0, 4):
-            start, n_owned, n_pad = get_obs_distribution_to_process(8)
+        start, n_owned, n_pad = get_obs_distribution_to_process(8, rank=0, n_proc=1, n_local=4)
         assert (start, n_owned, n_pad) == (0, 8, 0)
 
     def test_single_process_needs_padding(self):
         # 10 obs, 1 proc, 4 local devs → pad to 12
-        with _mock_jax(1, 0, 4):
-            start, n_owned, n_pad = get_obs_distribution_to_process(10)
+        start, n_owned, n_pad = get_obs_distribution_to_process(10, rank=0, n_proc=1, n_local=4)
         assert (start, n_owned, n_pad) == (0, 10, 2)
 
     def test_multi_process_even_distribution(self):
         # 10 obs, 2 procs, 2 local devs → 5 obs each, chunk=6 (pad to multiple of 2)
-        with _mock_jax(2, 0, 2):
-            start, n_owned, n_pad = get_obs_distribution_to_process(10)
-        assert (start, n_owned, n_pad) == (0, 5, 1)
-
-        with _mock_jax(2, 1, 2):
-            start, n_owned, n_pad = get_obs_distribution_to_process(10)
-        assert (start, n_owned, n_pad) == (5, 5, 1)
+        assert get_obs_distribution_to_process(10, rank=0, n_proc=2, n_local=2) == (0, 5, 1)
+        assert get_obs_distribution_to_process(10, rank=1, n_proc=2, n_local=2) == (5, 5, 1)
 
     def test_multi_process_uneven_distribution(self):
         # 11 obs, 2 procs, 2 local devs → proc 0 gets 6, proc 1 gets 5
         # chunk = ceil(11/2)=6, padded to multiple of 2 → 6
-        with _mock_jax(2, 0, 2):
-            start, n_owned, n_pad = get_obs_distribution_to_process(11)
-        assert (start, n_owned, n_pad) == (0, 6, 0)
-
-        with _mock_jax(2, 1, 2):
-            start, n_owned, n_pad = get_obs_distribution_to_process(11)
-        assert (start, n_owned, n_pad) == (6, 5, 1)
+        assert get_obs_distribution_to_process(11, rank=0, n_proc=2, n_local=2) == (0, 6, 0)
+        assert get_obs_distribution_to_process(11, rank=1, n_proc=2, n_local=2) == (6, 5, 1)
 
     def test_no_process_left_empty(self):
         # 85 obs, 20 procs, 1 local dev → base=4, remainder=5
         # first 5 procs own 5 obs, rest own 4; no proc gets 0
         for rank in range(20):
-            with _mock_jax(20, rank, 1):
-                _, n_owned, _ = get_obs_distribution_to_process(85)
+            _, n_owned, _ = get_obs_distribution_to_process(85, rank=rank, n_proc=20, n_local=1)
             assert n_owned > 0
 
     def test_fewer_obs_than_procs_raises(self):
         # n_obs < n_proc is always an error regardless of rank
-        with _mock_jax(4, 3, 1):
-            with pytest.raises(ValueError, match='Not enough observations'):
-                get_obs_distribution_to_process(3)
+        with pytest.raises(ValueError, match='Not enough observations'):
+            get_obs_distribution_to_process(3, rank=3, n_proc=4, n_local=1)
 
     def test_chunk_always_divisible_by_local_devices(self):
         # n_owned + n_pad must be divisible by n_local_dev
         n_obs, n_local_dev, n_procs = 7, 2, 3
-        for proc_index in range(n_procs):
-            with _mock_jax(n_procs, proc_index, n_local_dev):
-                _, n_owned, n_pad = get_obs_distribution_to_process(n_obs)
+        for rank in range(n_procs):
+            _, n_owned, n_pad = get_obs_distribution_to_process(
+                n_obs, rank=rank, n_proc=n_procs, n_local=n_local_dev
+            )
             assert (n_owned + n_pad) % n_local_dev == 0
 
     def test_all_procs_cover_all_obs(self):
@@ -104,9 +79,10 @@ class TestProcessChunk:
         n_obs, n_local_dev, n_procs = 10, 2, 2
         starts = []
         total_real = 0
-        for proc_index in range(n_procs):
-            with _mock_jax(n_procs, proc_index, n_local_dev):
-                start, n_owned, _ = get_obs_distribution_to_process(n_obs)
+        for rank in range(n_procs):
+            start, n_owned, _ = get_obs_distribution_to_process(
+                n_obs, rank=rank, n_proc=n_procs, n_local=n_local_dev
+            )
             starts.append(start)
             total_real += n_owned
         assert starts == [0, 5]
@@ -203,7 +179,8 @@ class TestMultiObsMapMaker:
         maker = MultiObservationMapMaker(observations, config=config)
         model = maker.distribute(maker.build_model())
         indices = maker.distribute(maker.get_padded_indices())
-        rhs = maker.accumulate_rhs(model, indices)
+        reader = maker.get_reader(['metadata', 'sample_data'])
+        rhs = maker.accumulate_rhs(model, indices, reader)
         assert rhs.shape == maker.landscape.shape
 
     def test_hits_are_nonnegative(self, name, demodulated, stokes, landscape_type):

--- a/tests/mapmaking/test_mapmaker.py
+++ b/tests/mapmaking/test_mapmaker.py
@@ -224,7 +224,7 @@ def _observations(name: str, demodulated: bool = False) -> list[AbstractLazyObse
         files = [folder / 'test_obs.h5'] * 2
         return [LazyToastObservation(f) for f in files]
     elif name == 'sotodlib':
-        from furax.interfaces.sotodlib import LazySOTODLibObservation
+        from furax.interfaces.sotodlib.observation import LazySOTODLibObservation
 
         sotodlib_config = SotodlibConfig(demodulated=True) if demodulated else None
         files = [folder / 'test_obs.h5', folder / 'test_obs_2.h5']

--- a/tests/mapmaking/test_mapmaker.py
+++ b/tests/mapmaking/test_mapmaker.py
@@ -157,16 +157,18 @@ class TestMultiObsMapMaker:
     Use a class in order to parametrize over multiple tests at once.
     """
 
-    def test_blocks_vs_reader_structure(self, name, demodulated, stokes, landscape_type):
+    def test_model_vs_reader_structure(self, name, demodulated, stokes, landscape_type):
         observations = _observations(name, demodulated)
         config = _config(landscape_type, stokes, demodulated)
         maker = MultiObservationMapMaker(observations, config=config)
-        reader = ObservationReader(observations, demodulated=demodulated, stokes=stokes)
-        blocks = maker.build_model()
-        n_obs = jax.tree.leaves(blocks)[0].shape[0]
+        reader = ObservationReader.from_observations(
+            observations, demodulated=demodulated, stokes=stokes
+        )
+        model = maker.build_model()
+        n_obs = jax.tree.leaves(model)[0].shape[0]
         assert n_obs == len(observations) == reader.count
-        assert blocks.map_structure == maker.landscape.structure
-        assert blocks.tod_structure == reader.out_structure['sample_data']
+        assert model.map_structure == maker.landscape.structure
+        assert model.tod_structure == reader.out_structure['sample_data']
 
     def test_last_acquisition_operand_is_pointing(self, name, demodulated, stokes, landscape_type):
         observations = _observations(name, demodulated)
@@ -199,15 +201,16 @@ class TestMultiObsMapMaker:
         observations = _observations(name, demodulated)
         config = _config(landscape_type, stokes, demodulated)
         maker = MultiObservationMapMaker(observations, config=config)
-        blocks = maker.build_model()
-        rhs = maker.accumulate_rhs(blocks)
+        model = maker.distribute(maker.build_model())
+        indices = maker.distribute(maker.get_padded_indices())
+        rhs = maker.accumulate_rhs(model, indices)
         assert rhs.shape == maker.landscape.shape
 
     def test_hits_are_nonnegative(self, name, demodulated, stokes, landscape_type):
         observations = _observations(name, demodulated)
         config = _config(landscape_type, stokes, demodulated)
         maker = MultiObservationMapMaker(observations, config=config)
-        blocks = maker.build_model()
+        blocks = maker.distribute(maker.build_model())
         hits = maker.accumulate_hits(blocks)
         assert hits.shape == maker.landscape.shape
         assert jnp.all(hits >= 0)

--- a/tests/mapmaking/test_mapmaker.py
+++ b/tests/mapmaking/test_mapmaker.py
@@ -178,7 +178,7 @@ class TestMultiObsMapMaker:
         config = _config(landscape_type, stokes, demodulated)
         maker = MultiObservationMapMaker(observations, config=config)
         model = maker.distribute(maker.build_model())
-        indices = maker.distribute(maker.get_padded_indices())
+        indices = maker.distribute(maker.get_padded_read_indices())
         reader = maker.get_reader(['metadata', 'sample_data'])
         rhs = maker.accumulate_rhs(model, indices, reader)
         assert rhs.shape == maker.landscape.shape

--- a/tests/mapmaking/test_mapmaker.py
+++ b/tests/mapmaking/test_mapmaker.py
@@ -1,6 +1,7 @@
 import importlib.util
 from pathlib import Path
 from typing import Literal
+from unittest.mock import patch
 
 import jax
 import jax.numpy as jnp
@@ -24,10 +25,93 @@ from furax.mapmaking.config import (
     SotodlibConfig,
     WCSConfig,
 )
+from furax.mapmaking.mapmaker import get_obs_distribution_to_process
 from furax.mapmaking.noise import WhiteNoiseModel
 from furax.obs.landscapes import ProjectionType
 from furax.obs.pointing import PointingOperator
 from furax.obs.stokes import Stokes, ValidStokesType
+
+
+def _mock_jax(process_count: int, process_index: int, local_device_count: int):
+    """Context manager patching JAX distributed state for _process_chunk tests."""
+    return patch.multiple(
+        'furax.mapmaking.mapmaker.jax',
+        process_count=lambda: process_count,
+        process_index=lambda: process_index,
+        local_device_count=lambda: local_device_count,
+        device_count=lambda: process_count * local_device_count,
+    )
+
+
+class TestProcessChunk:
+    def test_single_process_divisible(self):
+        # 8 obs, 1 proc, 4 local devs → no padding needed
+        with _mock_jax(1, 0, 4):
+            start, n_owned, n_pad = get_obs_distribution_to_process(8)
+        assert (start, n_owned, n_pad) == (0, 8, 0)
+
+    def test_single_process_needs_padding(self):
+        # 10 obs, 1 proc, 4 local devs → pad to 12
+        with _mock_jax(1, 0, 4):
+            start, n_owned, n_pad = get_obs_distribution_to_process(10)
+        assert (start, n_owned, n_pad) == (0, 10, 2)
+
+    def test_multi_process_even_distribution(self):
+        # 10 obs, 2 procs, 2 local devs → 5 obs each, chunk=6 (pad to multiple of 2)
+        with _mock_jax(2, 0, 2):
+            start, n_owned, n_pad = get_obs_distribution_to_process(10)
+        assert (start, n_owned, n_pad) == (0, 5, 1)
+
+        with _mock_jax(2, 1, 2):
+            start, n_owned, n_pad = get_obs_distribution_to_process(10)
+        assert (start, n_owned, n_pad) == (5, 5, 1)
+
+    def test_multi_process_uneven_distribution(self):
+        # 11 obs, 2 procs, 2 local devs → proc 0 gets 6, proc 1 gets 5
+        # chunk = ceil(11/2)=6, padded to multiple of 2 → 6
+        with _mock_jax(2, 0, 2):
+            start, n_owned, n_pad = get_obs_distribution_to_process(11)
+        assert (start, n_owned, n_pad) == (0, 6, 0)
+
+        with _mock_jax(2, 1, 2):
+            start, n_owned, n_pad = get_obs_distribution_to_process(11)
+        assert (start, n_owned, n_pad) == (6, 5, 1)
+
+    def test_no_process_left_empty(self):
+        # 85 obs, 20 procs, 1 local dev → base=4, remainder=5
+        # first 5 procs own 5 obs, rest own 4; no proc gets 0
+        for rank in range(20):
+            with _mock_jax(20, rank, 1):
+                _, n_owned, _ = get_obs_distribution_to_process(85)
+            assert n_owned > 0
+
+    def test_fewer_obs_than_procs_raises(self):
+        # n_obs < n_proc is always an error regardless of rank
+        with _mock_jax(4, 3, 1):
+            with pytest.raises(ValueError, match='Not enough observations'):
+                get_obs_distribution_to_process(3)
+
+    def test_chunk_always_divisible_by_local_devices(self):
+        # n_owned + n_pad must be divisible by n_local_dev
+        n_obs, n_local_dev, n_procs = 7, 2, 3
+        for proc_index in range(n_procs):
+            with _mock_jax(n_procs, proc_index, n_local_dev):
+                _, n_owned, n_pad = get_obs_distribution_to_process(n_obs)
+            assert (n_owned + n_pad) % n_local_dev == 0
+
+    def test_all_procs_cover_all_obs(self):
+        # All processes together must cover every real observation exactly once
+        n_obs, n_local_dev, n_procs = 10, 2, 2
+        starts = []
+        total_real = 0
+        for proc_index in range(n_procs):
+            with _mock_jax(n_procs, proc_index, n_local_dev):
+                start, n_owned, _ = get_obs_distribution_to_process(n_obs)
+            starts.append(start)
+            total_real += n_owned
+        assert starts == [0, 5]
+        assert total_real == n_obs
+
 
 # Skip tests for interfaces that are not installed
 sotodlib_installed = importlib.util.find_spec('sotodlib') is not None


### PR DESCRIPTION
## Summary

Distribute multi-observation mapmaking across processes/devices via a 1D `('obs',)` mesh + `shard_map` over the observation axis. Each device loops over its slice sequentially with `lax.scan` for memory efficiency.

`get_obs_distribution_to_process(n_obs)` evenly spreads observations and pads each rank up to a multiple of `local_device_count`. Padding repeats the last real observation with a zeroed sample mask so dummy slots contribute nothing.

## Notable changes

- `build_model()` returns process-local data; sharding itself is done in a `distribute(x)` call.
- `accumulate_rhs(model, read_indices, reader)` takes a reader (for jit compatibility) and (sharded) indices of which observations to read and accumulate.
- `ObservationReader` constructor accepts optional `structures=` to skip I/O during structure inference (avoids redundant reads in distributed context).
- New `ObservationReader.from_observations()` factory that handles structure inference in distributed context.
- Per-process log files in the multi-observation script.