### PR TITLE
Quality-of-life updates for mapmaking

### DIFF
--- a/src/furax/mapmaking/_observation.py
+++ b/src/furax/mapmaking/_observation.py
@@ -131,6 +131,12 @@ class AbstractObservation(ABC, Generic[T]):
     def get_hwp_angles(self) -> Array:
         """Returns the HWP angles."""
 
+    def get_hwp_frequency(self) -> Float[Array, '']:
+        """Returns the average HWP rotation frequency in Hz."""
+        hwp_angles = self.get_hwp_angles()
+        timestamps = self.get_timestamps()
+        return (jnp.unwrap(hwp_angles)[-1] - hwp_angles[0]) / jnp.ptp(timestamps) / (2 * jnp.pi)
+
     @abstractmethod
     def get_sample_mask(self) -> Bool[Array, 'dets samps']:
         """Returns boolean sample mask (True=valid) of the TOD."""

--- a/src/furax/mapmaking/config.py
+++ b/src/furax/mapmaking/config.py
@@ -361,6 +361,73 @@ class MapMakingConfig:
     sotodlib: SotodlibConfig | None = None
 
     @classmethod
+    def for_method(cls, method: 'Methods | str') -> 'MapMakingConfig':
+        """Return a default MapMakingConfig pre-configured for the given method.
+
+        Args:
+            method: A ``Methods`` enum value or its string name (e.g. ``'binned'``,
+                ``'ml'``, ``'twostep'``, ``'atop'``), case-insensitive.
+        """
+        if isinstance(method, str):
+            upper = method.upper()
+            try:
+                method = Methods[upper]
+            except KeyError:
+                # Fall back to matching by value (e.g. 'ML' → Methods.MAXL)
+                matched = next((m for m in Methods if m.value.upper() == upper), None)
+                if matched is None:
+                    raise KeyError(method)
+                method = matched
+
+        if method == Methods.BINNED:
+            return cls(
+                method=Methods.BINNED,
+                noise=NoiseConfig(white=True),
+                templates=None,
+            )
+        elif method == Methods.MAXL:
+            return cls(
+                method=Methods.MAXL,
+                noise=NoiseConfig(
+                    white=False,
+                    correlation_length=1_000,
+                ),
+                solver=SolverConfig(
+                    rtol=1e-6,
+                    atol=0,
+                    max_steps=1_000,
+                ),
+                templates=None,
+            )
+        elif method == Methods.TWOSTEP:
+            return cls(
+                method=Methods.TWOSTEP,
+                noise=NoiseConfig(white=True),
+                solver=SolverConfig(
+                    rtol=1e-6,
+                    atol=0,
+                    max_steps=1_000,
+                ),
+                templates=TemplatesConfig(
+                    polynomial=_PolyTemplateConfig(),
+                ),
+            )
+        elif method == Methods.ATOP:
+            return cls(
+                method=Methods.ATOP,
+                noise=NoiseConfig(white=True),
+                solver=SolverConfig(
+                    rtol=1e-6,
+                    atol=0,
+                    max_steps=100,
+                ),
+                atop_tau=37,
+                templates=None,
+            )
+        else:
+            raise ValueError(f'Unknown method: {method}')
+
+    @classmethod
     def full_defaults(cls) -> 'MapMakingConfig':
         """Create a config with default values for all fields including optional ones."""
         return cls(templates=TemplatesConfig.full_defaults())

--- a/src/furax/mapmaking/mapmaker.py
+++ b/src/furax/mapmaking/mapmaker.py
@@ -44,7 +44,7 @@ from furax.obs.stokes import Stokes, StokesIQU, StokesPyTreeType, ValidStokesTyp
 from . import templates
 from ._geometry import minimum_enclosing_arc
 from ._logger import logger as furax_logger
-from ._model import ObservationModel, SystemOperator, _hwp_frequency
+from ._model import ObservationModel, SystemOperator
 from ._observation import AbstractGroundObservation, AbstractLazyObservation
 from ._reader import ObservationReader
 from .config import LandscapeConfig, MapMakingConfig, Methods, WCSConfig
@@ -552,7 +552,7 @@ class MapMaker:
         f, Pxx = jax.scipy.signal.welch(
             observation.get_tods(), fs=observation.sample_rate, nperseg=config.noise.fitting.nperseg
         )
-        hwp_frequency = _hwp_frequency(observation.get_timestamps(), observation.get_hwp_angles())
+        hwp_frequency = observation.get_hwp_frequency()
         return Model.fit_psd_model(
             f,
             Pxx,

--- a/src/furax/mapmaking/results.py
+++ b/src/furax/mapmaking/results.py
@@ -118,9 +118,9 @@ class MapMakingResults:
             noise_fits=noise_fits,
         )
 
-    @classmethod
+    @staticmethod
     def _load_array(
-        cls, name: str, out_dir: Path, landscape: StokesLandscape, n_fields: int
+        name: str, out_dir: Path, landscape: StokesLandscape, n_fields: int
     ) -> np.ndarray:
         """Load a [n_fields, *pixel_dims] array from FITS or npy.
 
@@ -152,15 +152,15 @@ class MapMakingResults:
                 raise FileNotFoundError(f'Expected file not found: {path}')
             return np.load(path)  # type: ignore[no-any-return]
 
-    @classmethod
-    def _load_map(cls, out_dir: Path, landscape: StokesLandscape) -> StokesPyTreeType:
+    @staticmethod
+    def _load_map(out_dir: Path, landscape: StokesLandscape) -> StokesPyTreeType:
         ns = len(landscape.stokes)
-        arr = cls._load_array('map', out_dir, landscape, ns)
+        arr = MapMakingResults._load_array('map', out_dir, landscape, ns)
         stokes_cls = Stokes.class_for(landscape.stokes)
         return stokes_cls(*[jnp.array(arr[i]) for i in range(ns)])
 
-    @classmethod
-    def _load_hit_map(cls, out_dir: Path, landscape: StokesLandscape) -> Array:
+    @staticmethod
+    def _load_hit_map(out_dir: Path, landscape: StokesLandscape) -> Array:
         if isinstance(landscape, (WCSLandscape, AstropyWCSLandscape)):
             path = out_dir / 'hit_map.fits'
             if not path.exists():
@@ -178,12 +178,12 @@ class MapMakingResults:
                 raise FileNotFoundError(f'Expected file not found: {path}')
             return jnp.array(np.load(path))
 
-    @classmethod
-    def _load_icov(cls, out_dir: Path, landscape: StokesLandscape) -> Array:
+    @staticmethod
+    def _load_icov(out_dir: Path, landscape: StokesLandscape) -> Array:
         stokes = landscape.stokes
         ns = len(stokes)
         n_upper = ns * (ns + 1) // 2
-        arr_upper = cls._load_array('icov', out_dir, landscape, n_upper)
+        arr_upper = MapMakingResults._load_array('icov', out_dir, landscape, n_upper)
 
         upper = [(i, j) for i in range(ns) for j in range(i, ns)]
         pixel_shape = arr_upper.shape[1:]
@@ -194,15 +194,15 @@ class MapMakingResults:
                 icov[j, i] = arr_upper[k]
         return jnp.array(icov)
 
-    @classmethod
-    def _load_noise_fits(cls, out_dir: Path) -> Array | None:
+    @staticmethod
+    def _load_noise_fits(out_dir: Path) -> Array | None:
         path = out_dir / 'noise_fits.npy'
         if not path.exists():
             return None
         return jnp.array(np.load(path))
 
-    @classmethod
-    def _load_solver_stats(cls, out_dir: Path) -> dict[str, Any] | None:
+    @staticmethod
+    def _load_solver_stats(out_dir: Path) -> dict[str, Any] | None:
         path = out_dir / 'solver_stats.json'
         if not path.exists():
             return None

--- a/src/furax/mapmaking/results.py
+++ b/src/furax/mapmaking/results.py
@@ -1,9 +1,11 @@
+import json
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
 import healpy as hp
 import jax
+import jax.numpy as jnp
 import numpy as np
 from astropy.io import fits
 from jaxtyping import Array, Float, Integer
@@ -14,13 +16,25 @@ from furax.obs.landscapes import (
     StokesLandscape,
     WCSLandscape,
 )
-from furax.obs.stokes import StokesPyTreeType
+from furax.obs.stokes import Stokes, StokesPyTreeType
 
 from ._logger import logger as furax_logger
 
 __all__ = [
     'MapMakingResults',
 ]
+
+_VALID_FIELDS = frozenset({'map', 'hit_map', 'icov', 'noise_fits', 'solver_stats'})
+_REQUIRED_FIELDS = frozenset({'map', 'hit_map', 'icov'})
+
+
+class _JsonEncoder(json.JSONEncoder):
+    def default(self, obj: Any) -> Any:
+        if isinstance(obj, np.ndarray):
+            return obj.tolist()
+        if hasattr(obj, 'item'):  # numpy/jax scalars
+            return obj.item()
+        return super().default(obj)
 
 
 @dataclass
@@ -52,6 +66,148 @@ class MapMakingResults:
         self._save_icov(np.array(self.icov), out_dir)
         if self.noise_fits is not None:
             np.save(out_dir / 'noise_fits', np.array(self.noise_fits))
+        if self.solver_stats is not None:
+            with open(out_dir / 'solver_stats.json', 'w') as f:
+                json.dump(self.solver_stats, f, indent=2, cls=_JsonEncoder)
+
+    @classmethod
+    def load(
+        cls,
+        out_dir: str | Path,
+        landscape: StokesLandscape,
+        fields: set[str] | list[str] | None = None,
+    ) -> 'MapMakingResults':
+        """Load a previously saved MapMakingResults from disk.
+
+        Args:
+            out_dir: Directory containing the saved files.
+            landscape: The landscape used when the results were saved.
+            fields: Fields to load. Defaults to all fields. Required fields
+                (map, hit_map, icov) must always be included if specified.
+        """
+        out_dir = Path(out_dir)
+        if not out_dir.exists():
+            raise FileNotFoundError(f'Output directory not found: {out_dir}')
+
+        if fields is None:
+            fields_to_load = _VALID_FIELDS
+        else:
+            fields_to_load = frozenset(fields)
+            invalid = fields_to_load - _VALID_FIELDS
+            if invalid:
+                raise ValueError(
+                    f'Unknown fields: {sorted(invalid)}. Valid fields: {sorted(_VALID_FIELDS)}'
+                )
+            missing_required = _REQUIRED_FIELDS - fields_to_load
+            if missing_required:
+                raise ValueError(f'Required fields cannot be excluded: {sorted(missing_required)}')
+
+        sky_map = cls._load_map(out_dir, landscape)
+        hit_map = cls._load_hit_map(out_dir, landscape)
+        icov = cls._load_icov(out_dir, landscape)
+
+        noise_fits = cls._load_noise_fits(out_dir) if 'noise_fits' in fields_to_load else None
+        solver_stats = cls._load_solver_stats(out_dir) if 'solver_stats' in fields_to_load else None
+
+        return cls(
+            map=sky_map,
+            landscape=landscape,
+            hit_map=hit_map,
+            icov=icov,
+            solver_stats=solver_stats,
+            noise_fits=noise_fits,
+        )
+
+    @classmethod
+    def _load_array(
+        cls, name: str, out_dir: Path, landscape: StokesLandscape, n_fields: int
+    ) -> np.ndarray:
+        """Load a [n_fields, *pixel_dims] array from FITS or npy.
+
+        For HEALPix landscapes with n_fields=1, a leading dimension is added
+        so the returned shape is always [n_fields, npix].
+        """
+        if isinstance(landscape, (WCSLandscape, AstropyWCSLandscape)):
+            path = out_dir / f'{name}.fits'
+            if not path.exists():
+                raise FileNotFoundError(f'Expected file not found: {path}')
+            with fits.open(path) as hdul:
+                return np.array(hdul[0].data)
+        elif isinstance(landscape, HealpixLandscape):
+            path = out_dir / f'{name}.fits'
+            if not path.exists():
+                raise FileNotFoundError(f'Expected file not found: {path}')
+            if n_fields == 1:
+                arr = np.array(hp.read_map(str(path), field=0))
+            else:
+                maps = hp.read_map(str(path), field=list(range(n_fields)))
+                arr = np.stack(maps, axis=0)
+            # hp.read_map with field=0 drops the leading dim; restore it
+            if arr.ndim == len(landscape.shape):
+                arr = arr[np.newaxis]
+            return arr
+        else:
+            path = out_dir / f'{name}.npy'
+            if not path.exists():
+                raise FileNotFoundError(f'Expected file not found: {path}')
+            return np.load(path)  # type: ignore[no-any-return]
+
+    @classmethod
+    def _load_map(cls, out_dir: Path, landscape: StokesLandscape) -> StokesPyTreeType:
+        ns = len(landscape.stokes)
+        arr = cls._load_array('map', out_dir, landscape, ns)
+        stokes_cls = Stokes.class_for(landscape.stokes)
+        return stokes_cls(*[jnp.array(arr[i]) for i in range(ns)])
+
+    @classmethod
+    def _load_hit_map(cls, out_dir: Path, landscape: StokesLandscape) -> Array:
+        if isinstance(landscape, (WCSLandscape, AstropyWCSLandscape)):
+            path = out_dir / 'hit_map.fits'
+            if not path.exists():
+                raise FileNotFoundError(f'Expected file not found: {path}')
+            with fits.open(path) as hdul:
+                return jnp.array(hdul[0].data)
+        elif isinstance(landscape, HealpixLandscape):
+            path = out_dir / 'hit_map.fits'
+            if not path.exists():
+                raise FileNotFoundError(f'Expected file not found: {path}')
+            return jnp.array(hp.read_map(str(path), field=0))
+        else:
+            path = out_dir / 'hit_map.npy'
+            if not path.exists():
+                raise FileNotFoundError(f'Expected file not found: {path}')
+            return jnp.array(np.load(path))
+
+    @classmethod
+    def _load_icov(cls, out_dir: Path, landscape: StokesLandscape) -> Array:
+        stokes = landscape.stokes
+        ns = len(stokes)
+        n_upper = ns * (ns + 1) // 2
+        arr_upper = cls._load_array('icov', out_dir, landscape, n_upper)
+
+        upper = [(i, j) for i in range(ns) for j in range(i, ns)]
+        pixel_shape = arr_upper.shape[1:]
+        icov = np.zeros((ns, ns, *pixel_shape), dtype=arr_upper.dtype)
+        for k, (i, j) in enumerate(upper):
+            icov[i, j] = arr_upper[k]
+            if i != j:
+                icov[j, i] = arr_upper[k]
+        return jnp.array(icov)
+
+    @classmethod
+    def _load_noise_fits(cls, out_dir: Path) -> Array | None:
+        path = out_dir / 'noise_fits.npy'
+        if not path.exists():
+            return None
+        return jnp.array(np.load(path))
+
+    @classmethod
+    def _load_solver_stats(cls, out_dir: Path) -> dict[str, Any] | None:
+        path = out_dir / 'solver_stats.json'
+        if not path.exists():
+            return None
+        with open(path) as f:
+            return json.load(f)  # type: ignore[no-any-return]
 
     def _save_icov(self, arr: np.ndarray, out_dir: Path) -> None:
         """Save the inverse covariance, storing only the upper triangle with stokes-aware names."""

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,4 @@
+import logging
 from typing import get_args
 
 import healpy as hp
@@ -13,6 +14,11 @@ from tests.helpers import TEST_DATA_PLANCK, TEST_DATA_SAT
 @pytest.fixture(scope='session', autouse=True)
 def enable_x64() -> None:
     jax.config.update('jax_enable_x64', True)
+
+
+@pytest.fixture(scope='session', autouse=True)
+def silence_furax_logger() -> None:
+    logging.getLogger('furax-mapmaking').setLevel(logging.WARNING)
 
 
 def load_planck(nside: int) -> np.ndarray:

--- a/tests/interfaces/sotodlib/test_observation.py
+++ b/tests/interfaces/sotodlib/test_observation.py
@@ -1,17 +1,19 @@
 from pathlib import Path
 
 import pytest
+from numpy.testing import assert_allclose
 
 from furax.interfaces.sotodlib import SOTODLibObservation
 
+FOLDER = Path(__file__).parents[2] / 'data/sotodlib'
+FILE = FOLDER / 'test_obs.h5'
+
 
 def test_from_file() -> None:
-    folder = Path(__file__).parents[2] / 'data/sotodlib'
-    file = folder / 'test_obs.h5'
     ndet = 2
     nsample = 1000
 
-    obs = SOTODLibObservation.from_file(file)
+    obs = SOTODLibObservation.from_file(FILE)
     assert obs.n_detectors == ndet
     assert obs.n_samples == nsample
 
@@ -19,3 +21,9 @@ def test_from_file() -> None:
 def test_from_file_missing() -> None:
     with pytest.raises(FileNotFoundError):
         SOTODLibObservation.from_file('non_existing_file.h5')
+
+
+def test_get_hwp_frequency() -> None:
+    obs = SOTODLibObservation.from_file(FILE)
+    freq = obs.get_hwp_frequency()
+    assert_allclose(float(freq), 2.0, rtol=1e-5)

--- a/tests/mapmaking/test_results.py
+++ b/tests/mapmaking/test_results.py
@@ -1,4 +1,6 @@
+import dataclasses
 import importlib.util
+import json
 
 import healpy as hp
 import jax.numpy as jnp
@@ -40,6 +42,16 @@ def healpix_results() -> MapMakingResults:
     hit_map = jnp.array(rng.integers(1, 100, NPIX))
     icov = jnp.array(rng.standard_normal((3, 3, NPIX)))
     return MapMakingResults(map=sky, landscape=landscape, hit_map=hit_map, icov=icov)
+
+
+@pytest.fixture
+def healpix_results_with_extras(healpix_results) -> MapMakingResults:
+    rng = np.random.default_rng(42)
+    return dataclasses.replace(
+        healpix_results,
+        solver_stats={'num_steps': np.int32(7), 'converged': True, 'residual': np.float64(1e-8)},
+        noise_fits=jnp.array(rng.standard_normal(NPIX)),
+    )
 
 
 @pytest.fixture
@@ -108,130 +120,85 @@ def unknown_landscape_results() -> MapMakingResults:
     return MapMakingResults(map=sky, landscape=landscape, hit_map=hit_map, icov=icov)
 
 
-# --- HEALPix ---
+# --- save() ---
 
 
-def test_healpix_save_produces_fits(healpix_results, tmp_path):
+def test_healpix_save(healpix_results, tmp_path):
     healpix_results.save(tmp_path)
+
     assert (tmp_path / 'map.fits').exists()
     assert (tmp_path / 'hit_map.fits').exists()
     assert (tmp_path / 'icov.fits').exists()
 
-
-def test_healpix_map_roundtrip(healpix_results, tmp_path):
-    healpix_results.save(tmp_path)
     i_read, q_read, u_read = hp.read_map(tmp_path / 'map.fits', field=[0, 1, 2])
     assert_array_almost_equal(i_read, healpix_results.map.i)
     assert_array_almost_equal(q_read, healpix_results.map.q)
     assert_array_almost_equal(u_read, healpix_results.map.u)
 
+    with fits.open(tmp_path / 'map.fits') as hdul:
+        assert hdul[1].header['ORDERING'] == 'RING'
+    with fits.open(tmp_path / 'hit_map.fits') as hdul:
+        assert hdul[1].columns[0].name == 'HITS'
+    with fits.open(tmp_path / 'icov.fits') as hdul:
+        assert [c.name for c in hdul[1].columns] == ['II', 'IQ', 'IU', 'QQ', 'QU', 'UU']
 
-def test_healpix_hit_map_roundtrip(healpix_results, tmp_path):
-    healpix_results.save(tmp_path)
-    hit_map_read = hp.read_map(tmp_path / 'hit_map.fits')
-    assert_array_equal(hit_map_read, healpix_results.hit_map)
-
-
-def test_healpix_icov_column_names(healpix_results, tmp_path):
-    healpix_results.save(tmp_path)
-    from astropy.io import fits as _fits
-
-    with _fits.open(tmp_path / 'icov.fits') as hdul:
-        names = [c.name for c in hdul[1].columns]
-    assert names == ['II', 'IQ', 'IU', 'QQ', 'QU', 'UU']
-
-
-def test_healpix_icov_roundtrip(healpix_results, tmp_path):
-    healpix_results.save(tmp_path)
-    # icov is stored as upper triangle: (n_upper, npix) with n_upper=6 for IQU
     icov_read = np.array(hp.read_map(tmp_path / 'icov.fits', field=list(range(6))))
     icov = np.array(healpix_results.icov)
     upper = [(i, j) for i in range(3) for j in range(i, 3)]
-    expected = np.stack([icov[i, j] for i, j in upper])
-    assert_array_almost_equal(icov_read, expected)
+    assert_array_almost_equal(icov_read, np.stack([icov[i, j] for i, j in upper]))
 
 
-def test_healpix_hit_map_column_name(healpix_results, tmp_path):
-    healpix_results.save(tmp_path)
-    with fits.open(tmp_path / 'hit_map.fits') as hdul:
-        assert hdul[1].columns[0].name == 'HITS'
-
-
-def test_healpix_ordering(healpix_results, tmp_path):
-    healpix_results.save(tmp_path)
-    expected = 'NESTED' if healpix_results.landscape.nested else 'RING'
-    with fits.open(tmp_path / 'map.fits') as hdul:
-        assert hdul[1].header['ORDERING'] == expected
-
-
-# --- WCS (CAR) ---
-
-
-def test_wcs_save_produces_fits(car_results, tmp_path):
+def test_wcs_save(car_results, tmp_path):
     car_results.save(tmp_path)
-    assert (tmp_path / 'map.fits').exists()
-    assert (tmp_path / 'hit_map.fits').exists()
-    assert (tmp_path / 'icov.fits').exists()
 
-
-def test_wcs_map_has_wcs_header(car_results, tmp_path):
-    car_results.save(tmp_path)
     header = fits.open(tmp_path / 'map.fits')[0].header
-    assert 'CTYPE1' in header
-    assert 'CRVAL1' in header
-    assert 'CRPIX1' in header
-    assert 'CDELT1' in header
+    for key in ('CTYPE1', 'CRVAL1', 'CRPIX1', 'CDELT1'):
+        assert key in header
 
-
-def test_wcs_map_roundtrip(car_results, tmp_path):
-    car_results.save(tmp_path)
-    data = fits.open(tmp_path / 'map.fits')[0].data  # shape (3, ny, nx)
+    data = fits.open(tmp_path / 'map.fits')[0].data
     assert_array_almost_equal(data[0], car_results.map.i)
     assert_array_almost_equal(data[1], car_results.map.q)
     assert_array_almost_equal(data[2], car_results.map.u)
 
-
-def test_wcs_hit_map_roundtrip(car_results, tmp_path):
-    car_results.save(tmp_path)
-    data = fits.open(tmp_path / 'hit_map.fits')[0].data
-    assert_array_equal(data, car_results.hit_map)
-
-
-def test_wcs_icov_roundtrip(car_results, tmp_path):
-    car_results.save(tmp_path)
-    # icov is stored as upper triangle: (n_upper, ny, nx)
-    data = fits.open(tmp_path / 'icov.fits')[0].data
+    icov_data = fits.open(tmp_path / 'icov.fits')[0].data
     icov = np.array(car_results.icov)
     upper = [(i, j) for i in range(3) for j in range(i, 3)]
-    expected = np.stack([icov[i, j] for i, j in upper])
-    assert_array_almost_equal(data, expected)
+    assert_array_almost_equal(icov_data, np.stack([icov[i, j] for i, j in upper]))
 
 
-# --- AstropyWCS ---
-
-
-def test_astropy_wcs_save_produces_fits(astropy_wcs_results, tmp_path):
-    astropy_wcs_results.save(tmp_path)
-    assert (tmp_path / 'map.fits').exists()
-    assert (tmp_path / 'hit_map.fits').exists()
-    assert (tmp_path / 'icov.fits').exists()
-
-
-def test_astropy_wcs_map_has_wcs_header(astropy_wcs_results, tmp_path):
+def test_astropy_wcs_embeds_wcs_header(astropy_wcs_results, tmp_path):
     astropy_wcs_results.save(tmp_path)
     header = fits.open(tmp_path / 'map.fits')[0].header
-    assert 'CTYPE1' in header
-    assert 'CRVAL1' in header
-    assert 'CRPIX1' in header
-    assert 'CDELT1' in header
+    for key in ('CTYPE1', 'CRVAL1', 'CRPIX1', 'CDELT1'):
+        assert key in header
 
 
-def test_astropy_wcs_map_roundtrip(astropy_wcs_results, tmp_path):
-    astropy_wcs_results.save(tmp_path)
-    data = fits.open(tmp_path / 'map.fits')[0].data
-    assert_array_almost_equal(data[0], astropy_wcs_results.map.i)
-    assert_array_almost_equal(data[1], astropy_wcs_results.map.q)
-    assert_array_almost_equal(data[2], astropy_wcs_results.map.u)
+def test_unknown_landscape_save(unknown_landscape_results, tmp_path):
+    unknown_landscape_results.save(tmp_path)
+    assert (tmp_path / 'map.npy').exists()
+    assert (tmp_path / 'hit_map.npy').exists()
+    assert (tmp_path / 'icov.npy').exists()
+    data = np.load(tmp_path / 'map.npy')
+    assert_array_almost_equal(data[0], unknown_landscape_results.map.i)
+    assert_array_almost_equal(data[1], unknown_landscape_results.map.q)
+    assert_array_almost_equal(data[2], unknown_landscape_results.map.u)
+
+
+def test_save_solver_stats(healpix_results, tmp_path):
+    results = dataclasses.replace(
+        healpix_results,
+        solver_stats={'num_steps': np.int32(3), 'converged': True, 'loss': np.float32(0.5)},
+    )
+    results.save(tmp_path)
+    assert (tmp_path / 'solver_stats.json').exists()
+    with open(tmp_path / 'solver_stats.json') as f:
+        stats = json.load(f)
+    assert stats == {'num_steps': 3, 'converged': True, 'loss': pytest.approx(0.5, abs=1e-6)}
+
+
+def test_save_no_solver_stats_file_when_none(healpix_results, tmp_path):
+    healpix_results.save(tmp_path)
+    assert not (tmp_path / 'solver_stats.json').exists()
 
 
 # --- pixell loading ---
@@ -239,7 +206,7 @@ def test_astropy_wcs_map_roundtrip(astropy_wcs_results, tmp_path):
 
 @pytest.mark.skipif(not pixell_installed, reason='pixell not installed')
 class TestPixellLoading:
-    def test_wcs_map(self, car_results, tmp_path):
+    def test_wcs_map_roundtrip(self, car_results, tmp_path):
         from pixell import enmap
 
         car_results.save(tmp_path)
@@ -247,49 +214,6 @@ class TestPixellLoading:
         assert_array_almost_equal(m[0], car_results.map.i)
         assert_array_almost_equal(m[1], car_results.map.q)
         assert_array_almost_equal(m[2], car_results.map.u)
-
-    def test_wcs_hit_map(self, car_results, tmp_path):
-        from pixell import enmap
-
-        car_results.save(tmp_path)
-        m = enmap.read_map(str(tmp_path / 'hit_map.fits'))
-        assert_array_equal(np.array(m), car_results.hit_map)
-
-    def test_wcs_icov(self, car_results, tmp_path):
-        from pixell import enmap
-
-        car_results.save(tmp_path)
-        m = enmap.read_map(str(tmp_path / 'icov.fits'))
-        icov = np.array(car_results.icov)
-        upper = [(i, j) for i in range(3) for j in range(i, 3)]
-        expected = np.stack([icov[i, j] for i, j in upper])
-        assert_array_almost_equal(np.array(m), expected)
-
-    def test_astropy_wcs_map(self, astropy_wcs_results, tmp_path):
-        from pixell import enmap
-
-        astropy_wcs_results.save(tmp_path)
-        m = enmap.read_map(str(tmp_path / 'map.fits'))
-        assert_array_almost_equal(m[0], astropy_wcs_results.map.i)
-        assert_array_almost_equal(m[1], astropy_wcs_results.map.q)
-        assert_array_almost_equal(m[2], astropy_wcs_results.map.u)
-
-    def test_astropy_wcs_hit_map(self, astropy_wcs_results, tmp_path):
-        from pixell import enmap
-
-        astropy_wcs_results.save(tmp_path)
-        m = enmap.read_map(str(tmp_path / 'hit_map.fits'))
-        assert_array_equal(np.array(m), astropy_wcs_results.hit_map)
-
-    def test_astropy_wcs_icov(self, astropy_wcs_results, tmp_path):
-        from pixell import enmap
-
-        astropy_wcs_results.save(tmp_path)
-        m = enmap.read_map(str(tmp_path / 'icov.fits'))
-        icov = np.array(astropy_wcs_results.icov)
-        upper = [(i, j) for i in range(3) for j in range(i, 3)]
-        expected = np.stack([icov[i, j] for i, j in upper])
-        assert_array_almost_equal(np.array(m), expected)
 
     def test_wcs_header_consistency(self, car_results, tmp_path):
         from pixell import enmap
@@ -302,31 +226,94 @@ class TestPixellLoading:
         np.testing.assert_allclose(m.wcs.wcs.crpix, wcs.wcs.crpix)
         np.testing.assert_allclose(m.wcs.wcs.cdelt, wcs.wcs.cdelt)
 
-    def test_astropy_wcs_header_consistency(self, astropy_wcs_results, tmp_path):
-        from pixell import enmap
 
-        astropy_wcs_results.save(tmp_path)
-        m = enmap.read_map(str(tmp_path / 'map.fits'))
-        wcs = astropy_wcs_results.landscape.wcs
-        assert list(m.wcs.wcs.ctype) == list(wcs.wcs.ctype)
-        np.testing.assert_allclose(m.wcs.wcs.crval, wcs.wcs.crval)
-        np.testing.assert_allclose(m.wcs.wcs.crpix, wcs.wcs.crpix)
-        np.testing.assert_allclose(m.wcs.wcs.cdelt, wcs.wcs.cdelt)
+# --- load() ---
 
 
-# --- Unknown landscape ---
+def test_healpix_load_roundtrip(healpix_results_with_extras, tmp_path):
+    r = healpix_results_with_extras
+    r.save(tmp_path)
+    loaded = MapMakingResults.load(tmp_path, r.landscape)
+
+    assert_array_almost_equal(loaded.map.i, r.map.i)
+    assert_array_almost_equal(loaded.map.q, r.map.q)
+    assert_array_almost_equal(loaded.map.u, r.map.u)
+    assert_array_equal(loaded.hit_map, r.hit_map)
+
+    upper = [(i, j) for i in range(3) for j in range(i, 3)]
+    for i, j in upper:
+        assert_array_almost_equal(loaded.icov[i, j], r.icov[i, j])
+    icov = np.array(loaded.icov)
+    assert_array_equal(icov, icov.transpose(1, 0, 2))  # symmetric
+
+    assert loaded.solver_stats == {'num_steps': 7, 'converged': True, 'residual': 1e-8}
+    assert_array_almost_equal(loaded.noise_fits, r.noise_fits)
 
 
-def test_unknown_landscape_saves_as_npy(unknown_landscape_results, tmp_path):
+def test_healpix_load_missing_optionals_are_none(healpix_results, tmp_path):
+    healpix_results.save(tmp_path)
+    loaded = MapMakingResults.load(tmp_path, healpix_results.landscape)
+    assert loaded.solver_stats is None
+    assert loaded.noise_fits is None
+
+
+def test_wcs_load_roundtrip(car_results, tmp_path):
+    car_results.save(tmp_path)
+    loaded = MapMakingResults.load(tmp_path, car_results.landscape)
+
+    assert_array_almost_equal(loaded.map.i, car_results.map.i)
+    assert_array_almost_equal(loaded.map.q, car_results.map.q)
+    assert_array_almost_equal(loaded.map.u, car_results.map.u)
+    assert_array_equal(loaded.hit_map, car_results.hit_map)
+
+    icov = np.array(loaded.icov)
+    assert_array_equal(icov, icov.transpose(1, 0, 2, 3))  # symmetric
+
+
+def test_unknown_landscape_load_roundtrip(unknown_landscape_results, tmp_path):
     unknown_landscape_results.save(tmp_path)
-    assert (tmp_path / 'map.npy').exists()
-    assert (tmp_path / 'hit_map.npy').exists()
-    assert (tmp_path / 'icov.npy').exists()
+    loaded = MapMakingResults.load(tmp_path, unknown_landscape_results.landscape)
+    assert_array_almost_equal(loaded.map.i, unknown_landscape_results.map.i)
+    assert_array_almost_equal(loaded.map.q, unknown_landscape_results.map.q)
+    assert_array_almost_equal(loaded.map.u, unknown_landscape_results.map.u)
+    assert_array_equal(loaded.hit_map, unknown_landscape_results.hit_map)
 
 
-def test_unknown_landscape_map_roundtrip(unknown_landscape_results, tmp_path):
-    unknown_landscape_results.save(tmp_path)
-    data = np.load(tmp_path / 'map.npy')
-    assert_array_almost_equal(data[0], unknown_landscape_results.map.i)
-    assert_array_almost_equal(data[1], unknown_landscape_results.map.q)
-    assert_array_almost_equal(data[2], unknown_landscape_results.map.u)
+# --- load() field selection and errors ---
+
+
+def test_load_subset_fields_skips_optionals(healpix_results_with_extras, tmp_path):
+    healpix_results_with_extras.save(tmp_path)
+    loaded = MapMakingResults.load(
+        tmp_path, healpix_results_with_extras.landscape, fields={'map', 'hit_map', 'icov'}
+    )
+    assert loaded.solver_stats is None
+    assert loaded.noise_fits is None
+    assert_array_almost_equal(loaded.map.i, healpix_results_with_extras.map.i)
+
+
+def test_load_invalid_field_raises(healpix_results, tmp_path):
+    healpix_results.save(tmp_path)
+    with pytest.raises(ValueError, match='Unknown fields'):
+        MapMakingResults.load(
+            tmp_path, healpix_results.landscape, fields={'map', 'hit_map', 'icov', 'bad_field'}
+        )
+
+
+def test_load_missing_required_field_raises(healpix_results, tmp_path):
+    healpix_results.save(tmp_path)
+    with pytest.raises(ValueError, match='Required fields cannot be excluded'):
+        MapMakingResults.load(tmp_path, healpix_results.landscape, fields={'map', 'hit_map'})
+
+
+def test_load_missing_directory_raises(tmp_path):
+    landscape = HealpixLandscape(NSIDE, stokes='IQU')
+    with pytest.raises(FileNotFoundError, match='Output directory not found'):
+        MapMakingResults.load(tmp_path / 'nonexistent', landscape)
+
+
+def test_load_missing_required_file_raises(healpix_results, tmp_path):
+    healpix_results.save(tmp_path)
+    (tmp_path / 'map.fits').unlink()
+    with pytest.raises(FileNotFoundError, match='Expected file not found'):
+        MapMakingResults.load(tmp_path, healpix_results.landscape)


### PR DESCRIPTION
Several updates for convenience during mapmaking :

- `AbstractObservation.get_hwp_frequency()` — derives average HWP rotation frequency (Hz) from existing `get_hwp_angles()` and `get_timestamps()`.

- `MapMakingConfig.for_method(method)` — classmethod returning a default config for a given method ('binned', 'ml', 'atop', 'twostep').

- `MapMakingResults.save()` save/load — also solver_stats using JSON

- `MapMakingResults.load()` — loads results from disk, compatible with save()

- Tests: mapmaking logger silenced during pytest