### PR TITLE
Distributed multi-observation mapmaking (v2)

### DIFF
--- a/src/furax/distributed.py
+++ b/src/furax/distributed.py
@@ -1,0 +1,9 @@
+import jax
+
+
+def maybe_init() -> bool:
+    try:
+        jax.distributed.initialize()
+        return True
+    except ValueError:
+        return False

--- a/src/furax/interfaces/sotodlib/__init__.py
+++ b/src/furax/interfaces/sotodlib/__init__.py
@@ -1,0 +1,8 @@
+# Intentionally empty: no eager re-exports.
+#
+# Re-exporting SOTODLibObservation / LazySOTODLibObservation here would force
+# `observation.py` (and its jax-using transitive imports) to load at package
+# import time, which initializes the JAX backend before
+# `jax.distributed.initialize()` can run in distributed entrypoints.
+# Import the concrete classes from `furax.interfaces.sotodlib.observation`
+# directly.

--- a/src/furax/interfaces/sotodlib/__init__.py
+++ b/src/furax/interfaces/sotodlib/__init__.py
@@ -1,6 +1,0 @@
-from .observation import LazySOTODLibObservation, SOTODLibObservation
-
-__all__ = [
-    'SOTODLibObservation',
-    'LazySOTODLibObservation',
-]

--- a/src/furax/interfaces/sotodlib/multi_observation/__main__.py
+++ b/src/furax/interfaces/sotodlib/multi_observation/__main__.py
@@ -1,3 +1,11 @@
+import os
+
+import jax
+
+if 'SLURM_JOB_ID' in os.environ:
+    jax.distributed.initialize()
+
+
 from cyclopts import App
 
 from .prepare import prepare

--- a/src/furax/interfaces/sotodlib/multi_observation/__main__.py
+++ b/src/furax/interfaces/sotodlib/multi_observation/__main__.py
@@ -1,11 +1,9 @@
-import os
+from furax.distributed import maybe_init
 
-import jax
+# Must run before import that touches the JAX backend
+maybe_init()
 
-if 'SLURM_JOB_ID' in os.environ:
-    jax.distributed.initialize()
-
-
+# ruff: noqa: E402
 from cyclopts import App
 
 from .prepare import prepare

--- a/src/furax/interfaces/sotodlib/multi_observation/run.py
+++ b/src/furax/interfaces/sotodlib/multi_observation/run.py
@@ -1,5 +1,7 @@
 from pathlib import Path
 
+import jax
+
 from furax.interfaces.sotodlib.observation import LazySOTODLibObservation
 from furax.mapmaking import MapMakingConfig, MultiObservationMapMaker
 
@@ -26,7 +28,7 @@ def run(  # type: ignore[no-untyped-def]
         loglevel: Logging level (debug, info, warning, error).
         log_path: Log output path.
     """
-    logger = setup_logger(loglevel, log_path)
+    logger = setup_logger(loglevel, log_path, process_index=jax.process_index())
 
     obsids = resolve_obsids(obsid, obsids_file)
     if obsids:

--- a/src/furax/interfaces/sotodlib/multi_observation/run.py
+++ b/src/furax/interfaces/sotodlib/multi_observation/run.py
@@ -1,6 +1,6 @@
 from pathlib import Path
 
-from furax.interfaces.sotodlib import LazySOTODLibObservation
+from furax.interfaces.sotodlib.observation import LazySOTODLibObservation
 from furax.mapmaking import MapMakingConfig, MultiObservationMapMaker
 
 from .util import resolve_obsids, setup_logger

--- a/src/furax/interfaces/sotodlib/multi_observation/util.py
+++ b/src/furax/interfaces/sotodlib/multi_observation/util.py
@@ -2,16 +2,20 @@ import logging
 from pathlib import Path
 
 
-def setup_logger(loglevel: str, log_path: Path | None) -> logging.Logger:
+def setup_logger(loglevel: str, log_path: Path | None, process_index: int = 0) -> logging.Logger:
     level = logging.getLevelName(loglevel.upper())
     logger = logging.getLogger('furax.mapmaker')
     logger.setLevel(level)
-    formatter = logging.Formatter('%(asctime)s - %(levelname)s - %(message)s')
+    logger.propagate = False
+    formatter = logging.Formatter(
+        f'%(asctime)s - [rank {process_index}] - %(levelname)s - %(message)s'
+    )
     ch = logging.StreamHandler()
     ch.setLevel(level)
     ch.setFormatter(formatter)
     logger.addHandler(ch)
-    if log_path is not None:
+    # Only rank 0 writes to the final logfile
+    if process_index == 0 and log_path is not None:
         log_path.parent.mkdir(parents=True, exist_ok=True)
         fh = logging.FileHandler(log_path)
         fh.setLevel(logging.DEBUG)

--- a/src/furax/interfaces/sotodlib/multi_observation/util.py
+++ b/src/furax/interfaces/sotodlib/multi_observation/util.py
@@ -14,8 +14,8 @@ def setup_logger(loglevel: str, log_path: Path | None, process_index: int = 0) -
     ch.setLevel(level)
     ch.setFormatter(formatter)
     logger.addHandler(ch)
-    # Only rank 0 writes to the final logfile
-    if process_index == 0 and log_path is not None:
+    if log_path is not None:
+        log_path = log_path.with_stem(f'{log_path.stem}.rank{process_index}')
         log_path.parent.mkdir(parents=True, exist_ok=True)
         fh = logging.FileHandler(log_path)
         fh.setLevel(logging.DEBUG)

--- a/src/furax/interfaces/sotodlib/multi_observation/util.py
+++ b/src/furax/interfaces/sotodlib/multi_observation/util.py
@@ -7,6 +7,7 @@ def setup_logger(loglevel: str, log_path: Path | None, process_index: int = 0) -
     logger = logging.getLogger('furax.mapmaker')
     logger.setLevel(level)
     logger.propagate = False
+    logger.handlers.clear()
     formatter = logging.Formatter(
         f'%(asctime)s - [rank {process_index}] - %(levelname)s - %(message)s'
     )

--- a/src/furax/io/readers.py
+++ b/src/furax/io/readers.py
@@ -39,10 +39,8 @@ class AbstractReader(ABC):
         Args:
             *args: One list per positional argument to the read function, one element per data item.
             common_keywords: Keyword arguments shared by all data items.
-            structures: Pre-computed per-item output structures.  When provided the
-                constructor skips all I/O and uses them directly; when ``None``
-                (the default) structures are inferred by calling
-                ``_read_structure_impure`` on each item.
+            structures: Pre-computed per-item output structures.
+                When provided, constructor skips all I/O and uses them directly.
             **keywords: One list per keyword argument to the read function, one element per data item.
         """
         self.args, self.keywords = self._normalize_args_keywords(args, keywords)
@@ -50,6 +48,10 @@ class AbstractReader(ABC):
         self.common_keywords = common_keywords or {}
         if structures is None:
             structures = self._read_structures()
+        elif len(structures) != self.count:
+            raise ValueError(
+                f'structures length {len(structures)} does not match data count {self.count}'
+            )
         self._infer_structure_and_paddings(structures)
 
     def _infer_structure_and_paddings(self, structures: list[PyTree[jax.ShapeDtypeStruct]]) -> None:

--- a/src/furax/io/readers.py
+++ b/src/furax/io/readers.py
@@ -32,21 +32,35 @@ class AbstractReader(ABC):
         self,
         *args: Sequence[Any],
         common_keywords: Mapping[str, Any] | None = None,
+        structures: list[PyTree[jax.ShapeDtypeStruct]] | None = None,
         **keywords: Sequence[Any],
     ) -> None:
+        """
+        Args:
+            *args: One list per positional argument to the read function, one element per data item.
+            common_keywords: Keyword arguments shared by all data items.
+            structures: Pre-computed per-item output structures.  When provided the
+                constructor skips all I/O and uses them directly; when ``None``
+                (the default) structures are inferred by calling
+                ``_read_structure_impure`` on each item.
+            **keywords: One list per keyword argument to the read function, one element per data item.
+        """
         self.args, self.keywords = self._normalize_args_keywords(args, keywords)
         self.count = len(self.args)
-        if common_keywords is None:
-            common_keywords = {}
-        self.common_keywords = common_keywords
-        structures = self._read_structures()
+        self.common_keywords = common_keywords or {}
+        if structures is None:
+            structures = self._read_structures()
+        self._infer_structure_and_paddings(structures)
+
+    def _infer_structure_and_paddings(self, structures: list[PyTree[jax.ShapeDtypeStruct]]) -> None:
         self.out_structure = self._get_common_structure(structures)
         self.paddings: list[PyTree[tuple[int, ...]]] = [
             self._get_padding(structures[i]) for i in range(self.count)
         ]
 
+    @staticmethod
     def _normalize_args_keywords(
-        self, args: Sequence[Any], keywords: dict[str, Sequence[Any]]
+        args: Sequence[Any], keywords: dict[str, Sequence[Any]]
     ) -> tuple[list[Any], list[dict[str, Any]]]:
         """Normalize the arguments and keywords to ensure they are lists of the same length."""
         invalid_args = [i for i, v in enumerate(args) if not isinstance(v, Sequence)]

--- a/src/furax/mapmaking/_model.py
+++ b/src/furax/mapmaking/_model.py
@@ -1,6 +1,6 @@
-import functools
 from dataclasses import dataclass, field
-from typing import Any, TypeVar
+from functools import partial
+from typing import Any, Self, TypeVar
 
 import jax
 import jax.numpy as jnp
@@ -48,7 +48,7 @@ class ObservationModel:
     @classmethod
     def create(
         cls, data: Any, padding: Any, config: MapMakingConfig, landscape: StokesLandscape
-    ) -> 'ObservationModel':
+    ) -> Self:
         H = build_acquisition_operator(
             landscape,
             data['boresight_quaternions'],
@@ -137,7 +137,7 @@ class ObservationModel:
             )
             key = jax.random.key(config.gaps.fill_options.seed)
             tod = gapfill(key, tod)
-        rhs: Stokes = (self.H.T @ self.masker @ self.W)(tod)
+        rhs: Stokes = self.H.T(self.masker(self.W(tod)))
         return rhs
 
     def _get_indexer(self) -> IndexOperator:
@@ -151,26 +151,74 @@ class ObservationModel:
         return IndexOperator(mask, in_structure=self.tod_structure)
 
 
+def pad_model(models: ObservationModel, n_pad: int) -> ObservationModel:
+    """Pad models with n_pad dummy observations that contribute nothing to sums.
+
+    The dummy observations are copies of the last real observation with their
+    masker array leaves zeroed out, so masker(x) = 0 for any x.
+    """
+    last = jax.tree.map(lambda a: jnp.repeat(a[-1:], n_pad, axis=0), models)
+    zero_masker = jax.tree.map(jnp.zeros_like, last.masker)
+    padded = ObservationModel(
+        H=last.H,
+        W=last.W,
+        masker=zero_masker,
+        noise_model=last.noise_model,
+        sample_rate=last.sample_rate,
+    )
+    return jax.tree.map(lambda a, b: jnp.concatenate([a, b], axis=0), models, padded)  # type: ignore[no-any-return]
+
+
 _StokesPyTree = TypeVar('_StokesPyTree', bound=StokesPyTreeType)
 
 
-@functools.partial(jax.jit, static_argnames=['diag'])
-def _system_scan(model: ObservationModel, x: _StokesPyTree, *, diag: bool = False) -> _StokesPyTree:
-    """Apply H^T W H to x, summed over the batch of observations in model.
+@partial(jax.jit, static_argnames=['diag', 'mesh'])
+def _system_scan(
+    model: ObservationModel,
+    x: _StokesPyTree,
+    *,
+    diag: bool = False,
+    mesh: jax.sharding.Mesh | None = None,
+) -> _StokesPyTree:
+    """Apply H^T W H to x, summed over all observations in model.
 
     `model` is an explicit JIT argument so it is never captured as an XLA constant.
 
     Args:
-        model: Stacked ObservationModel with a leading batch dimension over observations.
+        model: Stacked ObservationModel with a flat leading obs axis sharded across
+            devices. Each device scans its slice sequentially; psum reduces globally.
         x: Input sky map pytree.
         diag: If True, use the diagonal white-noise approximation for W.
+        mesh: The concrete Mesh on which `model` is sharded. When set, shard_map is
+            used to parallelise the scan across devices. Must be the same Mesh object
+            that was used when sharding the model arrays.
     """
 
-    def accumulate(lhs, obs):  # type: ignore[no-untyped-def]
-        return tree.add(lhs, obs.apply_system(x, white_noise=diag)), None
+    if mesh is None:
 
-    lhs, _ = jax.lax.scan(accumulate, tree.zeros_like(x), model)
-    return lhs
+        def step(lhs: _StokesPyTree, obs: ObservationModel) -> tuple[_StokesPyTree, None]:
+            return tree.add(lhs, obs.apply_system(x, white_noise=diag)), None
+
+        lhs, _ = jax.lax.scan(step, tree.zeros_like(x), model)
+        return lhs
+
+    from jax.sharding import NamedSharding
+    from jax.sharding import PartitionSpec as P
+
+    # Re-impose 'obs' sharding on the model in case its annotation was stripped
+    # (e.g. closure capture during lineax abstract eval drops sharding metadata).
+    obs_sharding = NamedSharding(mesh, P('obs'))
+    model = jax.tree.map(lambda a: jax.reshard(a, obs_sharding), model)
+
+    @jax.shard_map(mesh=mesh, in_specs=(P('obs'), P()), out_specs=P(), check_vma=False)
+    def local_scan(local_model: ObservationModel, local_x: _StokesPyTree) -> _StokesPyTree:
+        def step(lhs: _StokesPyTree, obs: ObservationModel) -> tuple[_StokesPyTree, None]:
+            return tree.add(lhs, obs.apply_system(local_x, white_noise=diag)), None
+
+        lhs, _ = jax.lax.scan(step, tree.zeros_like(local_x), local_model)
+        return jax.lax.psum(lhs, axis_name='obs')  # type: ignore[no-any-return]
+
+    return local_scan(model, x)
 
 
 @symmetric
@@ -179,14 +227,22 @@ class SystemOperator(AbstractLinearOperator):
 
     models: ObservationModel
     diag: bool = field(metadata={'static': True})
+    mesh: jax.sharding.Mesh | None = field(metadata={'static': True})
 
-    def __init__(self, models: ObservationModel, *, diag: bool = False):
+    def __init__(
+        self,
+        models: ObservationModel,
+        *,
+        diag: bool = False,
+        mesh: jax.sharding.Mesh | None = None,
+    ):
         object.__setattr__(self, 'models', models)
         object.__setattr__(self, 'diag', diag)
+        object.__setattr__(self, 'mesh', mesh)
         object.__setattr__(self, 'in_structure', models.map_structure)
 
     def mv(self, x: _StokesPyTree) -> _StokesPyTree:
-        return _system_scan(self.models, x, diag=self.diag)  # type: ignore[no-any-return]
+        return _system_scan(self.models, x, diag=self.diag, mesh=self.mesh)  # type: ignore[no-any-return]
 
 
 def _noise_model(data: Any, config: MapMakingConfig) -> tuple[PyTree[NoiseModel], Array]:

--- a/src/furax/mapmaking/_model.py
+++ b/src/furax/mapmaking/_model.py
@@ -4,6 +4,8 @@ from typing import Any, Self, TypeVar
 
 import jax
 import jax.numpy as jnp
+from jax.sharding import NamedSharding
+from jax.sharding import PartitionSpec as P
 from jax.tree_util import register_dataclass
 from jaxtyping import Array, Float, Int64, PyTree
 
@@ -201,9 +203,6 @@ def _system_scan(
 
         lhs, _ = jax.lax.scan(step, tree.zeros_like(x), model)
         return lhs
-
-    from jax.sharding import NamedSharding
-    from jax.sharding import PartitionSpec as P
 
     # Re-impose 'obs' sharding on the model in case its annotation was stripped
     # (e.g. closure capture during lineax abstract eval drops sharding metadata).

--- a/src/furax/mapmaking/_model.py
+++ b/src/furax/mapmaking/_model.py
@@ -204,11 +204,13 @@ def _system_scan(
         lhs, _ = jax.lax.scan(step, tree.zeros_like(x), model)
         return lhs
 
-    # Re-impose 'obs' sharding on the model in case its annotation was stripped
-    # (e.g. closure capture during lineax abstract eval drops sharding metadata).
+    # lineax's abstract eval drops the NamedSharding on closure-captured arrays,
+    # so shard_map sees replicated leaves and rejects the P('obs') in_specs.
+    # Reshard restores it (the fix JAX's error message points to).
     obs_sharding = NamedSharding(mesh, P('obs'))
     model = jax.tree.map(lambda a: jax.reshard(a, obs_sharding), model)
 
+    # check_vma=False: furax operator chain inside the body lacks manual-axis annotations.
     @jax.shard_map(mesh=mesh, in_specs=(P('obs'), P()), out_specs=P(), check_vma=False)
     def local_scan(local_model: ObservationModel, local_x: _StokesPyTree) -> _StokesPyTree:
         def step(lhs: _StokesPyTree, obs: ObservationModel) -> tuple[_StokesPyTree, None]:

--- a/src/furax/mapmaking/_model.py
+++ b/src/furax/mapmaking/_model.py
@@ -159,6 +159,8 @@ def pad_model(models: ObservationModel, n_pad: int) -> ObservationModel:
     The dummy observations are copies of the last real observation with their
     masker array leaves zeroed out, so masker(x) = 0 for any x.
     """
+    if n_pad == 0:
+        return models
     last = jax.tree.map(lambda a: jnp.repeat(a[-1:], n_pad, axis=0), models)
     zero_masker = jax.tree.map(jnp.zeros_like, last.masker)
     padded = ObservationModel(

--- a/src/furax/mapmaking/_model.py
+++ b/src/furax/mapmaking/_model.py
@@ -81,25 +81,30 @@ class ObservationModel:
     def map_structure(self) -> PyTree[jax.ShapeDtypeStruct]:
         return self.H.in_structure
 
-    def get_system_operator(self, n_obs: int, *, diag: bool = False) -> AbstractLinearOperator:
-        H = ScanBlockColumnOperator(self.H, n_obs)
-        M = ScanBlockDiagonalOperator(self.masker, n_obs)
+    @property
+    def n_observations(self) -> int:
+        # assuming stacked pytree
+        return jax.tree.leaves(self.H)[0].shape[0]  # type: ignore[no-any-return]
+
+    def get_system_operator(self, *, diag: bool = False) -> AbstractLinearOperator:
+        n = self.n_observations
+        H = ScanBlockColumnOperator(self.H, n)
+        M = ScanBlockDiagonalOperator(self.masker, n)
         weight = self.diag_W() if diag else self.W
-        W = ScanBlockDiagonalOperator(weight, n_obs)
+        W = ScanBlockDiagonalOperator(weight, n)
         return (H.T @ M @ W @ M @ H).reduce()
 
-    def hits(self) -> Int64[Array, ' pixels']:
+    def accumulate_hits(self) -> Int64[Array, ' pixels']:
+        n = self.n_observations
         assert isinstance(self.H, CompositionOperator)  # mypy assert
-        # the pointing operator should be the first in the acquisition chain, so the last operand...
-        # there is a unit test for that
+        # pointing operator is the last operand of the acquisition chain (see unit test)
         pointing = self.H.operands[-1]
         assert isinstance(pointing, PointingOperator)  # mypy assert
-        pointing_i = pointing.as_stokes_i(interpolate=False)
-        ones = tree.ones_like(self.tod_structure)
-        # the masker could be acting on a Stokes pytree or an Array
-        masked_ones = jax.tree.leaves(self.masker(ones))[0]
-        hits_stokes = pointing_i.T(StokesI(masked_ones))
-        return jnp.int64(hits_stokes.i)  # type: ignore[no-any-return]
+        P = ScanBlockColumnOperator(pointing.as_stokes_i(interpolate=False), n)
+        M = ScanBlockDiagonalOperator(self.masker, n)
+        ones = tree.ones_like(M.in_structure)
+        masked_i = jax.tree.leaves(M(ones))[0]
+        return jnp.int64(P.T(StokesI(masked_i)).i)  # type: ignore[no-any-return]
 
     def diag_W(self) -> AbstractLinearOperator:
         """Build the inverse white noise covariance operator."""

--- a/src/furax/mapmaking/_model.py
+++ b/src/furax/mapmaking/_model.py
@@ -1,5 +1,4 @@
-import functools
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from typing import Any, TypeVar
 
 import jax
@@ -7,12 +6,13 @@ import jax.numpy as jnp
 from jax.tree_util import register_dataclass
 from jaxtyping import Array, Float, Int64, PyTree
 
-from furax import AbstractLinearOperator, IdentityOperator, MaskOperator, symmetric, tree
+from furax import AbstractLinearOperator, IdentityOperator, MaskOperator, tree
 from furax.core import BlockDiagonalOperator, CompositionOperator, IndexOperator
 from furax.obs.landscapes import StokesLandscape
 from furax.obs.pointing import PointingOperator
 from furax.obs.stokes import Stokes, StokesI, StokesPyTreeType
 
+from ._scan_blocks import ScanBlockColumnOperator, ScanBlockDiagonalOperator
 from .acquisition import build_acquisition_operator
 from .config import MapMakingConfig, Methods
 from .gap_filling import GapFillingOperator
@@ -81,6 +81,13 @@ class ObservationModel:
     def map_structure(self) -> PyTree[jax.ShapeDtypeStruct]:
         return self.H.in_structure
 
+    def get_system_operator(self, n_obs: int, *, diag: bool = False) -> AbstractLinearOperator:
+        H = ScanBlockColumnOperator(self.H, n_obs)
+        M = ScanBlockDiagonalOperator(self.masker, n_obs)
+        weight = self.diag_W() if diag else self.W
+        W = ScanBlockDiagonalOperator(weight, n_obs)
+        return (H.T @ M @ W @ M @ H).reduce()
+
     def hits(self) -> Int64[Array, ' pixels']:
         assert isinstance(self.H, CompositionOperator)  # mypy assert
         # the pointing operator should be the first in the acquisition chain, so the last operand...
@@ -94,7 +101,7 @@ class ObservationModel:
         hits_stokes = pointing_i.T(StokesI(masked_ones))
         return jnp.int64(hits_stokes.i)  # type: ignore[no-any-return]
 
-    def white_noise_W(self) -> AbstractLinearOperator:
+    def diag_W(self) -> AbstractLinearOperator:
         """Build the inverse white noise covariance operator."""
         operator_tree = jax.tree.map(
             lambda noise, s: noise.to_white_noise_model().inverse_operator(s),
@@ -103,13 +110,6 @@ class ObservationModel:
             is_leaf=lambda nm: isinstance(nm, NoiseModel),
         )
         return BlockDiagonalOperator(operator_tree)
-
-    def apply_system(self, x: Stokes, *, white_noise: bool = False) -> Stokes:
-        """Applies H.T @ W @ H (+ TOD masking) to x for this observation."""
-        weight = self.white_noise_W() if white_noise else self.W
-        y = self.masker(self.H(x))
-        y = weight(y)
-        return self.H.T(self.masker.T(y))  # type: ignore[no-any-return]
 
     def rhs(self, data: Any, config: MapMakingConfig) -> Stokes:
         """Accumulates data into the r.h.s. of the mapmaking equation.
@@ -152,41 +152,6 @@ class ObservationModel:
 
 
 _StokesPyTree = TypeVar('_StokesPyTree', bound=StokesPyTreeType)
-
-
-@functools.partial(jax.jit, static_argnames=['diag'])
-def _system_scan(model: ObservationModel, x: _StokesPyTree, *, diag: bool = False) -> _StokesPyTree:
-    """Apply H^T W H to x, summed over the batch of observations in model.
-
-    `model` is an explicit JIT argument so it is never captured as an XLA constant.
-
-    Args:
-        model: Stacked ObservationModel with a leading batch dimension over observations.
-        x: Input sky map pytree.
-        diag: If True, use the diagonal white-noise approximation for W.
-    """
-
-    def accumulate(lhs, obs):  # type: ignore[no-untyped-def]
-        return tree.add(lhs, obs.apply_system(x, white_noise=diag)), None
-
-    lhs, _ = jax.lax.scan(accumulate, tree.zeros_like(x), model)
-    return lhs
-
-
-@symmetric
-class SystemOperator(AbstractLinearOperator):
-    """System operator for multiple observations: `A = Σ_i H_i^T W_i H_i`."""
-
-    models: ObservationModel
-    diag: bool = field(metadata={'static': True})
-
-    def __init__(self, models: ObservationModel, *, diag: bool = False):
-        object.__setattr__(self, 'models', models)
-        object.__setattr__(self, 'diag', diag)
-        object.__setattr__(self, 'in_structure', models.map_structure)
-
-    def mv(self, x: _StokesPyTree) -> _StokesPyTree:
-        return _system_scan(self.models, x, diag=self.diag)  # type: ignore[no-any-return]
 
 
 def _noise_model(data: Any, config: MapMakingConfig) -> tuple[PyTree[NoiseModel], Array]:

--- a/src/furax/mapmaking/_model.py
+++ b/src/furax/mapmaking/_model.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass
-from typing import Any, TypeVar
+from typing import Any
 
 import jax
 import jax.numpy as jnp
@@ -10,13 +10,11 @@ from furax import AbstractLinearOperator, IdentityOperator, MaskOperator, tree
 from furax.core import BlockDiagonalOperator, CompositionOperator, IndexOperator
 from furax.obs.landscapes import StokesLandscape
 from furax.obs.pointing import PointingOperator
-from furax.obs.stokes import Stokes, StokesI, StokesPyTreeType
+from furax.obs.stokes import Stokes, StokesI
 
-from ._reader import ObservationReader
 from ._scan_blocks import ScanBlockColumnOperator, ScanBlockDiagonalOperator
 from .acquisition import build_acquisition_operator
 from .config import MapMakingConfig, Methods
-from .gap_filling import GapFillingOperator
 from .noise import AtmosphericNoiseModel, NoiseModel, WhiteNoiseModel
 from .templates import ATOPProjectionOperator
 
@@ -109,43 +107,21 @@ class ObservationModel:
         masked_i = jax.tree.leaves(M(ones))[0]
         return jnp.int64(P.T(StokesI(masked_i)).i)  # type: ignore[no-any-return]
 
-    @jax.jit(static_argnames=('config',))
-    def accumulate_rhs(self, reader: ObservationReader[Any], config: MapMakingConfig) -> Stokes:
-        """Accumulate RHS vector across all observations."""
+    def rhs(self, tod: PyTree[Array]) -> Stokes:
+        """Project tod into map domain: H^T M W tod."""
+        return (self.H.T @ self.masker @ self.W)(tod)  # type: ignore[no-any-return]
 
-        def prepare_tod(model, data):  # type: ignore[no-untyped-def]
-            tod = data['sample_data']
-            if not config.gaps.fill or config.binned:
-                return tod
-
-            # FIXME: check with demodulated data
-            N = _noise_operator(
-                model.noise_model,
-                model.tod_structure,
-                model.sample_rate,
-                config.noise.correlation_length,
-                inverse=False,
-            )
-            return GapFillingOperator(
-                N,  # type: ignore[arg-type]
-                model._get_indexer(),
-                data['metadata'],
-                model.W,
-                rate=model.sample_rate,
-                max_cg_steps=config.gaps.fill_options.max_steps,
-                rtol=config.gaps.fill_options.rtol,
-            )(jax.random.key(config.gaps.fill_options.seed), tod)
-
-        def step(carry, args):  # type: ignore[no-untyped-def]
-            i, model = args
-            data, _ = reader.read(i)
-            tod = prepare_tod(model, data)
-            rhs = (model.H.T @ model.masker @ model.W)(tod)
-            return carry + rhs, None
-
-        init = tree.zeros_like(self.map_structure)
-        total, _ = jax.lax.scan(step, init, (jnp.arange(reader.count), self))
-        return total  # type: ignore[no-any-return]
+    def noise_operator(
+        self, correlation_length: int, *, inverse: bool = True
+    ) -> AbstractLinearOperator:
+        """Build the (inverse) noise covariance operator."""
+        return _noise_operator(
+            self.noise_model,
+            self.tod_structure,
+            self.sample_rate,
+            correlation_length,
+            inverse=inverse,
+        )
 
     def diag_W(self) -> AbstractLinearOperator:
         """Build the inverse white noise covariance operator."""
@@ -166,9 +142,6 @@ class ObservationModel:
         else:
             raise NotImplementedError
         return IndexOperator(mask, in_structure=self.tod_structure)
-
-
-_StokesPyTree = TypeVar('_StokesPyTree', bound=StokesPyTreeType)
 
 
 def _noise_model(data: Any, config: MapMakingConfig) -> tuple[PyTree[NoiseModel], Array]:

--- a/src/furax/mapmaking/_model.py
+++ b/src/furax/mapmaking/_model.py
@@ -12,6 +12,7 @@ from furax.obs.landscapes import StokesLandscape
 from furax.obs.pointing import PointingOperator
 from furax.obs.stokes import Stokes, StokesI, StokesPyTreeType
 
+from ._reader import ObservationReader
 from ._scan_blocks import ScanBlockColumnOperator, ScanBlockDiagonalOperator
 from .acquisition import build_acquisition_operator
 from .config import MapMakingConfig, Methods
@@ -94,7 +95,9 @@ class ObservationModel:
         W = ScanBlockDiagonalOperator(weight, n)
         return (H.T @ M @ W @ M @ H).reduce()
 
+    @jax.jit
     def accumulate_hits(self) -> Int64[Array, ' pixels']:
+        """Accumulate hit counts across all observations."""
         n = self.n_observations
         assert isinstance(self.H, CompositionOperator)  # mypy assert
         # pointing operator is the last operand of the acquisition chain (see unit test)
@@ -106,6 +109,44 @@ class ObservationModel:
         masked_i = jax.tree.leaves(M(ones))[0]
         return jnp.int64(P.T(StokesI(masked_i)).i)  # type: ignore[no-any-return]
 
+    @jax.jit(static_argnames=('config',))
+    def accumulate_rhs(self, reader: ObservationReader[Any], config: MapMakingConfig) -> Stokes:
+        """Accumulate RHS vector across all observations."""
+
+        def prepare_tod(model, data):  # type: ignore[no-untyped-def]
+            tod = data['sample_data']
+            if not config.gaps.fill or config.binned:
+                return tod
+
+            # FIXME: check with demodulated data
+            N = _noise_operator(
+                model.noise_model,
+                model.tod_structure,
+                model.sample_rate,
+                config.noise.correlation_length,
+                inverse=False,
+            )
+            return GapFillingOperator(
+                N,  # type: ignore[arg-type]
+                model._get_indexer(),
+                data['metadata'],
+                model.W,
+                rate=model.sample_rate,
+                max_cg_steps=config.gaps.fill_options.max_steps,
+                rtol=config.gaps.fill_options.rtol,
+            )(jax.random.key(config.gaps.fill_options.seed), tod)
+
+        def step(carry, args):  # type: ignore[no-untyped-def]
+            i, model = args
+            data, _ = reader.read(i)
+            tod = prepare_tod(model, data)
+            rhs = (model.H.T @ model.masker @ model.W)(tod)
+            return carry + rhs, None
+
+        init = tree.zeros_like(self.map_structure)
+        total, _ = jax.lax.scan(step, init, (jnp.arange(reader.count), self))
+        return total  # type: ignore[no-any-return]
+
     def diag_W(self) -> AbstractLinearOperator:
         """Build the inverse white noise covariance operator."""
         operator_tree = jax.tree.map(
@@ -115,35 +156,6 @@ class ObservationModel:
             is_leaf=lambda nm: isinstance(nm, NoiseModel),
         )
         return BlockDiagonalOperator(operator_tree)
-
-    def rhs(self, data: Any, config: MapMakingConfig) -> Stokes:
-        """Accumulates data into the r.h.s. of the mapmaking equation.
-
-        Also performs gap-filling on the data before projecting into map domain.
-        """
-        tod = data['sample_data']
-        if config.gaps.fill and not config.binned:
-            # FIXME: check with demodulated data
-            N = _noise_operator(
-                self.noise_model,
-                self.tod_structure,
-                self.sample_rate,
-                config.noise.correlation_length,
-                inverse=False,
-            )
-            gapfill = GapFillingOperator(
-                N,  # type: ignore[arg-type]
-                self._get_indexer(),
-                data['metadata'],
-                self.W,  # type: ignore[arg-type]
-                rate=self.sample_rate,
-                max_cg_steps=config.gaps.fill_options.max_steps,
-                rtol=config.gaps.fill_options.rtol,
-            )
-            key = jax.random.key(config.gaps.fill_options.seed)
-            tod = gapfill(key, tod)
-        rhs: Stokes = (self.H.T @ self.masker @ self.W)(tod)
-        return rhs
 
     def _get_indexer(self) -> IndexOperator:
         """Get the IndexOperator for gap-filling"""

--- a/src/furax/mapmaking/_model.py
+++ b/src/furax/mapmaking/_model.py
@@ -4,15 +4,13 @@ from typing import Any
 import jax
 import jax.numpy as jnp
 from jax.tree_util import register_dataclass
-from jaxtyping import Array, Float, Int64, PyTree
+from jaxtyping import Array, Float, PyTree
 
 from furax import AbstractLinearOperator, IdentityOperator, MaskOperator, tree
 from furax.core import BlockDiagonalOperator, CompositionOperator, IndexOperator
 from furax.obs.landscapes import StokesLandscape
-from furax.obs.pointing import PointingOperator
-from furax.obs.stokes import Stokes, StokesI
+from furax.obs.stokes import Stokes
 
-from ._scan_blocks import ScanBlockColumnOperator, ScanBlockDiagonalOperator
 from .acquisition import build_acquisition_operator
 from .config import MapMakingConfig, Methods
 from .noise import AtmosphericNoiseModel, NoiseModel, WhiteNoiseModel
@@ -79,33 +77,6 @@ class ObservationModel:
     @property
     def map_structure(self) -> PyTree[jax.ShapeDtypeStruct]:
         return self.H.in_structure
-
-    @property
-    def n_observations(self) -> int:
-        # assuming stacked pytree
-        return jax.tree.leaves(self.H)[0].shape[0]  # type: ignore[no-any-return]
-
-    def get_system_operator(self, *, diag: bool = False) -> AbstractLinearOperator:
-        n = self.n_observations
-        H = ScanBlockColumnOperator(self.H, n)
-        M = ScanBlockDiagonalOperator(self.masker, n)
-        weight = self.diag_W() if diag else self.W
-        W = ScanBlockDiagonalOperator(weight, n)
-        return (H.T @ M @ W @ M @ H).reduce()
-
-    @jax.jit
-    def accumulate_hits(self) -> Int64[Array, ' pixels']:
-        """Accumulate hit counts across all observations."""
-        n = self.n_observations
-        assert isinstance(self.H, CompositionOperator)  # mypy assert
-        # pointing operator is the last operand of the acquisition chain (see unit test)
-        pointing = self.H.operands[-1]
-        assert isinstance(pointing, PointingOperator)  # mypy assert
-        P = ScanBlockColumnOperator(pointing.as_stokes_i(interpolate=False), n)
-        M = ScanBlockDiagonalOperator(self.masker, n)
-        ones = tree.ones_like(M.in_structure)
-        masked_i = jax.tree.leaves(M(ones))[0]
-        return jnp.int64(P.T(StokesI(masked_i)).i)  # type: ignore[no-any-return]
 
     def rhs(self, tod: PyTree[Array]) -> Stokes:
         """Project tod into map domain: H^T M W tod."""

--- a/src/furax/mapmaking/_model.py
+++ b/src/furax/mapmaking/_model.py
@@ -119,7 +119,15 @@ def pad_model(models: ObservationModel, n_pad: int) -> ObservationModel:
     if n_pad == 0:
         return models
     last = jax.tree.map(lambda a: jnp.repeat(a[-1:], n_pad, axis=0), models)
-    zero_masker = jax.tree.map(jnp.zeros_like, last.masker)
+    if len(jax.tree.leaves(last.masker)) == 0:
+        # Leaf-free masker (e.g. IdentityOperator): jax.tree.map produces no zeros.
+        # Build an explicit all-False MaskOperator so padding obs contribute nothing.
+        structure = last.masker.in_structure
+        first_leaf = jax.tree.leaves(structure)[0]
+        zero_mask = jnp.zeros((n_pad, *first_leaf.shape), dtype=bool)
+        zero_masker = MaskOperator.from_boolean_mask(zero_mask, in_structure=structure)
+    else:
+        zero_masker = jax.tree.map(jnp.zeros_like, last.masker)
     padded = ObservationModel(
         H=last.H,
         W=last.W,

--- a/src/furax/mapmaking/_model.py
+++ b/src/furax/mapmaking/_model.py
@@ -9,7 +9,6 @@ from jaxtyping import Array, Float, PyTree
 from furax import AbstractLinearOperator, IdentityOperator, MaskOperator, tree
 from furax.core import BlockDiagonalOperator, CompositionOperator, IndexOperator
 from furax.obs.landscapes import StokesLandscape
-from furax.obs.stokes import Stokes
 
 from .acquisition import build_acquisition_operator
 from .config import MapMakingConfig, Methods
@@ -77,10 +76,6 @@ class ObservationModel:
     @property
     def map_structure(self) -> PyTree[jax.ShapeDtypeStruct]:
         return self.H.in_structure
-
-    def rhs(self, tod: PyTree[Array]) -> Stokes:
-        """Project tod into map domain: H^T M W tod."""
-        return (self.H.T @ self.masker @ self.W)(tod)  # type: ignore[no-any-return]
 
     def noise_operator(
         self, correlation_length: int, *, inverse: bool = True

--- a/src/furax/mapmaking/_reader.py
+++ b/src/furax/mapmaking/_reader.py
@@ -73,24 +73,89 @@ class ObservationReader(AbstractReader, Generic[T]):
             demodulated: Whether to read demodulated TODs.
             stokes: Stokes components to read when demodulated.
         """
+        fields = cls._resolve_fields(observations, requested_fields)
+        return cls(
+            list(observations),
+            common_keywords={'data_field_names': fields},
+            demodulated=demodulated,
+            stokes=stokes,
+        )
+
+    @classmethod
+    def from_observations_distributed(
+        cls,
+        observations: Sequence[AbstractLazyObservation[T]],
+        local_indices: Sequence[int],
+        *,
+        requested_fields: list[str] | None = None,
+        demodulated: bool = False,
+        stokes: ValidStokesType = 'IQU',
+    ) -> Self:
+        """Create a reader for distributed mapmaking.
+
+        Each process opens only its local observation files to read their shapes, then
+        an all-gather synchronises the shapes so every process can build structures for
+        all observations without duplicate I/O.  Requires a JAX distributed context.
+
+        Args:
+            observations: Full list of observations across all processes.
+            local_indices: Indices into ``observations`` owned by this process.
+            requested_fields: Optional list of fields to load.
+            demodulated: Whether to read demodulated TODs.
+            stokes: Stokes components to read when demodulated.
+        """
+        from jax.experimental import multihost_utils as mhu
+
+        fields = cls._resolve_fields(observations, requested_fields)
+
+        # Each process reads shapes only for its local observations
+        def _shape(idx: int) -> tuple[int, int, int]:
+            data = observations[idx].get_data([])
+            return idx, data.n_detectors, data.n_samples
+
+        local_shapes = np.array([_shape(idx) for idx in local_indices], dtype=np.int32)
+
+        # All-gather → (n_procs * n_local, 3), sort by global index
+        all_shapes = mhu.process_allgather(local_shapes).reshape(-1, 3)
+        all_shapes = all_shapes[np.argsort(all_shapes[:, 0])]
+
+        structures = [
+            {
+                field: all_field_structures[field]
+                for field in fields
+                for all_field_structures in [
+                    cls._get_data_field_structures_for(
+                        int(n_det), int(n_samp), demodulated=demodulated, stokes=stokes
+                    )
+                ]
+            }
+            for _, n_det, n_samp in all_shapes
+        ]
+
+        return cls(
+            list(observations),
+            common_keywords={'data_field_names': fields},
+            demodulated=demodulated,
+            stokes=stokes,
+            structures=structures,
+        )
+
+    @staticmethod
+    def _resolve_fields(
+        observations: Sequence[AbstractLazyObservation[T]],
+        requested_fields: list[str] | None,
+    ) -> list[str]:
         interface = observations[0].interface_class
         available = set(interface.AVAILABLE_READER_FIELDS)
         optional = set(interface.OPTIONAL_READER_FIELDS)
         if requested_fields is None:
-            fields = available - optional
-        else:
-            fields = set(requested_fields)
-            unsupported = fields - available
-            if len(unsupported) > 0:
-                msg = f'Requested data fields {unsupported} are not supported by the interface.'
-                raise ValueError(msg)
-
-        return cls(
-            list(observations),
-            common_keywords={'data_field_names': list(fields)},
-            demodulated=demodulated,
-            stokes=stokes,
-        )
+            return sorted(available - optional)
+        unsupported = set(requested_fields) - available
+        if unsupported:
+            raise ValueError(
+                f'Requested data fields {unsupported} are not supported by the interface.'
+            )
+        return list(requested_fields)
 
     def read(self, data_index: int) -> tuple[PyTree[Array], PyTree[Array]]:  # type: ignore[override]
         """Reads one ground observation from the list of filenames specified in the reader.

--- a/src/furax/mapmaking/_reader.py
+++ b/src/furax/mapmaking/_reader.py
@@ -87,7 +87,7 @@ class ObservationReader(AbstractReader, Generic[T]):
         observations: Sequence[AbstractLazyObservation[T]],
         local_indices: Sequence[int],
         *,
-        requested_fields: list[str] | None = None,
+        requested_fields: Sequence[str] | None = None,
         demodulated: bool = False,
         stokes: ValidStokesType = 'IQU',
     ) -> Self:
@@ -143,7 +143,7 @@ class ObservationReader(AbstractReader, Generic[T]):
     @staticmethod
     def _resolve_fields(
         observations: Sequence[AbstractLazyObservation[T]],
-        requested_fields: list[str] | None,
+        requested_fields: Sequence[str] | None,
     ) -> list[str]:
         interface = observations[0].interface_class
         available = set(interface.AVAILABLE_READER_FIELDS)

--- a/src/furax/mapmaking/_reader.py
+++ b/src/furax/mapmaking/_reader.py
@@ -1,6 +1,6 @@
 from collections.abc import Sequence
 from hashlib import sha1
-from typing import Any, Generic, TypeVar
+from typing import Any, Generic, Self, TypeVar
 
 import jax
 import jax.numpy as jnp
@@ -44,22 +44,35 @@ class ObservationReader(AbstractReader, Generic[T]):
 
     def __init__(
         self,
+        *args: Sequence[Any],
+        demodulated: bool,
+        stokes: ValidStokesType,
+        common_keywords: dict[str, Any] | None = None,
+        structures: list[PyTree[jax.ShapeDtypeStruct]] | None = None,
+        **keywords: Sequence[Any],
+    ) -> None:
+        # Set before super().__init__ so _read_structure_impure can use them
+        self.demodulated = demodulated
+        self.stokes = stokes
+        super().__init__(*args, common_keywords=common_keywords, structures=structures, **keywords)
+
+    @classmethod
+    def from_observations(
+        cls,
         observations: Sequence[AbstractLazyObservation[T]],
         *,
         requested_fields: list[str] | None = None,
         demodulated: bool = False,
         stokes: ValidStokesType = 'IQU',
-    ) -> None:
-        """Initializes the reader with a list of filenames and optional list of field names.
+    ) -> Self:
+        """Create a reader, performing I/O to infer data structures.
 
         Args:
-            filenames: A list of filenames. Each filename can be a string or a Path object.
+            observations: List of lazy observations to read.
             requested_fields: Optional list of fields to load. If None, read all non-optional fields.
             demodulated: Whether to read demodulated TODs.
             stokes: Stokes components to read when demodulated.
         """
-        self.demodulated = demodulated
-        self.stokes = stokes
         interface = observations[0].interface_class
         available = set(interface.AVAILABLE_READER_FIELDS)
         optional = set(interface.OPTIONAL_READER_FIELDS)
@@ -72,7 +85,12 @@ class ObservationReader(AbstractReader, Generic[T]):
                 msg = f'Requested data fields {unsupported} are not supported by the interface.'
                 raise ValueError(msg)
 
-        super().__init__(observations, common_keywords={'data_field_names': list(fields)})
+        return cls(
+            list(observations),
+            common_keywords={'data_field_names': list(fields)},
+            demodulated=demodulated,
+            stokes=stokes,
+        )
 
     def read(self, data_index: int) -> tuple[PyTree[Array], PyTree[Array]]:  # type: ignore[override]
         """Reads one ground observation from the list of filenames specified in the reader.
@@ -152,12 +170,14 @@ class ObservationReader(AbstractReader, Generic[T]):
 
         return data, padding
 
+    @staticmethod
     def _get_data_field_structures_for(
-        self, n_detectors: int, n_samples: int
+        n_detectors: int,
+        n_samples: int,
+        *,
+        demodulated: bool,
+        stokes: ValidStokesType,
     ) -> PyTree[jax.ShapeDtypeStruct]:
-        demodulated = self.demodulated
-        stokes = self.stokes
-
         tod_shape = (n_detectors, n_samples)
         sample_data_structure = (
             Stokes.class_for(stokes).structure_for(tod_shape, jnp.float64)
@@ -230,13 +250,11 @@ class ObservationReader(AbstractReader, Generic[T]):
         # request an empty list
         # this loads sufficient info to determine the structure
         data = observation.get_data([])
-
-        # find the data shape
-        n_detectors = data.n_detectors
-        n_samples = data.n_samples
-
         field_structure = self._get_data_field_structures_for(
-            n_detectors=n_detectors, n_samples=n_samples
+            data.n_detectors,
+            data.n_samples,
+            demodulated=self.demodulated,
+            stokes=self.stokes,
         )
         return {field: field_structure[field] for field in data_field_names}
 

--- a/src/furax/mapmaking/_reader.py
+++ b/src/furax/mapmaking/_reader.py
@@ -62,7 +62,7 @@ class ObservationReader(AbstractReader, Generic[T]):
         cls,
         observations: Sequence[AbstractLazyObservation[T]],
         *,
-        subset_indices: Sequence[int] | None = None,
+        read_indices: Sequence[int] | None = None,
         requested_fields: Sequence[str] | None = None,
         demodulated: bool = False,
         stokes: ValidStokesType = 'IQU',
@@ -80,7 +80,7 @@ class ObservationReader(AbstractReader, Generic[T]):
         """
         fields = cls._resolve_fields(observations, requested_fields)
         common_keywords = {'data_field_names': fields}
-        if subset_indices is None:
+        if read_indices is None:
             # Default path: AbstractReader.__init__ will call _read_structures(),
             # opening every observation on this process to infer its structure.
             return cls(
@@ -98,7 +98,7 @@ class ObservationReader(AbstractReader, Generic[T]):
             data = observations[idx].get_data([])
             return idx, data.n_detectors, data.n_samples
 
-        local_shapes = np.array([_shape(idx) for idx in subset_indices], dtype=np.int64)
+        local_shapes = np.array([_shape(idx) for idx in read_indices], dtype=np.int64)
 
         # All-gather → (n_procs * n_local, 3). Padding (see ``get_padded_indices``,
         # which uses ``np.pad(..., mode='edge')``) makes some indices repeat across

--- a/src/furax/mapmaking/_reader.py
+++ b/src/furax/mapmaking/_reader.py
@@ -115,9 +115,11 @@ class ObservationReader(AbstractReader, Generic[T]):
 
         local_shapes = np.array([_shape(idx) for idx in local_indices], dtype=np.int32)
 
-        # All-gather → (n_procs * n_local, 3), sort by global index
+        # All-gather → (n_procs * n_local, 3), sort and deduplicate (padding repeats indices)
         all_shapes = mhu.process_allgather(local_shapes).reshape(-1, 3)
-        all_shapes = all_shapes[np.argsort(all_shapes[:, 0])]
+        all_shapes = all_shapes[np.argsort(all_shapes[:, 0], kind='stable')]
+        _, first = np.unique(all_shapes[:, 0], return_index=True)
+        all_shapes = all_shapes[first]
 
         structures = [
             {

--- a/src/furax/mapmaking/_reader.py
+++ b/src/furax/mapmaking/_reader.py
@@ -6,6 +6,7 @@ import jax
 import jax.numpy as jnp
 import numpy as np
 from jax import Array
+from jax.experimental import multihost_utils as mhu
 from jax.tree_util import register_static
 from jaxtyping import PyTree, UInt32
 
@@ -61,82 +62,60 @@ class ObservationReader(AbstractReader, Generic[T]):
         cls,
         observations: Sequence[AbstractLazyObservation[T]],
         *,
-        requested_fields: list[str] | None = None,
+        subset_indices: Sequence[int] | None = None,
+        requested_fields: Sequence[str] | None = None,
         demodulated: bool = False,
         stokes: ValidStokesType = 'IQU',
     ) -> Self:
         """Create a reader, performing I/O to infer data structures.
 
         Args:
-            observations: List of lazy observations to read.
+            observations: Full list of lazy observations.
+            subset_indices: Optional indices into ``observations``; when set, only
+                those are opened on this process to infer shapes, and shapes are
+                synchronised across processes (distributed-mode shortcut).
             requested_fields: Optional list of fields to load. If None, read all non-optional fields.
             demodulated: Whether to read demodulated TODs.
             stokes: Stokes components to read when demodulated.
         """
         fields = cls._resolve_fields(observations, requested_fields)
-        return cls(
-            list(observations),
-            common_keywords={'data_field_names': fields},
-            demodulated=demodulated,
-            stokes=stokes,
-        )
+        common_keywords = {'data_field_names': fields}
+        if subset_indices is None:
+            # Default path: AbstractReader.__init__ will call _read_structures(),
+            # opening every observation on this process to infer its structure.
+            return cls(
+                list(observations),
+                common_keywords=common_keywords,
+                demodulated=demodulated,
+                stokes=stokes,
+            )
 
-    @classmethod
-    def from_observations_distributed(
-        cls,
-        observations: Sequence[AbstractLazyObservation[T]],
-        local_indices: Sequence[int],
-        *,
-        requested_fields: Sequence[str] | None = None,
-        demodulated: bool = False,
-        stokes: ValidStokesType = 'IQU',
-    ) -> Self:
-        """Create a reader for distributed mapmaking.
-
-        Each process opens only its local observation files to read their shapes, then
-        an all-gather synchronises the shapes so every process can build structures for
-        all observations without duplicate I/O.  Requires a JAX distributed context.
-
-        Args:
-            observations: Full list of observations across all processes.
-            local_indices: Indices into ``observations`` owned by this process.
-            requested_fields: Optional list of fields to load.
-            demodulated: Whether to read demodulated TODs.
-            stokes: Stokes components to read when demodulated.
-        """
-        from jax.experimental import multihost_utils as mhu
-
-        fields = cls._resolve_fields(observations, requested_fields)
-
-        # Each process reads shapes only for its local observations
+        # Distributed-mode shortcut. Each process opens only its subset; an
+        # all-gather then makes every rank agree on the full structures list so
+        # padding / out_structure / etc. are consistent. Bypasses the superclass's
+        # per-item I/O by passing the assembled `structures` directly.
         def _shape(idx: int) -> tuple[int, int, int]:
             data = observations[idx].get_data([])
             return idx, data.n_detectors, data.n_samples
 
-        local_shapes = np.array([_shape(idx) for idx in local_indices], dtype=np.int32)
+        local_shapes = np.array([_shape(idx) for idx in subset_indices], dtype=np.int64)
 
-        # All-gather → (n_procs * n_local, 3), sort and deduplicate (padding repeats indices)
+        # All-gather → (n_procs * n_local, 3). Padding (see ``get_padded_indices``,
+        # which uses ``np.pad(..., mode='edge')``) makes some indices repeat across
+        # ranks; keep only one entry per obs index.
         all_shapes = mhu.process_allgather(local_shapes).reshape(-1, 3)
-        all_shapes = all_shapes[np.argsort(all_shapes[:, 0], kind='stable')]
-        _, first = np.unique(all_shapes[:, 0], return_index=True)
-        all_shapes = all_shapes[first]
+        by_idx = {int(idx): (int(n_det), int(n_samp)) for idx, n_det, n_samp in all_shapes}
 
-        structures = [
-            {
-                field: all_field_structures[field]
-                for field in fields
-                for all_field_structures in [
-                    cls._get_data_field_structures_for(
-                        int(n_det), int(n_samp), demodulated=demodulated, stokes=stokes
-                    )
-                ]
-            }
-            for _, n_det, n_samp in all_shapes
-        ]
+        def _struct_for(n_det: int, n_samp: int) -> PyTree[jax.ShapeDtypeStruct]:
+            field_struct = cls._get_data_field_structures_for(
+                n_det, n_samp, demodulated=demodulated, stokes=stokes
+            )
+            return {field: field_struct[field] for field in fields}
 
+        structures = [_struct_for(*by_idx[idx]) for idx in sorted(by_idx)]
         return cls(
             list(observations),
-            common_keywords={'data_field_names': fields},
+            common_keywords=common_keywords,
             demodulated=demodulated,
             stokes=stokes,
             structures=structures,

--- a/src/furax/mapmaking/_reader.py
+++ b/src/furax/mapmaking/_reader.py
@@ -71,7 +71,7 @@ class ObservationReader(AbstractReader, Generic[T]):
 
         Args:
             observations: Full list of lazy observations.
-            subset_indices: Optional indices into ``observations``; when set, only
+            read_indices: Optional indices into ``observations``; when set, only
                 those are opened on this process to infer shapes, and shapes are
                 synchronised across processes (distributed-mode shortcut).
             requested_fields: Optional list of fields to load. If None, read all non-optional fields.

--- a/src/furax/mapmaking/_scan_blocks.py
+++ b/src/furax/mapmaking/_scan_blocks.py
@@ -24,37 +24,41 @@ def _get_mesh() -> AbstractMesh:
 
 
 class AbstractScanBlockOperator(AbstractLinearOperator, ABC):
-    """Base class for operators built from N stacked blocks.
+    """Base class for operators that apply a batched pytree operator slice-by-slice via scan.
 
-    ``blocks`` is an operator whose leaves carry a leading axis of size ``N`` obtained by
-    stacking N individual operators into a single pytree beforehand (e.g. with
-    ``jax.tree.map(jnp.stack, list_of_ops)``).  ``blocks`` itself is not expected to handle
-    that leading axis: ``mv`` uses ``jax.lax.scan`` to peel off one slice at a time and feed
-    it to the underlying operator logic, inside a ``shard_map`` kernel that distributes the
-    work across devices along the first mesh axis.
+    ``operator`` is an operator whose leaves carry a leading axis of size ``N`` obtained by
+    stacking N individual operators into a single pytree beforehand.  ``operator`` itself is
+    not expected to handle that leading axis: ``mv`` uses ``jax.lax.scan`` to peel off one
+    slice at a time and feed it to the underlying operator logic, inside a ``shard_map`` kernel
+    that distributes the work across devices along the first mesh axis.
+
+    The "block" denomination refers to how each slice appears in the global operator matrix:
+    subclasses arrange the N per-slice operators as blocks of a larger matrix (diagonal,
+    column, or row layout), giving rise to block-diagonal, block-column, and block-row
+    structures respectively.
 
     An active mesh context is required when calling ``mv``; use ``jax.set_mesh`` beforehand.
     """
 
-    blocks: AbstractLinearOperator
+    operator: AbstractLinearOperator
 
     @classmethod
-    def create(cls, blocks: AbstractLinearOperator) -> Self:
-        if len(jax.tree.leaves(blocks)) == 0:
-            msg = 'unable to infer structures from blocks with no leaf'
+    def create(cls, operator: AbstractLinearOperator) -> Self:
+        if len(jax.tree.leaves(operator)) == 0:
+            msg = 'unable to infer structures from operator with no leaf'
             raise RuntimeError(msg)
-        in_structure = cls._infer_in_structure(blocks)
-        return cls(blocks, in_structure=in_structure)
+        in_structure = cls._infer_in_structure(operator)
+        return cls(operator, in_structure=in_structure)
 
     @classmethod
     @abstractmethod
-    def _infer_in_structure(cls, blocks: AbstractLinearOperator) -> PyTree[jax.ShapeDtypeStruct]:
+    def _infer_in_structure(cls, operator: AbstractLinearOperator) -> PyTree[jax.ShapeDtypeStruct]:
         """Returns sharding-aware in_structure"""
 
     def reduce(self) -> AbstractLinearOperator:
         with jax.sharding.use_abstract_mesh(_EMPTY_MESH):
-            reduced_blocks = self.blocks.reduce()
-        return type(self)(reduced_blocks, in_structure=self.in_structure)
+            reduced_operator = self.operator.reduce()
+        return type(self)(reduced_operator, in_structure=self.in_structure)
 
 
 def _prepend_axis(
@@ -72,190 +76,180 @@ def _prepend_axis(
 class ScanBlockDiagonalOperator(AbstractScanBlockOperator):
     """Block-diagonal operator: each block acts independently on its own slice of the input.
 
-    If ``blocks`` maps ``(N_in,) -> (N_out,)`` with leading axis ``N``, this operator
-    maps ``(N, N_in) -> (N, N_out)``.
+    Given ``operator: (*in,) -> (*out,)`` with ``N`` slices, maps ``(N, *in) -> (N, *out)``.
 
-    Transpose is another ``ScanBlockDiagonalOperator`` over the transposed blocks.
-
-    Example — per-observation noise weighting (square blocks, ``N_in == N_out``):
+    Example — per-observation noise weighting (square blocks, ``*in == *out``):
 
         >>> with jax.set_mesh(jax.make_mesh((4,), ('obs',))):
-        ...     W = ScanBlockDiagonalOperator.create(noise_blocks)  # blocks: (N_obs, N, N)
-        ...     weighted = W(samples)                               # (N_obs, N) -> (N_obs, N)
+        ...     W = ScanBlockDiagonalOperator.create(noise_op)  # leaves: (N, *in)
+        ...     weighted = W(samples)                           # (N, *in) -> (N, *out)
     """
 
     @classmethod
-    def _infer_in_structure(cls, blocks: AbstractLinearOperator) -> PyTree[jax.ShapeDtypeStruct]:
-        axis_size = jax.eval_shape(lambda: jax.tree.leaves(blocks)[0]).shape[0]
-        return _prepend_axis(blocks.in_structure, axis_size=axis_size)
+    def _infer_in_structure(cls, operator: AbstractLinearOperator) -> PyTree[jax.ShapeDtypeStruct]:
+        axis_size = jax.eval_shape(lambda: jax.tree.leaves(operator)[0]).shape[0]
+        return _prepend_axis(operator.in_structure, axis_size=axis_size)
 
     @property
     def out_structure(self) -> PyTree[jax.ShapeDtypeStruct]:
         n = jax.tree.leaves(self.in_structure)[0].shape[0]
-        return _prepend_axis(self.blocks.out_structure, axis_size=n)
+        return _prepend_axis(self.operator.out_structure, axis_size=n)
 
     def mv(self, x: PyTree[Inexact[Array, '...']]) -> PyTree[Inexact[Array, '...']]:
         axis = _get_mesh().axis_names[0]
 
         @jax.shard_map(out_specs=P(axis), check_vma=False)
-        def kernel(blocks, x):  # type: ignore[no-untyped-def]
+        def kernel(operator, x):  # type: ignore[no-untyped-def]
             def step(_, args):  # type: ignore[no-untyped-def]
                 op, x_i = args
                 return None, op.mv(x_i)
 
-            _, out = jax.lax.scan(step, None, (blocks, x))
+            _, out = jax.lax.scan(step, None, (operator, x))
             return out
 
         # shard_map validates in_specs against actual array sharding; reshard sets it
         # explicitly so the check passes even when sharding is lost inside a JIT trace
-        blocks = jax.tree.map(lambda a: jax.reshard(a, P(axis)), self.blocks)
+        operator = jax.tree.map(lambda a: jax.reshard(a, P(axis)), self.operator)
         x = jax.tree.map(lambda a: jax.reshard(a, P(axis)), x)
-        return kernel(blocks, x)
+        return kernel(operator, x)
 
     def transpose(self) -> AbstractLinearOperator:
         with jax.sharding.use_abstract_mesh(_EMPTY_MESH):
-            blocks_T = self.blocks.T
-        return ScanBlockDiagonalOperator(blocks_T, in_structure=self.out_structure)
+            operator_T = self.operator.T
+        return ScanBlockDiagonalOperator(operator_T, in_structure=self.out_structure)
 
 
 class ScanBlockColumnOperator(AbstractScanBlockOperator):
     """Column operator: applies all blocks to the same input and stacks the results.
 
-    If ``blocks`` maps ``(N_in,) -> (N_out,)`` with leading axis ``N``, this operator
-    maps ``(N_in,) -> (N, N_out)``.
-
-    Transpose is a ``ScanBlockRowOperator`` that sums contributions across blocks.
+    Given ``operator: (*in,) -> (*out,)`` with ``N`` slices, maps ``(*in,) -> (N, *out)``.
 
     Example — pointing matrix from pixel map to time-ordered data:
 
         >>> with jax.set_mesh(jax.make_mesh((4,), ('obs',))):
-        ...     H = ScanBlockColumnOperator.create(pointing_blocks)  # blocks: (N_obs, N_tod, N_pix)
-        ...     tod = H(pixel_map)                                   # (N_pix,) -> (N_obs, N_tod)
+        ...     H = ScanBlockColumnOperator.create(pointing_op)  # leaves: (N, *out)
+        ...     tod = H(pixel_map)                               # (*in,) -> (N, *out)
     """
 
     @classmethod
-    def _infer_in_structure(cls, blocks: AbstractLinearOperator) -> PyTree[jax.ShapeDtypeStruct]:
-        return blocks.in_structure
+    def _infer_in_structure(cls, operator: AbstractLinearOperator) -> PyTree[jax.ShapeDtypeStruct]:
+        return operator.in_structure
 
     @property
     def out_structure(self) -> PyTree[jax.ShapeDtypeStruct]:
-        n = jax.tree.leaves(self.blocks)[0].shape[0]
-        return _prepend_axis(self.blocks.out_structure, axis_size=n)
+        n = jax.tree.leaves(self.operator)[0].shape[0]
+        return _prepend_axis(self.operator.out_structure, axis_size=n)
 
     def mv(self, x: PyTree[Inexact[Array, '...']]) -> PyTree[Inexact[Array, '...']]:
         axis = _get_mesh().axis_names[0]
 
         @jax.shard_map(out_specs=P(axis), check_vma=False)
-        def kernel(blocks, x):  # type: ignore[no-untyped-def]
+        def kernel(operator, x):  # type: ignore[no-untyped-def]
             def step(_, op):  # type: ignore[no-untyped-def]
                 return None, op.mv(x)
 
-            _, out = jax.lax.scan(step, None, blocks)
+            _, out = jax.lax.scan(step, None, operator)
             return out
 
-        blocks = jax.tree.map(lambda leaf: jax.reshard(leaf, P(axis)), self.blocks)
-        return kernel(blocks, x)
+        operator = jax.tree.map(lambda leaf: jax.reshard(leaf, P(axis)), self.operator)
+        return kernel(operator, x)
 
     def transpose(self) -> AbstractLinearOperator:
         with jax.sharding.use_abstract_mesh(_EMPTY_MESH):
-            blocks_T = self.blocks.T
-        return ScanBlockRowOperator(blocks_T, in_structure=self.out_structure)
+            operator_T = self.operator.T
+        return ScanBlockRowOperator(operator_T, in_structure=self.out_structure)
 
 
 class ScanBlockRowOperator(AbstractScanBlockOperator):
     """Row operator: applies each block to its own input slice and sums the results.
 
-    If ``blocks`` maps ``(N_in,) -> (N_out,)`` with leading axis ``N``, this operator
-    maps ``(N, N_in) -> (N_out,)``.
-
-    This is the transpose of ``ScanBlockColumnOperator``.
+    Given ``operator: (*in,) -> (*out,)`` with ``N`` slices, maps ``(N, *in) -> (*out,)``.
 
     Example — co-addition of time-ordered data back to a pixel map:
 
         >>> with jax.set_mesh(jax.make_mesh((4,), ('obs',))):
-        ...     HT = ScanBlockRowOperator.create(pointing_blocks_T)  # blocks: (N_obs, N_pix, N_tod)
-        ...     pixel_map = HT(tod)                                  # (N_obs, N_tod) -> (N_pix,)
+        ...     HT = ScanBlockRowOperator.create(pointing_op_T)  # leaves: (N, *in)
+        ...     pixel_map = HT(tod)                              # (N, *in) -> (*out,)
     """
 
     @classmethod
-    def _infer_in_structure(cls, blocks: AbstractLinearOperator) -> PyTree[jax.ShapeDtypeStruct]:
-        axis_size = jax.eval_shape(lambda: jax.tree.leaves(blocks)[0]).shape[0]
-        return _prepend_axis(blocks.in_structure, axis_size=axis_size)
+    def _infer_in_structure(cls, operator: AbstractLinearOperator) -> PyTree[jax.ShapeDtypeStruct]:
+        axis_size = jax.eval_shape(lambda: jax.tree.leaves(operator)[0]).shape[0]
+        return _prepend_axis(operator.in_structure, axis_size=axis_size)
 
     @property
     def out_structure(self) -> PyTree[jax.ShapeDtypeStruct]:
-        return self.blocks.out_structure
+        return self.operator.out_structure
 
     def mv(self, x: PyTree[Inexact[Array, '...']]) -> PyTree[Inexact[Array, '...']]:
         axis = _get_mesh().axis_names[0]
-        out_structure = self.blocks.out_structure
+        out_structure = self.operator.out_structure
 
         @jax.shard_map(out_specs=P(), check_vma=False)
-        def kernel(blocks, x):  # type: ignore[no-untyped-def]
+        def kernel(operator, x):  # type: ignore[no-untyped-def]
             def step(carry, args):  # type: ignore[no-untyped-def]
                 op, x_i = args
                 return tree.add(carry, op.mv(x_i)), None
 
             # pcast makes the replicated zeros match the varying carry type inside shard_map
             init = jax.lax.pcast(tree.zeros_like(out_structure), axis, to='varying')
-            out, _ = jax.lax.scan(step, init, (blocks, x))
+            out, _ = jax.lax.scan(step, init, (operator, x))
             return jax.lax.psum(out, axis_name=axis)
 
-        blocks = jax.tree.map(lambda a: jax.reshard(a, P(axis)), self.blocks)
+        operator = jax.tree.map(lambda a: jax.reshard(a, P(axis)), self.operator)
         x = jax.tree.map(lambda a: jax.reshard(a, P(axis)), x)
-        return kernel(blocks, x)
+        return kernel(operator, x)
 
     def transpose(self) -> AbstractLinearOperator:
         with jax.sharding.use_abstract_mesh(_EMPTY_MESH):
-            blocks_T = self.blocks.T
-        return ScanBlockColumnOperator(blocks_T, in_structure=self.out_structure)
+            operator_T = self.operator.T
+        return ScanBlockColumnOperator(operator_T, in_structure=self.out_structure)
 
 
 class ScanAdditionOperator(AbstractScanBlockOperator):
     """Addition operator: applies all blocks to the same input and sums the results.
 
-    If ``blocks`` maps ``(N_in,) -> (N_out,)`` with leading axis ``N``, this operator
-    maps ``(N_in,) -> (N_out,)``.
+    Given ``operator: (*in,) -> (*out,)`` with ``N`` slices, maps ``(*in,) -> (*out,)``.
 
-    This arises naturally as the reduction of ``ScanBlockRowOperator @ ScanBlockColumnOperator``,
+    Arises naturally as the reduction of ``ScanBlockRowOperator @ ScanBlockColumnOperator``,
     e.g. the normal equations operator ``H.T @ W @ H`` in mapmaking.
 
     Example — normal equations from a pointing and weighting operator:
 
         >>> with jax.set_mesh(jax.make_mesh((4,), ('obs',))):
         ...     A = (H.T @ W @ H).reduce()  # reduces to ScanAdditionOperator
-        ...     rhs = A(pixel_map)          # (N_pix,) -> (N_pix,)
+        ...     rhs = A(pixel_map)          # (*in,) -> (*out,)
     """
 
     @classmethod
-    def _infer_in_structure(cls, blocks: AbstractLinearOperator) -> PyTree[jax.ShapeDtypeStruct]:
-        return blocks.in_structure
+    def _infer_in_structure(cls, operator: AbstractLinearOperator) -> PyTree[jax.ShapeDtypeStruct]:
+        return operator.in_structure
 
     @property
     def out_structure(self) -> PyTree[jax.ShapeDtypeStruct]:
-        return self.blocks.out_structure
+        return self.operator.out_structure
 
     def mv(self, x: PyTree[Inexact[Array, '...']]) -> PyTree[Inexact[Array, '...']]:
         axis = _get_mesh().axis_names[0]
-        out_structure = self.blocks.out_structure
+        out_structure = self.operator.out_structure
 
         @jax.shard_map(out_specs=P(), check_vma=False)
-        def kernel(blocks, x):  # type: ignore[no-untyped-def]
+        def kernel(operator, x):  # type: ignore[no-untyped-def]
             def step(carry, op):  # type: ignore[no-untyped-def]
                 return tree.add(carry, op.mv(x)), None
 
             # pcast makes the replicated zeros match the varying carry type inside shard_map
             init = jax.lax.pcast(tree.zeros_like(out_structure), axis, to='varying')
-            out, _ = jax.lax.scan(step, init, blocks)
+            out, _ = jax.lax.scan(step, init, operator)
             return jax.lax.psum(out, axis_name=axis)
 
-        blocks = jax.tree.map(lambda leaf: jax.reshard(leaf, P(axis)), self.blocks)
-        return kernel(blocks, x)
+        operator = jax.tree.map(lambda leaf: jax.reshard(leaf, P(axis)), self.operator)
+        return kernel(operator, x)
 
     def transpose(self) -> AbstractLinearOperator:
         with jax.sharding.use_abstract_mesh(_EMPTY_MESH):
-            blocks_T = self.blocks.T
-        return ScanAdditionOperator(blocks_T, in_structure=self.out_structure)
+            operator_T = self.operator.T
+        return ScanAdditionOperator(operator_T, in_structure=self.out_structure)
 
 
 class AbstractScanFusionRule(AbstractBinaryRule):
@@ -267,7 +261,7 @@ class AbstractScanFusionRule(AbstractBinaryRule):
         assert isinstance(left, AbstractScanBlockOperator)  # mypy
         assert isinstance(right, AbstractScanBlockOperator)  # mypy
         with jax.sharding.use_abstract_mesh(_EMPTY_MESH):
-            composed = (left.blocks @ right.blocks).reduce()
+            composed = (left.operator @ right.operator).reduce()
         return [self.reduced_class.create(composed)]
 
 

--- a/src/furax/mapmaking/_scan_blocks.py
+++ b/src/furax/mapmaking/_scan_blocks.py
@@ -3,7 +3,7 @@ from typing import Self
 
 import jax
 from jax import Array
-from jax.sharding import AbstractMesh, NamedSharding
+from jax.sharding import AbstractMesh, Mesh, NamedSharding
 from jax.sharding import PartitionSpec as P
 from jaxtyping import Inexact, PyTree
 
@@ -23,7 +23,7 @@ class AbstractScanBlockOperator(AbstractLinearOperator, ABC):
         return cls(blocks, in_structure=in_structure)
 
     @property
-    def _mesh(self) -> AbstractMesh | None:
+    def _mesh(self) -> Mesh | AbstractMesh | None:
         s = jax.tree.leaves(self.in_structure)[0].sharding
         return s.mesh if isinstance(s, NamedSharding) else None
 

--- a/src/furax/mapmaking/_scan_blocks.py
+++ b/src/furax/mapmaking/_scan_blocks.py
@@ -3,6 +3,7 @@ from dataclasses import field
 
 import jax
 from jax import Array
+from jax.sharding import NamedSharding
 from jaxtyping import Inexact, PyTree
 
 from furax import AbstractLinearOperator, tree
@@ -77,10 +78,22 @@ class ScanBlockRowOperator(AbstractScanBlockOperator):
     """Block-row across the batch axis: stacked → single, sum over slices.
 
     Mirrors :class:`BlockRowOperator` but iterates via ``jax.lax.scan``.
+
+    An optional ``output_sharding`` triggers a ``with_sharding_constraint`` on
+    the (post-reduction) output — useful under distributed execution where the
+    summed-axis output should be replicated across devices.
     """
 
-    def __init__(self, blocks: AbstractLinearOperator, n_blocks: int) -> None:
+    output_sharding: NamedSharding | None = field(metadata={'static': True}, default=None)
+
+    def __init__(
+        self,
+        blocks: AbstractLinearOperator,
+        n_blocks: int,
+        output_sharding: NamedSharding | None = None,
+    ) -> None:
         in_structure = _prepend_axis(blocks.in_structure, n_blocks)
+        object.__setattr__(self, 'output_sharding', output_sharding)
         super().__init__(blocks, n_blocks, in_structure=in_structure)
 
     @property
@@ -96,14 +109,34 @@ class ScanBlockRowOperator(AbstractScanBlockOperator):
             return tree.add(carry, op.mv(x_i)), None
 
         out, _ = jax.lax.scan(step, init, (self.blocks, x))
+        if self.output_sharding is not None:
+            out = jax.lax.with_sharding_constraint(out, self.output_sharding)
         return out
 
     def transpose(self) -> AbstractLinearOperator:
         return ScanBlockColumnOperator(self.blocks.T, self.n_blocks)
 
+    def reduce(self) -> AbstractLinearOperator:
+        return ScanBlockRowOperator(self.blocks.reduce(), self.n_blocks, self.output_sharding)
+
 
 class ScanAdditionOperator(AbstractScanBlockOperator):
-    def __init__(self, blocks: AbstractLinearOperator, n_blocks: int) -> None:
+    """Sums per-block outputs into a single output (no leading batch axis).
+
+    An optional ``output_sharding`` triggers a ``with_sharding_constraint`` on
+    the summed result — useful under distributed execution where the reduction
+    output should be replicated across devices.
+    """
+
+    output_sharding: NamedSharding | None = field(metadata={'static': True}, default=None)
+
+    def __init__(
+        self,
+        blocks: AbstractLinearOperator,
+        n_blocks: int,
+        output_sharding: NamedSharding | None = None,
+    ) -> None:
+        object.__setattr__(self, 'output_sharding', output_sharding)
         super().__init__(blocks, n_blocks, in_structure=blocks.in_structure)
 
     @property
@@ -117,10 +150,15 @@ class ScanAdditionOperator(AbstractScanBlockOperator):
             return tree.add(carry, op.mv(x)), None
 
         out, _ = jax.lax.scan(step, init, self.blocks)
+        if self.output_sharding is not None:
+            out = jax.lax.with_sharding_constraint(out, self.output_sharding)
         return out
 
     def transpose(self) -> AbstractLinearOperator:
-        return ScanAdditionOperator(self.blocks.T, self.n_blocks)
+        return ScanAdditionOperator(self.blocks.T, self.n_blocks, self.output_sharding)
+
+    def reduce(self) -> AbstractLinearOperator:
+        return ScanAdditionOperator(self.blocks.reduce(), self.n_blocks, self.output_sharding)
 
 
 class AbstractScanFusionRule(AbstractBinaryRule):
@@ -158,10 +196,26 @@ class ScanBlockRowScanBlockDiagonalRule(AbstractScanFusionRule):
     right_operator_class = ScanBlockDiagonalOperator
     reduced_class = ScanBlockRowOperator
 
+    def apply(
+        self, left: AbstractLinearOperator, right: AbstractLinearOperator
+    ) -> list[AbstractLinearOperator]:
+        assert isinstance(left, ScanBlockRowOperator)  # mypy
+        assert isinstance(right, ScanBlockDiagonalOperator)  # mypy
+        composed = (left.blocks @ right.blocks).reduce()
+        return [ScanBlockRowOperator(composed, left.n_blocks, left.output_sharding)]
+
 
 class ScanBlockRowScanBlockColumnRule(AbstractScanFusionRule):
-    """``ScanBlockRow @ ScanBlockColumn = _ScanSumOperator``."""
+    """``ScanBlockRow @ ScanBlockColumn = ScanAddition``."""
 
     left_operator_class = ScanBlockRowOperator
     right_operator_class = ScanBlockColumnOperator
     reduced_class = ScanAdditionOperator
+
+    def apply(
+        self, left: AbstractLinearOperator, right: AbstractLinearOperator
+    ) -> list[AbstractLinearOperator]:
+        assert isinstance(left, ScanBlockRowOperator)  # mypy
+        assert isinstance(right, ScanBlockColumnOperator)  # mypy
+        composed = (left.blocks @ right.blocks).reduce()
+        return [ScanAdditionOperator(composed, left.n_blocks, left.output_sharding)]

--- a/src/furax/mapmaking/_scan_blocks.py
+++ b/src/furax/mapmaking/_scan_blocks.py
@@ -1,0 +1,167 @@
+from abc import ABC
+from dataclasses import field
+
+import jax
+from jax import Array
+from jaxtyping import Inexact, PyTree
+
+from furax import AbstractLinearOperator, tree
+from furax.core.rules import AbstractBinaryRule
+
+
+def _prepend_axis(structure: PyTree[jax.ShapeDtypeStruct], n: int) -> PyTree[jax.ShapeDtypeStruct]:
+    return jax.tree.map(lambda s: jax.ShapeDtypeStruct((n, *s.shape), s.dtype), structure)
+
+
+class AbstractScanBlockOperator(AbstractLinearOperator, ABC):
+    blocks: AbstractLinearOperator
+    n_blocks: int = field(metadata={'static': True})
+
+    def __init__(
+        self,
+        blocks: AbstractLinearOperator,
+        n_blocks: int,
+        *,
+        in_structure: PyTree[jax.ShapeDtypeStruct],
+    ) -> None:
+        object.__setattr__(self, 'blocks', blocks)
+        object.__setattr__(self, 'n_blocks', n_blocks)
+        super().__init__(in_structure=in_structure)
+
+    def reduce(self) -> AbstractLinearOperator:
+        return type(self)(self.blocks.reduce(), self.n_blocks)  # type: ignore[call-arg]
+
+
+class ScanBlockDiagonalOperator(AbstractScanBlockOperator):
+    def __init__(self, blocks: AbstractLinearOperator, n_blocks: int) -> None:
+        in_structure = _prepend_axis(blocks.in_structure, n_blocks)
+        super().__init__(blocks, n_blocks, in_structure=in_structure)
+
+    @property
+    def out_structure(self) -> PyTree[jax.ShapeDtypeStruct]:
+        return _prepend_axis(self.blocks.out_structure, self.n_blocks)
+
+    def mv(self, x: PyTree[Inexact[Array, '...']]) -> PyTree[Inexact[Array, '...']]:
+        def step(_, args):  # type: ignore[no-untyped-def]
+            op, x_i = args
+            return None, op.mv(x_i)
+
+        _, out = jax.lax.scan(step, None, (self.blocks, x))
+        return out
+
+    def transpose(self) -> AbstractLinearOperator:
+        return ScanBlockDiagonalOperator(self.blocks.T, self.n_blocks)
+
+
+class ScanBlockColumnOperator(AbstractScanBlockOperator):
+    def __init__(self, blocks: AbstractLinearOperator, n_blocks: int) -> None:
+        # no leading dim because input is broadcast
+        super().__init__(blocks, n_blocks, in_structure=blocks.in_structure)
+
+    @property
+    def out_structure(self) -> PyTree[jax.ShapeDtypeStruct]:
+        return _prepend_axis(self.blocks.out_structure, self.n_blocks)
+
+    def mv(self, x: PyTree[Inexact[Array, '...']]) -> PyTree[Inexact[Array, '...']]:
+        def step(_, op):  # type: ignore[no-untyped-def]
+            return None, op.mv(x)
+
+        _, out = jax.lax.scan(step, None, self.blocks)
+        return out
+
+    def transpose(self) -> AbstractLinearOperator:
+        return ScanBlockRowOperator(self.blocks.T, self.n_blocks)
+
+
+class ScanBlockRowOperator(AbstractScanBlockOperator):
+    """Block-row across the batch axis: stacked → single, sum over slices.
+
+    Mirrors :class:`BlockRowOperator` but iterates via ``jax.lax.scan``.
+    """
+
+    def __init__(self, blocks: AbstractLinearOperator, n_blocks: int) -> None:
+        in_structure = _prepend_axis(blocks.in_structure, n_blocks)
+        super().__init__(blocks, n_blocks, in_structure=in_structure)
+
+    @property
+    def out_structure(self) -> PyTree[jax.ShapeDtypeStruct]:
+        # no leading dim because sum over batch dimension
+        return self.blocks.out_structure
+
+    def mv(self, x: PyTree[Inexact[Array, '...']]) -> PyTree[Inexact[Array, '...']]:
+        init = tree.zeros_like(self.blocks.out_structure)
+
+        def step(carry, args):  # type: ignore[no-untyped-def]
+            op, x_i = args
+            return tree.add(carry, op.mv(x_i)), None
+
+        out, _ = jax.lax.scan(step, init, (self.blocks, x))
+        return out
+
+    def transpose(self) -> AbstractLinearOperator:
+        return ScanBlockColumnOperator(self.blocks.T, self.n_blocks)
+
+
+class ScanAdditionOperator(AbstractScanBlockOperator):
+    def __init__(self, blocks: AbstractLinearOperator, n_blocks: int) -> None:
+        super().__init__(blocks, n_blocks, in_structure=blocks.in_structure)
+
+    @property
+    def out_structure(self) -> PyTree[jax.ShapeDtypeStruct]:
+        return self.blocks.out_structure
+
+    def mv(self, x: PyTree[Inexact[Array, '...']]) -> PyTree[Inexact[Array, '...']]:
+        init = tree.zeros_like(self.blocks.out_structure)
+
+        def step(carry, op):  # type: ignore[no-untyped-def]
+            return tree.add(carry, op.mv(x)), None
+
+        out, _ = jax.lax.scan(step, init, self.blocks)
+        return out
+
+    def transpose(self) -> AbstractLinearOperator:
+        return ScanAdditionOperator(self.blocks.T, self.n_blocks)
+
+
+class AbstractScanFusionRule(AbstractBinaryRule):
+    reduced_class: type[AbstractScanBlockOperator]
+
+    def apply(
+        self, left: AbstractLinearOperator, right: AbstractLinearOperator
+    ) -> list[AbstractLinearOperator]:
+        assert isinstance(left, AbstractScanBlockOperator)  # mypy
+        assert isinstance(right, AbstractScanBlockOperator)  # mypy
+        composed = (left.blocks @ right.blocks).reduce()
+        return [self.reduced_class(composed, left.n_blocks)]  # type: ignore[call-arg]
+
+
+class ScanBlockDiagonalScanBlockDiagonalRule(AbstractScanFusionRule):
+    """``ScanBlockDiagonal @ ScanBlockDiagonal = ScanBlockDiagonal``."""
+
+    left_operator_class = ScanBlockDiagonalOperator
+    right_operator_class = ScanBlockDiagonalOperator
+    reduced_class = ScanBlockDiagonalOperator
+
+
+class ScanBlockDiagonalScanBlockColumnRule(AbstractScanFusionRule):
+    """``ScanBlockDiagonal @ ScanBlockColumn = ScanBlockColumn``."""
+
+    left_operator_class = ScanBlockDiagonalOperator
+    right_operator_class = ScanBlockColumnOperator
+    reduced_class = ScanBlockColumnOperator
+
+
+class ScanBlockRowScanBlockDiagonalRule(AbstractScanFusionRule):
+    """``ScanBlockRow @ ScanBlockDiagonal = ScanBlockRow``."""
+
+    left_operator_class = ScanBlockRowOperator
+    right_operator_class = ScanBlockDiagonalOperator
+    reduced_class = ScanBlockRowOperator
+
+
+class ScanBlockRowScanBlockColumnRule(AbstractScanFusionRule):
+    """``ScanBlockRow @ ScanBlockColumn = _ScanSumOperator``."""
+
+    left_operator_class = ScanBlockRowOperator
+    right_operator_class = ScanBlockColumnOperator
+    reduced_class = ScanAdditionOperator

--- a/src/furax/mapmaking/_scan_blocks.py
+++ b/src/furax/mapmaking/_scan_blocks.py
@@ -1,9 +1,9 @@
-from abc import ABC
-from dataclasses import field
+from abc import ABC, abstractmethod
+from typing import Self
 
 import jax
 from jax import Array
-from jax.sharding import NamedSharding
+from jax.sharding import AbstractMesh, NamedSharding
 from jax.sharding import PartitionSpec as P
 from jaxtyping import Inexact, PyTree
 
@@ -11,191 +11,230 @@ from furax import AbstractLinearOperator, tree
 from furax.core.rules import AbstractBinaryRule
 
 
-def _prepend_axis(structure: PyTree[jax.ShapeDtypeStruct], n: int) -> PyTree[jax.ShapeDtypeStruct]:
-    return jax.tree.map(lambda s: jax.ShapeDtypeStruct((n, *s.shape), s.dtype), structure)
-
-
 class AbstractScanBlockOperator(AbstractLinearOperator, ABC):
     blocks: AbstractLinearOperator
-    n_blocks: int = field(metadata={'static': True})
 
-    def __init__(
-        self,
-        blocks: AbstractLinearOperator,
-        n_blocks: int,
-        *,
-        in_structure: PyTree[jax.ShapeDtypeStruct],
-    ) -> None:
-        object.__setattr__(self, 'blocks', blocks)
-        object.__setattr__(self, 'n_blocks', n_blocks)
-        super().__init__(in_structure=in_structure)
+    @classmethod
+    def create(cls, blocks: AbstractLinearOperator) -> Self:
+        if len(jax.tree.leaves(blocks)) == 0:
+            msg = 'unable to infer structures from blocks with no leaf'
+            raise RuntimeError(msg)
+        in_structure = cls._infer_in_structure(blocks)
+        return cls(blocks, in_structure=in_structure)
+
+    @property
+    def _mesh(self) -> AbstractMesh | None:
+        s = jax.tree.leaves(self.in_structure)[0].sharding
+        return s.mesh if isinstance(s, NamedSharding) else None
+
+    @classmethod
+    @abstractmethod
+    def _infer_in_structure(cls, blocks: AbstractLinearOperator) -> PyTree[jax.ShapeDtypeStruct]:
+        """Returns sharding-aware in_structure"""
+
+    @property
+    def _in_specs(self) -> P:
+        """PartitionSpec for obs-sharded blocks. Only valid when sharded."""
+        return P(self._mesh.axis_names)  # type: ignore[union-attr]
+
+    @property
+    @abstractmethod
+    def _out_specs(self) -> P:
+        """PartitionSpec for shard_map out_specs. Only valid when sharded."""
 
     def reduce(self) -> AbstractLinearOperator:
-        return type(self)(self.blocks.reduce(), self.n_blocks)  # type: ignore[call-arg]
+        return type(self)(self.blocks.reduce(), in_structure=self.in_structure)
+
+
+def _match_sharding_rank(sharding: NamedSharding | None, rank: int) -> NamedSharding | None:
+    if sharding is None or len(sharding.spec) >= rank:
+        return sharding
+    padding = (None,) * (rank - len(sharding.spec))
+    return NamedSharding(sharding.mesh, P(*sharding.spec, *padding))
+
+
+def _augment_structure(
+    structure: PyTree[jax.ShapeDtypeStruct],
+    *,
+    axis_size: int | None = None,
+    sharding: NamedSharding | None = None,
+) -> PyTree[jax.ShapeDtypeStruct]:
+    def transform(s: jax.ShapeDtypeStruct) -> jax.ShapeDtypeStruct:
+        shape = (axis_size, *s.shape) if axis_size is not None else s.shape
+        new_sharding = _match_sharding_rank(sharding, len(shape))
+        return jax.ShapeDtypeStruct(shape, s.dtype, sharding=new_sharding)
+
+    return jax.tree.map(transform, structure)
+
+
+def _leaf_named_sharding(blocks: AbstractLinearOperator) -> NamedSharding | None:
+    leaf_shape = jax.eval_shape(lambda: jax.tree.leaves(blocks)[0])
+    s = leaf_shape.sharding
+    return s if isinstance(s, NamedSharding) else None
 
 
 class ScanBlockDiagonalOperator(AbstractScanBlockOperator):
-    def __init__(self, blocks: AbstractLinearOperator, n_blocks: int) -> None:
-        in_structure = _prepend_axis(blocks.in_structure, n_blocks)
-        super().__init__(blocks, n_blocks, in_structure=in_structure)
-
     @property
-    def out_structure(self) -> PyTree[jax.ShapeDtypeStruct]:
-        return _prepend_axis(self.blocks.out_structure, self.n_blocks)
+    def _out_specs(self) -> P:
+        return P(self._mesh.axis_names)  # type: ignore[union-attr]
+
+    @classmethod
+    def _infer_in_structure(cls, blocks: AbstractLinearOperator) -> PyTree[jax.ShapeDtypeStruct]:
+        leaf_shape = jax.eval_shape(lambda: jax.tree.leaves(blocks)[0])
+        leaf_sharding = leaf_shape.sharding
+        if isinstance(leaf_sharding, NamedSharding):
+            sharding = NamedSharding(leaf_sharding.mesh, P(leaf_sharding.spec[0]))
+        else:
+            sharding = None
+        return _augment_structure(
+            blocks.in_structure, axis_size=leaf_shape.shape[0], sharding=sharding
+        )
 
     def mv(self, x: PyTree[Inexact[Array, '...']]) -> PyTree[Inexact[Array, '...']]:
-        def step(_, args):  # type: ignore[no-untyped-def]
-            op, x_i = args
-            return None, op.mv(x_i)
+        def kernel(blocks, x):  # type: ignore[no-untyped-def]
+            def step(_, args):  # type: ignore[no-untyped-def]
+                op, x_i = args
+                return None, op.mv(x_i)
 
-        _, out = jax.lax.scan(step, None, (self.blocks, x))
-        return out
+            _, out = jax.lax.scan(step, None, (blocks, x))
+            return out
+
+        mesh = self._mesh
+        if mesh is None:
+            return kernel(self.blocks, x)
+
+        in_sharding = NamedSharding(mesh, self._in_specs)
+        # shard_map validates in_specs against actual array sharding; reshard sets it
+        # explicitly so the check passes even when sharding is lost inside a JIT trace
+        blocks = jax.tree.map(lambda a: jax.reshard(a, in_sharding), self.blocks)
+        x = jax.tree.map(lambda a: jax.reshard(a, in_sharding), x)
+        return jax.shard_map(kernel, mesh=mesh, out_specs=self._out_specs)(blocks, x)
 
     def transpose(self) -> AbstractLinearOperator:
-        return ScanBlockDiagonalOperator(self.blocks.T, self.n_blocks)
+        return ScanBlockDiagonalOperator(self.blocks.T, in_structure=self.out_structure)
 
 
 class ScanBlockColumnOperator(AbstractScanBlockOperator):
-    def __init__(self, blocks: AbstractLinearOperator, n_blocks: int) -> None:
-        # no leading dim because input is broadcast
-        super().__init__(blocks, n_blocks, in_structure=blocks.in_structure)
-
     @property
-    def out_structure(self) -> PyTree[jax.ShapeDtypeStruct]:
-        return _prepend_axis(self.blocks.out_structure, self.n_blocks)
+    def _out_specs(self) -> P:
+        return P(self._mesh.axis_names)  # type: ignore[union-attr]
+
+    @classmethod
+    def _infer_in_structure(cls, blocks: AbstractLinearOperator) -> PyTree[jax.ShapeDtypeStruct]:
+        sharding = _leaf_named_sharding(blocks)
+        replicated = NamedSharding(sharding.mesh, P()) if sharding is not None else None
+        return _augment_structure(blocks.in_structure, sharding=replicated)
 
     def mv(self, x: PyTree[Inexact[Array, '...']]) -> PyTree[Inexact[Array, '...']]:
-        def step(_, op):  # type: ignore[no-untyped-def]
-            return None, op.mv(x)
+        def kernel(blocks, x):  # type: ignore[no-untyped-def]
+            def step(_, op):  # type: ignore[no-untyped-def]
+                return None, op.mv(x)
 
-        _, out = jax.lax.scan(step, None, self.blocks)
-        return out
+            _, out = jax.lax.scan(step, None, blocks)
+            return out
+
+        mesh = self._mesh
+        if mesh is None:
+            return kernel(self.blocks, x)
+
+        # see Diagonal.mv
+        blocks = jax.tree.map(
+            lambda a: jax.reshard(a, NamedSharding(mesh, self._in_specs)), self.blocks
+        )
+        return jax.shard_map(kernel, mesh=mesh, out_specs=self._out_specs)(blocks, x)
 
     def transpose(self) -> AbstractLinearOperator:
-        return ScanBlockRowOperator(self.blocks.T, self.n_blocks)
+        return ScanBlockRowOperator(self.blocks.T, in_structure=self.out_structure)
 
 
 class ScanBlockRowOperator(AbstractScanBlockOperator):
-    """Block-row across the batch axis: stacked → single, sum over slices.
-
-    Mirrors :class:`BlockRowOperator` but iterates via ``jax.lax.scan``.
-
-    An optional ``output_sharding`` triggers a ``with_sharding_constraint`` on
-    the (post-reduction) output — useful under distributed execution where the
-    summed-axis output should be replicated across devices.
-    """
-
-    output_sharding: NamedSharding | None = field(metadata={'static': True}, default=None)
-
-    def __init__(
-        self,
-        blocks: AbstractLinearOperator,
-        n_blocks: int,
-        output_sharding: NamedSharding | None = None,
-    ) -> None:
-        in_structure = _prepend_axis(blocks.in_structure, n_blocks)
-        object.__setattr__(self, 'output_sharding', output_sharding)
-        super().__init__(blocks, n_blocks, in_structure=in_structure)
-
     @property
-    def out_structure(self) -> PyTree[jax.ShapeDtypeStruct]:
-        # no leading dim because sum over batch dimension
-        return self.blocks.out_structure
+    def _out_specs(self) -> P:
+        return P()
+
+    @classmethod
+    def _infer_in_structure(cls, blocks: AbstractLinearOperator) -> PyTree[jax.ShapeDtypeStruct]:
+        leaf_shape = jax.eval_shape(lambda: jax.tree.leaves(blocks)[0])
+        if isinstance(leaf_shape.sharding, NamedSharding):
+            sharding = NamedSharding(leaf_shape.sharding.mesh, P(leaf_shape.sharding.spec[0]))
+        else:
+            sharding = None
+        return _augment_structure(
+            blocks.in_structure, axis_size=leaf_shape.shape[0], sharding=sharding
+        )
 
     def mv(self, x: PyTree[Inexact[Array, '...']]) -> PyTree[Inexact[Array, '...']]:
         out_structure = self.blocks.out_structure
+        zeros = tree.zeros_like(out_structure)
 
-        if self.output_sharding is None:
-            init = tree.zeros_like(out_structure)
-
+        def kernel(blocks, x, init):  # type: ignore[no-untyped-def]
             def step(carry, args):  # type: ignore[no-untyped-def]
                 op, x_i = args
                 return tree.add(carry, op.mv(x_i)), None
 
-            out, _ = jax.lax.scan(step, init, (self.blocks, x))
+            out, _ = jax.lax.scan(step, init, (blocks, x))
             return out
 
-        mesh = self.output_sharding.mesh
-        obs_sharding = NamedSharding(mesh, P('obs'))
-        blocks = jax.tree.map(lambda a: jax.reshard(a, obs_sharding), self.blocks)
-        x = jax.tree.map(lambda a: jax.reshard(a, obs_sharding), x)
+        mesh = self._mesh
+        if mesh is None:
+            return kernel(self.blocks, x, zeros)
 
-        @jax.shard_map(mesh=mesh, in_specs=(P('obs'), P('obs')), out_specs=P(), check_vma=False)
-        def local_mv(local_blocks: AbstractLinearOperator, local_x: PyTree) -> PyTree:
-            init = tree.zeros_like(out_structure)
+        in_sharding = NamedSharding(mesh, self._in_specs)
+        # see Diagonal.mv
+        blocks = jax.tree.map(lambda a: jax.reshard(a, in_sharding), self.blocks)
+        x = jax.tree.map(lambda a: jax.reshard(a, in_sharding), x)
 
-            def step(carry, args):  # type: ignore[no-untyped-def]
-                op, x_i = args
-                return tree.add(carry, op.mv(x_i)), None
+        def sharded_kernel(blocks, x):  # type: ignore[no-untyped-def]
+            # pcast makes the replicated zeros match the varying carry type inside shard_map
+            init = jax.lax.pcast(zeros, mesh.axis_names, to='varying')
+            return jax.lax.psum(kernel(blocks, x, init), axis_name=mesh.axis_names)
 
-            out, _ = jax.lax.scan(step, init, (local_blocks, local_x))
-            return jax.lax.psum(out, axis_name='obs')
-
-        return local_mv(blocks, x)
+        return jax.shard_map(sharded_kernel, mesh=mesh, out_specs=self._out_specs)(blocks, x)
 
     def transpose(self) -> AbstractLinearOperator:
-        return ScanBlockColumnOperator(self.blocks.T, self.n_blocks)
-
-    def reduce(self) -> AbstractLinearOperator:
-        return ScanBlockRowOperator(self.blocks.reduce(), self.n_blocks, self.output_sharding)
+        return ScanBlockColumnOperator(self.blocks.T, in_structure=self.out_structure)
 
 
 class ScanAdditionOperator(AbstractScanBlockOperator):
-    """Sums per-block outputs into a single output (no leading batch axis).
-
-    An optional ``output_sharding`` triggers a ``with_sharding_constraint`` on
-    the summed result — useful under distributed execution where the reduction
-    output should be replicated across devices.
-    """
-
-    output_sharding: NamedSharding | None = field(metadata={'static': True}, default=None)
-
-    def __init__(
-        self,
-        blocks: AbstractLinearOperator,
-        n_blocks: int,
-        output_sharding: NamedSharding | None = None,
-    ) -> None:
-        object.__setattr__(self, 'output_sharding', output_sharding)
-        super().__init__(blocks, n_blocks, in_structure=blocks.in_structure)
-
     @property
-    def out_structure(self) -> PyTree[jax.ShapeDtypeStruct]:
-        return self.blocks.out_structure
+    def _out_specs(self) -> P:
+        return P()
+
+    @classmethod
+    def _infer_in_structure(cls, blocks: AbstractLinearOperator) -> PyTree[jax.ShapeDtypeStruct]:
+        sharding = _leaf_named_sharding(blocks)
+        replicated = NamedSharding(sharding.mesh, P()) if sharding is not None else None
+        return _augment_structure(blocks.in_structure, sharding=replicated)
 
     def mv(self, x: PyTree[Inexact[Array, '...']]) -> PyTree[Inexact[Array, '...']]:
         out_structure = self.blocks.out_structure
+        zeros = tree.zeros_like(out_structure)
 
-        if self.output_sharding is None:
-            init = tree.zeros_like(out_structure)
-
+        def kernel(blocks, x, init):  # type: ignore[no-untyped-def]
             def step(carry, op):  # type: ignore[no-untyped-def]
                 return tree.add(carry, op.mv(x)), None
 
-            out, _ = jax.lax.scan(step, init, self.blocks)
+            out, _ = jax.lax.scan(step, init, blocks)
             return out
 
-        mesh = self.output_sharding.mesh
-        obs_sharding = NamedSharding(mesh, P('obs'))
-        blocks = jax.tree.map(lambda a: jax.reshard(a, obs_sharding), self.blocks)
+        mesh = self._mesh
+        if mesh is None:
+            return kernel(self.blocks, x, zeros)
 
-        @jax.shard_map(mesh=mesh, in_specs=(P('obs'), P()), out_specs=P(), check_vma=False)
-        def local_mv(local_blocks: AbstractLinearOperator, local_x: PyTree) -> PyTree:
-            init = tree.zeros_like(out_structure)
+        # see Diagonal.mv
+        blocks = jax.tree.map(
+            lambda a: jax.reshard(a, NamedSharding(mesh, self._in_specs)), self.blocks
+        )
 
-            def step(carry, op):  # type: ignore[no-untyped-def]
-                return tree.add(carry, op.mv(local_x)), None
+        def sharded_kernel(blocks, x):  # type: ignore[no-untyped-def]
+            # pcast makes the replicated zeros match the varying carry type inside shard_map
+            init = jax.lax.pcast(zeros, mesh.axis_names, to='varying')
+            return jax.lax.psum(kernel(blocks, x, init), axis_name=mesh.axis_names)
 
-            out, _ = jax.lax.scan(step, init, local_blocks)
-            return jax.lax.psum(out, axis_name='obs')
-
-        return local_mv(blocks, x)
+        return jax.shard_map(sharded_kernel, mesh=mesh, out_specs=self._out_specs)(blocks, x)
 
     def transpose(self) -> AbstractLinearOperator:
-        return ScanAdditionOperator(self.blocks.T, self.n_blocks, self.output_sharding)
-
-    def reduce(self) -> AbstractLinearOperator:
-        return ScanAdditionOperator(self.blocks.reduce(), self.n_blocks, self.output_sharding)
+        return ScanAdditionOperator(self.blocks.T, in_structure=self.out_structure)
 
 
 class AbstractScanFusionRule(AbstractBinaryRule):
@@ -207,7 +246,7 @@ class AbstractScanFusionRule(AbstractBinaryRule):
         assert isinstance(left, AbstractScanBlockOperator)  # mypy
         assert isinstance(right, AbstractScanBlockOperator)  # mypy
         composed = (left.blocks @ right.blocks).reduce()
-        return [self.reduced_class(composed, left.n_blocks)]  # type: ignore[call-arg]
+        return [self.reduced_class.create(composed)]
 
 
 class ScanBlockDiagonalScanBlockDiagonalRule(AbstractScanFusionRule):
@@ -233,14 +272,6 @@ class ScanBlockRowScanBlockDiagonalRule(AbstractScanFusionRule):
     right_operator_class = ScanBlockDiagonalOperator
     reduced_class = ScanBlockRowOperator
 
-    def apply(
-        self, left: AbstractLinearOperator, right: AbstractLinearOperator
-    ) -> list[AbstractLinearOperator]:
-        assert isinstance(left, ScanBlockRowOperator)  # mypy
-        assert isinstance(right, ScanBlockDiagonalOperator)  # mypy
-        composed = (left.blocks @ right.blocks).reduce()
-        return [ScanBlockRowOperator(composed, left.n_blocks, left.output_sharding)]
-
 
 class ScanBlockRowScanBlockColumnRule(AbstractScanFusionRule):
     """``ScanBlockRow @ ScanBlockColumn = ScanAddition``."""
@@ -248,11 +279,3 @@ class ScanBlockRowScanBlockColumnRule(AbstractScanFusionRule):
     left_operator_class = ScanBlockRowOperator
     right_operator_class = ScanBlockColumnOperator
     reduced_class = ScanAdditionOperator
-
-    def apply(
-        self, left: AbstractLinearOperator, right: AbstractLinearOperator
-    ) -> list[AbstractLinearOperator]:
-        assert isinstance(left, ScanBlockRowOperator)  # mypy
-        assert isinstance(right, ScanBlockColumnOperator)  # mypy
-        composed = (left.blocks @ right.blocks).reduce()
-        return [ScanAdditionOperator(composed, left.n_blocks, left.output_sharding)]

--- a/src/furax/mapmaking/_scan_blocks.py
+++ b/src/furax/mapmaking/_scan_blocks.py
@@ -24,6 +24,18 @@ def _get_mesh() -> AbstractMesh:
 
 
 class AbstractScanBlockOperator(AbstractLinearOperator, ABC):
+    """Base class for operators built from N stacked blocks.
+
+    ``blocks`` is an operator whose leaves carry a leading axis of size ``N`` obtained by
+    stacking N individual operators into a single pytree beforehand (e.g. with
+    ``jax.tree.map(jnp.stack, list_of_ops)``).  ``blocks`` itself is not expected to handle
+    that leading axis: ``mv`` uses ``jax.lax.scan`` to peel off one slice at a time and feed
+    it to the underlying operator logic, inside a ``shard_map`` kernel that distributes the
+    work across devices along the first mesh axis.
+
+    An active mesh context is required when calling ``mv``; use ``jax.set_mesh`` beforehand.
+    """
+
     blocks: AbstractLinearOperator
 
     @classmethod
@@ -58,6 +70,20 @@ def _prepend_axis(
 
 
 class ScanBlockDiagonalOperator(AbstractScanBlockOperator):
+    """Block-diagonal operator: each block acts independently on its own slice of the input.
+
+    If ``blocks`` maps ``(N_in,) -> (N_out,)`` with leading axis ``N``, this operator
+    maps ``(N, N_in) -> (N, N_out)``.
+
+    Transpose is another ``ScanBlockDiagonalOperator`` over the transposed blocks.
+
+    Example — per-observation noise weighting (square blocks, ``N_in == N_out``):
+
+        >>> with jax.set_mesh(jax.make_mesh((4,), ('obs',))):
+        ...     W = ScanBlockDiagonalOperator.create(noise_blocks)  # blocks: (N_obs, N, N)
+        ...     weighted = W(samples)                               # (N_obs, N) -> (N_obs, N)
+    """
+
     @classmethod
     def _infer_in_structure(cls, blocks: AbstractLinearOperator) -> PyTree[jax.ShapeDtypeStruct]:
         axis_size = jax.eval_shape(lambda: jax.tree.leaves(blocks)[0]).shape[0]
@@ -93,6 +119,20 @@ class ScanBlockDiagonalOperator(AbstractScanBlockOperator):
 
 
 class ScanBlockColumnOperator(AbstractScanBlockOperator):
+    """Column operator: applies all blocks to the same input and stacks the results.
+
+    If ``blocks`` maps ``(N_in,) -> (N_out,)`` with leading axis ``N``, this operator
+    maps ``(N_in,) -> (N, N_out)``.
+
+    Transpose is a ``ScanBlockRowOperator`` that sums contributions across blocks.
+
+    Example — pointing matrix from pixel map to time-ordered data:
+
+        >>> with jax.set_mesh(jax.make_mesh((4,), ('obs',))):
+        ...     H = ScanBlockColumnOperator.create(pointing_blocks)  # blocks: (N_obs, N_tod, N_pix)
+        ...     tod = H(pixel_map)                                   # (N_pix,) -> (N_obs, N_tod)
+    """
+
     @classmethod
     def _infer_in_structure(cls, blocks: AbstractLinearOperator) -> PyTree[jax.ShapeDtypeStruct]:
         return blocks.in_structure
@@ -123,6 +163,20 @@ class ScanBlockColumnOperator(AbstractScanBlockOperator):
 
 
 class ScanBlockRowOperator(AbstractScanBlockOperator):
+    """Row operator: applies each block to its own input slice and sums the results.
+
+    If ``blocks`` maps ``(N_in,) -> (N_out,)`` with leading axis ``N``, this operator
+    maps ``(N, N_in) -> (N_out,)``.
+
+    This is the transpose of ``ScanBlockColumnOperator``.
+
+    Example — co-addition of time-ordered data back to a pixel map:
+
+        >>> with jax.set_mesh(jax.make_mesh((4,), ('obs',))):
+        ...     HT = ScanBlockRowOperator.create(pointing_blocks_T)  # blocks: (N_obs, N_pix, N_tod)
+        ...     pixel_map = HT(tod)                                  # (N_obs, N_tod) -> (N_pix,)
+    """
+
     @classmethod
     def _infer_in_structure(cls, blocks: AbstractLinearOperator) -> PyTree[jax.ShapeDtypeStruct]:
         axis_size = jax.eval_shape(lambda: jax.tree.leaves(blocks)[0]).shape[0]
@@ -158,6 +212,21 @@ class ScanBlockRowOperator(AbstractScanBlockOperator):
 
 
 class ScanAdditionOperator(AbstractScanBlockOperator):
+    """Addition operator: applies all blocks to the same input and sums the results.
+
+    If ``blocks`` maps ``(N_in,) -> (N_out,)`` with leading axis ``N``, this operator
+    maps ``(N_in,) -> (N_out,)``.
+
+    This arises naturally as the reduction of ``ScanBlockRowOperator @ ScanBlockColumnOperator``,
+    e.g. the normal equations operator ``H.T @ W @ H`` in mapmaking.
+
+    Example — normal equations from a pointing and weighting operator:
+
+        >>> with jax.set_mesh(jax.make_mesh((4,), ('obs',))):
+        ...     A = (H.T @ W @ H).reduce()  # reduces to ScanAdditionOperator
+        ...     rhs = A(pixel_map)          # (N_pix,) -> (N_pix,)
+    """
+
     @classmethod
     def _infer_in_structure(cls, blocks: AbstractLinearOperator) -> PyTree[jax.ShapeDtypeStruct]:
         return blocks.in_structure

--- a/src/furax/mapmaking/_scan_blocks.py
+++ b/src/furax/mapmaking/_scan_blocks.py
@@ -4,6 +4,7 @@ from dataclasses import field
 import jax
 from jax import Array
 from jax.sharding import NamedSharding
+from jax.sharding import PartitionSpec as P
 from jaxtyping import Inexact, PyTree
 
 from furax import AbstractLinearOperator, tree
@@ -102,16 +103,35 @@ class ScanBlockRowOperator(AbstractScanBlockOperator):
         return self.blocks.out_structure
 
     def mv(self, x: PyTree[Inexact[Array, '...']]) -> PyTree[Inexact[Array, '...']]:
-        init = tree.zeros_like(self.blocks.out_structure)
+        out_structure = self.blocks.out_structure
 
-        def step(carry, args):  # type: ignore[no-untyped-def]
-            op, x_i = args
-            return tree.add(carry, op.mv(x_i)), None
+        if self.output_sharding is None:
+            init = tree.zeros_like(out_structure)
 
-        out, _ = jax.lax.scan(step, init, (self.blocks, x))
-        if self.output_sharding is not None:
-            out = jax.lax.with_sharding_constraint(out, self.output_sharding)
-        return out
+            def step(carry, args):  # type: ignore[no-untyped-def]
+                op, x_i = args
+                return tree.add(carry, op.mv(x_i)), None
+
+            out, _ = jax.lax.scan(step, init, (self.blocks, x))
+            return out
+
+        mesh = self.output_sharding.mesh
+        obs_sharding = NamedSharding(mesh, P('obs'))
+        blocks = jax.tree.map(lambda a: jax.reshard(a, obs_sharding), self.blocks)
+        x = jax.tree.map(lambda a: jax.reshard(a, obs_sharding), x)
+
+        @jax.shard_map(mesh=mesh, in_specs=(P('obs'), P('obs')), out_specs=P(), check_vma=False)
+        def local_mv(local_blocks: AbstractLinearOperator, local_x: PyTree) -> PyTree:
+            init = tree.zeros_like(out_structure)
+
+            def step(carry, args):  # type: ignore[no-untyped-def]
+                op, x_i = args
+                return tree.add(carry, op.mv(x_i)), None
+
+            out, _ = jax.lax.scan(step, init, (local_blocks, local_x))
+            return jax.lax.psum(out, axis_name='obs')
+
+        return local_mv(blocks, x)
 
     def transpose(self) -> AbstractLinearOperator:
         return ScanBlockColumnOperator(self.blocks.T, self.n_blocks)
@@ -144,15 +164,32 @@ class ScanAdditionOperator(AbstractScanBlockOperator):
         return self.blocks.out_structure
 
     def mv(self, x: PyTree[Inexact[Array, '...']]) -> PyTree[Inexact[Array, '...']]:
-        init = tree.zeros_like(self.blocks.out_structure)
+        out_structure = self.blocks.out_structure
 
-        def step(carry, op):  # type: ignore[no-untyped-def]
-            return tree.add(carry, op.mv(x)), None
+        if self.output_sharding is None:
+            init = tree.zeros_like(out_structure)
 
-        out, _ = jax.lax.scan(step, init, self.blocks)
-        if self.output_sharding is not None:
-            out = jax.lax.with_sharding_constraint(out, self.output_sharding)
-        return out
+            def step(carry, op):  # type: ignore[no-untyped-def]
+                return tree.add(carry, op.mv(x)), None
+
+            out, _ = jax.lax.scan(step, init, self.blocks)
+            return out
+
+        mesh = self.output_sharding.mesh
+        obs_sharding = NamedSharding(mesh, P('obs'))
+        blocks = jax.tree.map(lambda a: jax.reshard(a, obs_sharding), self.blocks)
+
+        @jax.shard_map(mesh=mesh, in_specs=(P('obs'), P()), out_specs=P(), check_vma=False)
+        def local_mv(local_blocks: AbstractLinearOperator, local_x: PyTree) -> PyTree:
+            init = tree.zeros_like(out_structure)
+
+            def step(carry, op):  # type: ignore[no-untyped-def]
+                return tree.add(carry, op.mv(local_x)), None
+
+            out, _ = jax.lax.scan(step, init, local_blocks)
+            return jax.lax.psum(out, axis_name='obs')
+
+        return local_mv(blocks, x)
 
     def transpose(self) -> AbstractLinearOperator:
         return ScanAdditionOperator(self.blocks.T, self.n_blocks, self.output_sharding)

--- a/src/furax/mapmaking/_scan_blocks.py
+++ b/src/furax/mapmaking/_scan_blocks.py
@@ -11,6 +11,13 @@ from furax import AbstractLinearOperator, tree
 from furax.core.rules import AbstractBinaryRule
 
 
+def _get_mesh() -> AbstractMesh:
+    mesh = jax.sharding.get_abstract_mesh()
+    if mesh.empty:
+        raise RuntimeError('active mesh context required')
+    return mesh
+
+
 class AbstractScanBlockOperator(AbstractLinearOperator, ABC):
     blocks: AbstractLinearOperator
 
@@ -27,61 +34,37 @@ class AbstractScanBlockOperator(AbstractLinearOperator, ABC):
     def _infer_in_structure(cls, blocks: AbstractLinearOperator) -> PyTree[jax.ShapeDtypeStruct]:
         """Returns sharding-aware in_structure"""
 
-    def _get_mesh(self) -> AbstractMesh:
-        mesh = jax.sharding.get_abstract_mesh()
-        if mesh.empty:
-            raise RuntimeError('active mesh context required')
-        return mesh
-
     def reduce(self) -> AbstractLinearOperator:
         return type(self)(self.blocks.reduce(), in_structure=self.in_structure)
-
-
-def _match_sharding_rank(sharding: NamedSharding | None, rank: int) -> NamedSharding | None:
-    if sharding is None or len(sharding.spec) >= rank:
-        return sharding
-    padding = (None,) * (rank - len(sharding.spec))
-    return NamedSharding(sharding.mesh, P(*sharding.spec, *padding))
 
 
 def _augment_structure(
     structure: PyTree[jax.ShapeDtypeStruct],
     *,
+    spec: P,
     axis_size: int | None = None,
-    sharding: NamedSharding | None = None,
 ) -> PyTree[jax.ShapeDtypeStruct]:
+    mesh = _get_mesh()
+
     def transform(s: jax.ShapeDtypeStruct) -> jax.ShapeDtypeStruct:
         shape = (axis_size, *s.shape) if axis_size is not None else s.shape
-        new_sharding = _match_sharding_rank(sharding, len(shape))
-        return jax.ShapeDtypeStruct(shape, s.dtype, sharding=new_sharding)
+        padded = P(*spec, *((None,) * (len(shape) - len(spec))))
+        return jax.ShapeDtypeStruct(shape, s.dtype, sharding=NamedSharding(mesh, padded))
 
     return jax.tree.map(transform, structure)
-
-
-def _leaf_named_sharding(blocks: AbstractLinearOperator) -> NamedSharding | None:
-    leaf_shape = jax.eval_shape(lambda: jax.tree.leaves(blocks)[0])
-    s = leaf_shape.sharding
-    return s if isinstance(s, NamedSharding) else None
 
 
 class ScanBlockDiagonalOperator(AbstractScanBlockOperator):
     @classmethod
     def _infer_in_structure(cls, blocks: AbstractLinearOperator) -> PyTree[jax.ShapeDtypeStruct]:
-        leaf_shape = jax.eval_shape(lambda: jax.tree.leaves(blocks)[0])
-        leaf_sharding = leaf_shape.sharding
-        if isinstance(leaf_sharding, NamedSharding):
-            sharding = NamedSharding(leaf_sharding.mesh, P(leaf_sharding.spec[0]))
-        else:
-            sharding = None
-        return _augment_structure(
-            blocks.in_structure, axis_size=leaf_shape.shape[0], sharding=sharding
-        )
+        axis_size = jax.eval_shape(lambda: jax.tree.leaves(blocks)[0]).shape[0]
+        spec = P(_get_mesh().axis_names[0])
+        return _augment_structure(blocks.in_structure, axis_size=axis_size, spec=spec)
 
     def mv(self, x: PyTree[Inexact[Array, '...']]) -> PyTree[Inexact[Array, '...']]:
-        mesh = self._get_mesh()
-        axis = mesh.axis_names[0]
+        axis = _get_mesh().axis_names[0]
 
-        @jax.shard_map(mesh=mesh, out_specs=P(axis), check_vma=False)
+        @jax.shard_map(out_specs=P(axis), check_vma=False)
         def kernel(blocks, x):  # type: ignore[no-untyped-def]
             def step(_, args):  # type: ignore[no-untyped-def]
                 op, x_i = args
@@ -92,9 +75,8 @@ class ScanBlockDiagonalOperator(AbstractScanBlockOperator):
 
         # shard_map validates in_specs against actual array sharding; reshard sets it
         # explicitly so the check passes even when sharding is lost inside a JIT trace
-        sharding = NamedSharding(mesh, P(axis))
-        blocks = jax.tree.map(lambda a: jax.reshard(a, sharding), self.blocks)
-        x = jax.tree.map(lambda a: jax.reshard(a, sharding), x)
+        blocks = jax.tree.map(lambda a: jax.reshard(a, P(axis)), self.blocks)
+        x = jax.tree.map(lambda a: jax.reshard(a, P(axis)), x)
         return kernel(blocks, x)
 
     def transpose(self) -> AbstractLinearOperator:
@@ -104,15 +86,12 @@ class ScanBlockDiagonalOperator(AbstractScanBlockOperator):
 class ScanBlockColumnOperator(AbstractScanBlockOperator):
     @classmethod
     def _infer_in_structure(cls, blocks: AbstractLinearOperator) -> PyTree[jax.ShapeDtypeStruct]:
-        sharding = _leaf_named_sharding(blocks)
-        replicated = NamedSharding(sharding.mesh, P()) if sharding is not None else None
-        return _augment_structure(blocks.in_structure, sharding=replicated)
+        return _augment_structure(blocks.in_structure, spec=P())
 
     def mv(self, x: PyTree[Inexact[Array, '...']]) -> PyTree[Inexact[Array, '...']]:
-        mesh = self._get_mesh()
-        axis = mesh.axis_names[0]
+        axis = _get_mesh().axis_names[0]
 
-        @jax.shard_map(mesh=mesh, out_specs=P(axis), check_vma=False)
+        @jax.shard_map(out_specs=P(axis), check_vma=False)
         def kernel(blocks, x):  # type: ignore[no-untyped-def]
             def step(_, op):  # type: ignore[no-untyped-def]
                 return None, op.mv(x)
@@ -120,8 +99,7 @@ class ScanBlockColumnOperator(AbstractScanBlockOperator):
             _, out = jax.lax.scan(step, None, blocks)
             return out
 
-        sharding = NamedSharding(mesh, P(axis))
-        blocks = jax.tree.map(lambda leaf: jax.reshard(leaf, sharding), self.blocks)
+        blocks = jax.tree.map(lambda leaf: jax.reshard(leaf, P(axis)), self.blocks)
         return kernel(blocks, x)
 
     def transpose(self) -> AbstractLinearOperator:
@@ -131,21 +109,15 @@ class ScanBlockColumnOperator(AbstractScanBlockOperator):
 class ScanBlockRowOperator(AbstractScanBlockOperator):
     @classmethod
     def _infer_in_structure(cls, blocks: AbstractLinearOperator) -> PyTree[jax.ShapeDtypeStruct]:
-        leaf_shape = jax.eval_shape(lambda: jax.tree.leaves(blocks)[0])
-        if isinstance(leaf_shape.sharding, NamedSharding):
-            sharding = NamedSharding(leaf_shape.sharding.mesh, P(leaf_shape.sharding.spec[0]))
-        else:
-            sharding = None
-        return _augment_structure(
-            blocks.in_structure, axis_size=leaf_shape.shape[0], sharding=sharding
-        )
+        axis_size = jax.eval_shape(lambda: jax.tree.leaves(blocks)[0]).shape[0]
+        spec = P(_get_mesh().axis_names[0])
+        return _augment_structure(blocks.in_structure, axis_size=axis_size, spec=spec)
 
     def mv(self, x: PyTree[Inexact[Array, '...']]) -> PyTree[Inexact[Array, '...']]:
-        mesh = self._get_mesh()
-        axis = mesh.axis_names[0]
+        axis = _get_mesh().axis_names[0]
         out_structure = self.blocks.out_structure
 
-        @jax.shard_map(mesh=mesh, out_specs=P(), check_vma=False)
+        @jax.shard_map(out_specs=P(), check_vma=False)
         def kernel(blocks, x):  # type: ignore[no-untyped-def]
             def step(carry, args):  # type: ignore[no-untyped-def]
                 op, x_i = args
@@ -156,9 +128,8 @@ class ScanBlockRowOperator(AbstractScanBlockOperator):
             out, _ = jax.lax.scan(step, init, (blocks, x))
             return jax.lax.psum(out, axis_name=axis)
 
-        sharding = NamedSharding(mesh, P(axis))
-        blocks = jax.tree.map(lambda a: jax.reshard(a, sharding), self.blocks)
-        x = jax.tree.map(lambda a: jax.reshard(a, sharding), x)
+        blocks = jax.tree.map(lambda a: jax.reshard(a, P(axis)), self.blocks)
+        x = jax.tree.map(lambda a: jax.reshard(a, P(axis)), x)
         return kernel(blocks, x)
 
     def transpose(self) -> AbstractLinearOperator:
@@ -168,27 +139,23 @@ class ScanBlockRowOperator(AbstractScanBlockOperator):
 class ScanAdditionOperator(AbstractScanBlockOperator):
     @classmethod
     def _infer_in_structure(cls, blocks: AbstractLinearOperator) -> PyTree[jax.ShapeDtypeStruct]:
-        sharding = _leaf_named_sharding(blocks)
-        replicated = NamedSharding(sharding.mesh, P()) if sharding is not None else None
-        return _augment_structure(blocks.in_structure, sharding=replicated)
+        return _augment_structure(blocks.in_structure, spec=P())
 
     def mv(self, x: PyTree[Inexact[Array, '...']]) -> PyTree[Inexact[Array, '...']]:
-        mesh = self._get_mesh()
-        axis = mesh.axis_names[0]
+        axis = _get_mesh().axis_names[0]
         out_structure = self.blocks.out_structure
 
-        @jax.shard_map(mesh=mesh, out_specs=P(), check_vma=False)
+        @jax.shard_map(out_specs=P(), check_vma=False)
         def kernel(blocks, x):  # type: ignore[no-untyped-def]
             def step(carry, op):  # type: ignore[no-untyped-def]
                 return tree.add(carry, op.mv(x)), None
 
             # pcast makes the replicated zeros match the varying carry type inside shard_map
-            init = jax.lax.pcast(tree.zeros_like(out_structure), mesh.axis_names, to='varying')
+            init = jax.lax.pcast(tree.zeros_like(out_structure), axis, to='varying')
             out, _ = jax.lax.scan(step, init, blocks)
-            return jax.lax.psum(out, axis_name=mesh.axis_names)
+            return jax.lax.psum(out, axis_name=axis)
 
-        sharding = NamedSharding(mesh, P(axis))
-        blocks = jax.tree.map(lambda leaf: jax.reshard(leaf, sharding), self.blocks)
+        blocks = jax.tree.map(lambda leaf: jax.reshard(leaf, P(axis)), self.blocks)
         return kernel(blocks, x)
 
     def transpose(self) -> AbstractLinearOperator:

--- a/src/furax/mapmaking/_scan_blocks.py
+++ b/src/furax/mapmaking/_scan_blocks.py
@@ -3,12 +3,17 @@ from typing import Self
 
 import jax
 from jax import Array
-from jax.sharding import AbstractMesh, NamedSharding
+from jax.sharding import AbstractMesh
 from jax.sharding import PartitionSpec as P
 from jaxtyping import Inexact, PyTree
 
 from furax import AbstractLinearOperator, tree
 from furax.core.rules import AbstractBinaryRule
+
+# jax.eval_shape inside a jax.set_mesh context annotates outputs with sharding information,
+# which breaks operator compatibility checks. Wrapping inner transpose/reduction calls with
+# use_abstract_mesh(_EMPTY_MESH) clears the active mesh so those structs stay sharding-free.
+_EMPTY_MESH = jax.sharding.AbstractMesh((), ())
 
 
 def _get_mesh() -> AbstractMesh:
@@ -35,21 +40,19 @@ class AbstractScanBlockOperator(AbstractLinearOperator, ABC):
         """Returns sharding-aware in_structure"""
 
     def reduce(self) -> AbstractLinearOperator:
-        return type(self)(self.blocks.reduce(), in_structure=self.in_structure)
+        with jax.sharding.use_abstract_mesh(_EMPTY_MESH):
+            reduced_blocks = self.blocks.reduce()
+        return type(self)(reduced_blocks, in_structure=self.in_structure)
 
 
-def _augment_structure(
+def _prepend_axis(
     structure: PyTree[jax.ShapeDtypeStruct],
     *,
-    spec: P,
     axis_size: int | None = None,
 ) -> PyTree[jax.ShapeDtypeStruct]:
-    mesh = _get_mesh()
-
     def transform(s: jax.ShapeDtypeStruct) -> jax.ShapeDtypeStruct:
         shape = (axis_size, *s.shape) if axis_size is not None else s.shape
-        padded = P(*spec, *((None,) * (len(shape) - len(spec))))
-        return jax.ShapeDtypeStruct(shape, s.dtype, sharding=NamedSharding(mesh, padded))
+        return jax.ShapeDtypeStruct(shape, s.dtype)
 
     return jax.tree.map(transform, structure)
 
@@ -58,8 +61,12 @@ class ScanBlockDiagonalOperator(AbstractScanBlockOperator):
     @classmethod
     def _infer_in_structure(cls, blocks: AbstractLinearOperator) -> PyTree[jax.ShapeDtypeStruct]:
         axis_size = jax.eval_shape(lambda: jax.tree.leaves(blocks)[0]).shape[0]
-        spec = P(_get_mesh().axis_names[0])
-        return _augment_structure(blocks.in_structure, axis_size=axis_size, spec=spec)
+        return _prepend_axis(blocks.in_structure, axis_size=axis_size)
+
+    @property
+    def out_structure(self) -> PyTree[jax.ShapeDtypeStruct]:
+        n = jax.tree.leaves(self.in_structure)[0].shape[0]
+        return _prepend_axis(self.blocks.out_structure, axis_size=n)
 
     def mv(self, x: PyTree[Inexact[Array, '...']]) -> PyTree[Inexact[Array, '...']]:
         axis = _get_mesh().axis_names[0]
@@ -80,13 +87,20 @@ class ScanBlockDiagonalOperator(AbstractScanBlockOperator):
         return kernel(blocks, x)
 
     def transpose(self) -> AbstractLinearOperator:
-        return ScanBlockDiagonalOperator(self.blocks.T, in_structure=self.out_structure)
+        with jax.sharding.use_abstract_mesh(_EMPTY_MESH):
+            blocks_T = self.blocks.T
+        return ScanBlockDiagonalOperator(blocks_T, in_structure=self.out_structure)
 
 
 class ScanBlockColumnOperator(AbstractScanBlockOperator):
     @classmethod
     def _infer_in_structure(cls, blocks: AbstractLinearOperator) -> PyTree[jax.ShapeDtypeStruct]:
-        return _augment_structure(blocks.in_structure, spec=P())
+        return blocks.in_structure
+
+    @property
+    def out_structure(self) -> PyTree[jax.ShapeDtypeStruct]:
+        n = jax.tree.leaves(self.blocks)[0].shape[0]
+        return _prepend_axis(self.blocks.out_structure, axis_size=n)
 
     def mv(self, x: PyTree[Inexact[Array, '...']]) -> PyTree[Inexact[Array, '...']]:
         axis = _get_mesh().axis_names[0]
@@ -103,15 +117,20 @@ class ScanBlockColumnOperator(AbstractScanBlockOperator):
         return kernel(blocks, x)
 
     def transpose(self) -> AbstractLinearOperator:
-        return ScanBlockRowOperator(self.blocks.T, in_structure=self.out_structure)
+        with jax.sharding.use_abstract_mesh(_EMPTY_MESH):
+            blocks_T = self.blocks.T
+        return ScanBlockRowOperator(blocks_T, in_structure=self.out_structure)
 
 
 class ScanBlockRowOperator(AbstractScanBlockOperator):
     @classmethod
     def _infer_in_structure(cls, blocks: AbstractLinearOperator) -> PyTree[jax.ShapeDtypeStruct]:
         axis_size = jax.eval_shape(lambda: jax.tree.leaves(blocks)[0]).shape[0]
-        spec = P(_get_mesh().axis_names[0])
-        return _augment_structure(blocks.in_structure, axis_size=axis_size, spec=spec)
+        return _prepend_axis(blocks.in_structure, axis_size=axis_size)
+
+    @property
+    def out_structure(self) -> PyTree[jax.ShapeDtypeStruct]:
+        return self.blocks.out_structure
 
     def mv(self, x: PyTree[Inexact[Array, '...']]) -> PyTree[Inexact[Array, '...']]:
         axis = _get_mesh().axis_names[0]
@@ -133,13 +152,19 @@ class ScanBlockRowOperator(AbstractScanBlockOperator):
         return kernel(blocks, x)
 
     def transpose(self) -> AbstractLinearOperator:
-        return ScanBlockColumnOperator(self.blocks.T, in_structure=self.out_structure)
+        with jax.sharding.use_abstract_mesh(_EMPTY_MESH):
+            blocks_T = self.blocks.T
+        return ScanBlockColumnOperator(blocks_T, in_structure=self.out_structure)
 
 
 class ScanAdditionOperator(AbstractScanBlockOperator):
     @classmethod
     def _infer_in_structure(cls, blocks: AbstractLinearOperator) -> PyTree[jax.ShapeDtypeStruct]:
-        return _augment_structure(blocks.in_structure, spec=P())
+        return blocks.in_structure
+
+    @property
+    def out_structure(self) -> PyTree[jax.ShapeDtypeStruct]:
+        return self.blocks.out_structure
 
     def mv(self, x: PyTree[Inexact[Array, '...']]) -> PyTree[Inexact[Array, '...']]:
         axis = _get_mesh().axis_names[0]
@@ -159,7 +184,9 @@ class ScanAdditionOperator(AbstractScanBlockOperator):
         return kernel(blocks, x)
 
     def transpose(self) -> AbstractLinearOperator:
-        return ScanAdditionOperator(self.blocks.T, in_structure=self.out_structure)
+        with jax.sharding.use_abstract_mesh(_EMPTY_MESH):
+            blocks_T = self.blocks.T
+        return ScanAdditionOperator(blocks_T, in_structure=self.out_structure)
 
 
 class AbstractScanFusionRule(AbstractBinaryRule):
@@ -170,7 +197,8 @@ class AbstractScanFusionRule(AbstractBinaryRule):
     ) -> list[AbstractLinearOperator]:
         assert isinstance(left, AbstractScanBlockOperator)  # mypy
         assert isinstance(right, AbstractScanBlockOperator)  # mypy
-        composed = (left.blocks @ right.blocks).reduce()
+        with jax.sharding.use_abstract_mesh(_EMPTY_MESH):
+            composed = (left.blocks @ right.blocks).reduce()
         return [self.reduced_class.create(composed)]
 
 

--- a/src/furax/mapmaking/_scan_blocks.py
+++ b/src/furax/mapmaking/_scan_blocks.py
@@ -107,11 +107,7 @@ class ScanBlockDiagonalOperator(AbstractScanBlockOperator):
             _, out = jax.lax.scan(step, None, (operator, x))
             return out
 
-        # shard_map validates in_specs against actual array sharding; reshard sets it
-        # explicitly so the check passes even when sharding is lost inside a JIT trace
-        operator = jax.tree.map(lambda a: jax.reshard(a, P(axis)), self.operator)
-        x = jax.tree.map(lambda a: jax.reshard(a, P(axis)), x)
-        return kernel(operator, x)
+        return kernel(self.operator, x)
 
     def transpose(self) -> AbstractLinearOperator:
         with jax.sharding.use_abstract_mesh(_EMPTY_MESH):
@@ -151,8 +147,7 @@ class ScanBlockColumnOperator(AbstractScanBlockOperator):
             _, out = jax.lax.scan(step, None, operator)
             return out
 
-        operator = jax.tree.map(lambda leaf: jax.reshard(leaf, P(axis)), self.operator)
-        return kernel(operator, x)
+        return kernel(self.operator, x)
 
     def transpose(self) -> AbstractLinearOperator:
         with jax.sharding.use_abstract_mesh(_EMPTY_MESH):
@@ -196,9 +191,7 @@ class ScanBlockRowOperator(AbstractScanBlockOperator):
             out, _ = jax.lax.scan(step, init, (operator, x))
             return jax.lax.psum(out, axis_name=axis)
 
-        operator = jax.tree.map(lambda a: jax.reshard(a, P(axis)), self.operator)
-        x = jax.tree.map(lambda a: jax.reshard(a, P(axis)), x)
-        return kernel(operator, x)
+        return kernel(self.operator, x)
 
     def transpose(self) -> AbstractLinearOperator:
         with jax.sharding.use_abstract_mesh(_EMPTY_MESH):
@@ -243,8 +236,7 @@ class ScanAdditionOperator(AbstractScanBlockOperator):
             out, _ = jax.lax.scan(step, init, operator)
             return jax.lax.psum(out, axis_name=axis)
 
-        operator = jax.tree.map(lambda leaf: jax.reshard(leaf, P(axis)), self.operator)
-        return kernel(operator, x)
+        return kernel(self.operator, x)
 
     def transpose(self) -> AbstractLinearOperator:
         with jax.sharding.use_abstract_mesh(_EMPTY_MESH):

--- a/src/furax/mapmaking/_scan_blocks.py
+++ b/src/furax/mapmaking/_scan_blocks.py
@@ -3,7 +3,7 @@ from typing import Self
 
 import jax
 from jax import Array
-from jax.sharding import AbstractMesh, Mesh, NamedSharding
+from jax.sharding import AbstractMesh, NamedSharding
 from jax.sharding import PartitionSpec as P
 from jaxtyping import Inexact, PyTree
 
@@ -22,25 +22,16 @@ class AbstractScanBlockOperator(AbstractLinearOperator, ABC):
         in_structure = cls._infer_in_structure(blocks)
         return cls(blocks, in_structure=in_structure)
 
-    @property
-    def _mesh(self) -> Mesh | AbstractMesh | None:
-        s = jax.tree.leaves(self.in_structure)[0].sharding
-        return s.mesh if isinstance(s, NamedSharding) else None
-
     @classmethod
     @abstractmethod
     def _infer_in_structure(cls, blocks: AbstractLinearOperator) -> PyTree[jax.ShapeDtypeStruct]:
         """Returns sharding-aware in_structure"""
 
-    @property
-    def _in_specs(self) -> P:
-        """PartitionSpec for obs-sharded blocks. Only valid when sharded."""
-        return P(self._mesh.axis_names)  # type: ignore[union-attr]
-
-    @property
-    @abstractmethod
-    def _out_specs(self) -> P:
-        """PartitionSpec for shard_map out_specs. Only valid when sharded."""
+    def _get_mesh(self) -> AbstractMesh:
+        mesh = jax.sharding.get_abstract_mesh()
+        if mesh.empty:
+            raise RuntimeError('active mesh context required')
+        return mesh
 
     def reduce(self) -> AbstractLinearOperator:
         return type(self)(self.blocks.reduce(), in_structure=self.in_structure)
@@ -74,10 +65,6 @@ def _leaf_named_sharding(blocks: AbstractLinearOperator) -> NamedSharding | None
 
 
 class ScanBlockDiagonalOperator(AbstractScanBlockOperator):
-    @property
-    def _out_specs(self) -> P:
-        return P(self._mesh.axis_names)  # type: ignore[union-attr]
-
     @classmethod
     def _infer_in_structure(cls, blocks: AbstractLinearOperator) -> PyTree[jax.ShapeDtypeStruct]:
         leaf_shape = jax.eval_shape(lambda: jax.tree.leaves(blocks)[0])
@@ -91,6 +78,10 @@ class ScanBlockDiagonalOperator(AbstractScanBlockOperator):
         )
 
     def mv(self, x: PyTree[Inexact[Array, '...']]) -> PyTree[Inexact[Array, '...']]:
+        mesh = self._get_mesh()
+        axis = mesh.axis_names[0]
+
+        @jax.shard_map(mesh=mesh, out_specs=P(axis), check_vma=False)
         def kernel(blocks, x):  # type: ignore[no-untyped-def]
             def step(_, args):  # type: ignore[no-untyped-def]
                 op, x_i = args
@@ -99,26 +90,18 @@ class ScanBlockDiagonalOperator(AbstractScanBlockOperator):
             _, out = jax.lax.scan(step, None, (blocks, x))
             return out
 
-        mesh = self._mesh
-        if mesh is None:
-            return kernel(self.blocks, x)
-
-        in_sharding = NamedSharding(mesh, self._in_specs)
         # shard_map validates in_specs against actual array sharding; reshard sets it
         # explicitly so the check passes even when sharding is lost inside a JIT trace
-        blocks = jax.tree.map(lambda a: jax.reshard(a, in_sharding), self.blocks)
-        x = jax.tree.map(lambda a: jax.reshard(a, in_sharding), x)
-        return jax.shard_map(kernel, mesh=mesh, out_specs=self._out_specs)(blocks, x)
+        sharding = NamedSharding(mesh, P(axis))
+        blocks = jax.tree.map(lambda a: jax.reshard(a, sharding), self.blocks)
+        x = jax.tree.map(lambda a: jax.reshard(a, sharding), x)
+        return kernel(blocks, x)
 
     def transpose(self) -> AbstractLinearOperator:
         return ScanBlockDiagonalOperator(self.blocks.T, in_structure=self.out_structure)
 
 
 class ScanBlockColumnOperator(AbstractScanBlockOperator):
-    @property
-    def _out_specs(self) -> P:
-        return P(self._mesh.axis_names)  # type: ignore[union-attr]
-
     @classmethod
     def _infer_in_structure(cls, blocks: AbstractLinearOperator) -> PyTree[jax.ShapeDtypeStruct]:
         sharding = _leaf_named_sharding(blocks)
@@ -126,6 +109,10 @@ class ScanBlockColumnOperator(AbstractScanBlockOperator):
         return _augment_structure(blocks.in_structure, sharding=replicated)
 
     def mv(self, x: PyTree[Inexact[Array, '...']]) -> PyTree[Inexact[Array, '...']]:
+        mesh = self._get_mesh()
+        axis = mesh.axis_names[0]
+
+        @jax.shard_map(mesh=mesh, out_specs=P(axis), check_vma=False)
         def kernel(blocks, x):  # type: ignore[no-untyped-def]
             def step(_, op):  # type: ignore[no-untyped-def]
                 return None, op.mv(x)
@@ -133,25 +120,15 @@ class ScanBlockColumnOperator(AbstractScanBlockOperator):
             _, out = jax.lax.scan(step, None, blocks)
             return out
 
-        mesh = self._mesh
-        if mesh is None:
-            return kernel(self.blocks, x)
-
-        # see Diagonal.mv
-        blocks = jax.tree.map(
-            lambda a: jax.reshard(a, NamedSharding(mesh, self._in_specs)), self.blocks
-        )
-        return jax.shard_map(kernel, mesh=mesh, out_specs=self._out_specs)(blocks, x)
+        sharding = NamedSharding(mesh, P(axis))
+        blocks = jax.tree.map(lambda leaf: jax.reshard(leaf, sharding), self.blocks)
+        return kernel(blocks, x)
 
     def transpose(self) -> AbstractLinearOperator:
         return ScanBlockRowOperator(self.blocks.T, in_structure=self.out_structure)
 
 
 class ScanBlockRowOperator(AbstractScanBlockOperator):
-    @property
-    def _out_specs(self) -> P:
-        return P()
-
     @classmethod
     def _infer_in_structure(cls, blocks: AbstractLinearOperator) -> PyTree[jax.ShapeDtypeStruct]:
         leaf_shape = jax.eval_shape(lambda: jax.tree.leaves(blocks)[0])
@@ -164,42 +141,31 @@ class ScanBlockRowOperator(AbstractScanBlockOperator):
         )
 
     def mv(self, x: PyTree[Inexact[Array, '...']]) -> PyTree[Inexact[Array, '...']]:
+        mesh = self._get_mesh()
+        axis = mesh.axis_names[0]
         out_structure = self.blocks.out_structure
-        zeros = tree.zeros_like(out_structure)
 
-        def kernel(blocks, x, init):  # type: ignore[no-untyped-def]
+        @jax.shard_map(mesh=mesh, out_specs=P(), check_vma=False)
+        def kernel(blocks, x):  # type: ignore[no-untyped-def]
             def step(carry, args):  # type: ignore[no-untyped-def]
                 op, x_i = args
                 return tree.add(carry, op.mv(x_i)), None
 
-            out, _ = jax.lax.scan(step, init, (blocks, x))
-            return out
-
-        mesh = self._mesh
-        if mesh is None:
-            return kernel(self.blocks, x, zeros)
-
-        in_sharding = NamedSharding(mesh, self._in_specs)
-        # see Diagonal.mv
-        blocks = jax.tree.map(lambda a: jax.reshard(a, in_sharding), self.blocks)
-        x = jax.tree.map(lambda a: jax.reshard(a, in_sharding), x)
-
-        def sharded_kernel(blocks, x):  # type: ignore[no-untyped-def]
             # pcast makes the replicated zeros match the varying carry type inside shard_map
-            init = jax.lax.pcast(zeros, mesh.axis_names, to='varying')
-            return jax.lax.psum(kernel(blocks, x, init), axis_name=mesh.axis_names)
+            init = jax.lax.pcast(tree.zeros_like(out_structure), axis, to='varying')
+            out, _ = jax.lax.scan(step, init, (blocks, x))
+            return jax.lax.psum(out, axis_name=axis)
 
-        return jax.shard_map(sharded_kernel, mesh=mesh, out_specs=self._out_specs)(blocks, x)
+        sharding = NamedSharding(mesh, P(axis))
+        blocks = jax.tree.map(lambda a: jax.reshard(a, sharding), self.blocks)
+        x = jax.tree.map(lambda a: jax.reshard(a, sharding), x)
+        return kernel(blocks, x)
 
     def transpose(self) -> AbstractLinearOperator:
         return ScanBlockColumnOperator(self.blocks.T, in_structure=self.out_structure)
 
 
 class ScanAdditionOperator(AbstractScanBlockOperator):
-    @property
-    def _out_specs(self) -> P:
-        return P()
-
     @classmethod
     def _infer_in_structure(cls, blocks: AbstractLinearOperator) -> PyTree[jax.ShapeDtypeStruct]:
         sharding = _leaf_named_sharding(blocks)
@@ -207,31 +173,23 @@ class ScanAdditionOperator(AbstractScanBlockOperator):
         return _augment_structure(blocks.in_structure, sharding=replicated)
 
     def mv(self, x: PyTree[Inexact[Array, '...']]) -> PyTree[Inexact[Array, '...']]:
+        mesh = self._get_mesh()
+        axis = mesh.axis_names[0]
         out_structure = self.blocks.out_structure
-        zeros = tree.zeros_like(out_structure)
 
-        def kernel(blocks, x, init):  # type: ignore[no-untyped-def]
+        @jax.shard_map(mesh=mesh, out_specs=P(), check_vma=False)
+        def kernel(blocks, x):  # type: ignore[no-untyped-def]
             def step(carry, op):  # type: ignore[no-untyped-def]
                 return tree.add(carry, op.mv(x)), None
 
-            out, _ = jax.lax.scan(step, init, blocks)
-            return out
-
-        mesh = self._mesh
-        if mesh is None:
-            return kernel(self.blocks, x, zeros)
-
-        # see Diagonal.mv
-        blocks = jax.tree.map(
-            lambda a: jax.reshard(a, NamedSharding(mesh, self._in_specs)), self.blocks
-        )
-
-        def sharded_kernel(blocks, x):  # type: ignore[no-untyped-def]
             # pcast makes the replicated zeros match the varying carry type inside shard_map
-            init = jax.lax.pcast(zeros, mesh.axis_names, to='varying')
-            return jax.lax.psum(kernel(blocks, x, init), axis_name=mesh.axis_names)
+            init = jax.lax.pcast(tree.zeros_like(out_structure), mesh.axis_names, to='varying')
+            out, _ = jax.lax.scan(step, init, blocks)
+            return jax.lax.psum(out, axis_name=mesh.axis_names)
 
-        return jax.shard_map(sharded_kernel, mesh=mesh, out_specs=self._out_specs)(blocks, x)
+        sharding = NamedSharding(mesh, P(axis))
+        blocks = jax.tree.map(lambda leaf: jax.reshard(leaf, sharding), self.blocks)
+        return kernel(blocks, x)
 
     def transpose(self) -> AbstractLinearOperator:
         return ScanAdditionOperator(self.blocks.T, in_structure=self.out_structure)

--- a/src/furax/mapmaking/_scan_blocks.py
+++ b/src/furax/mapmaking/_scan_blocks.py
@@ -102,7 +102,7 @@ class ScanBlockDiagonalOperator(AbstractScanBlockOperator):
         def kernel(operator, x):  # type: ignore[no-untyped-def]
             def step(_, args):  # type: ignore[no-untyped-def]
                 op, x_i = args
-                return None, op.mv(x_i)
+                return None, op(x_i)
 
             _, out = jax.lax.scan(step, None, (operator, x))
             return out
@@ -142,7 +142,7 @@ class ScanBlockColumnOperator(AbstractScanBlockOperator):
         @jax.shard_map(out_specs=P(axis), check_vma=False)
         def kernel(operator, x):  # type: ignore[no-untyped-def]
             def step(_, op):  # type: ignore[no-untyped-def]
-                return None, op.mv(x)
+                return None, op(x)
 
             _, out = jax.lax.scan(step, None, operator)
             return out
@@ -184,7 +184,7 @@ class ScanBlockRowOperator(AbstractScanBlockOperator):
         def kernel(operator, x):  # type: ignore[no-untyped-def]
             def step(carry, args):  # type: ignore[no-untyped-def]
                 op, x_i = args
-                return tree.add(carry, op.mv(x_i)), None
+                return tree.add(carry, op(x_i)), None
 
             # pcast makes the replicated zeros match the varying carry type inside shard_map
             init = jax.lax.pcast(tree.zeros_like(out_structure), axis, to='varying')
@@ -229,7 +229,7 @@ class ScanAdditionOperator(AbstractScanBlockOperator):
         @jax.shard_map(out_specs=P(), check_vma=False)
         def kernel(operator, x):  # type: ignore[no-untyped-def]
             def step(carry, op):  # type: ignore[no-untyped-def]
-                return tree.add(carry, op.mv(x)), None
+                return tree.add(carry, op(x)), None
 
             # pcast makes the replicated zeros match the varying carry type inside shard_map
             init = jax.lax.pcast(tree.zeros_like(out_structure), axis, to='varying')

--- a/src/furax/mapmaking/_scan_blocks.py
+++ b/src/furax/mapmaking/_scan_blocks.py
@@ -87,7 +87,7 @@ class ScanBlockDiagonalOperator(AbstractScanBlockOperator):
 
     @classmethod
     def _infer_in_structure(cls, operator: AbstractLinearOperator) -> PyTree[jax.ShapeDtypeStruct]:
-        axis_size = jax.eval_shape(lambda: jax.tree.leaves(operator)[0]).shape[0]
+        axis_size = jax.tree.leaves(operator)[0].shape[0]
         return _prepend_axis(operator.in_structure, axis_size=axis_size)
 
     @property
@@ -169,7 +169,7 @@ class ScanBlockRowOperator(AbstractScanBlockOperator):
 
     @classmethod
     def _infer_in_structure(cls, operator: AbstractLinearOperator) -> PyTree[jax.ShapeDtypeStruct]:
-        axis_size = jax.eval_shape(lambda: jax.tree.leaves(operator)[0]).shape[0]
+        axis_size = jax.tree.leaves(operator)[0].shape[0]
         return _prepend_axis(operator.in_structure, axis_size=axis_size)
 
     @property

--- a/src/furax/mapmaking/acquisition.py
+++ b/src/furax/mapmaking/acquisition.py
@@ -68,10 +68,14 @@ def build_acquisition_operator(
         return 0.5 * rot.T @ pointing
 
     # In the general case, we include polarizer and HWP
+    assert hwp_angles is not None  # mypy assert
+
+    # Pad hwp_angles to rank 2 so that, when stacked across observations, the
+    # QURotation fusion rule can broadcast against the per-detector gamma angles.
     hwp = HWPOperator.create(
         shape=data_shape,
         dtype=dtype,
         stokes=landscape.stokes,
-        angles=hwp_angles,
+        angles=hwp_angles[None, :],
     )
     return polarizer @ rot @ hwp @ pointing

--- a/src/furax/mapmaking/config.py
+++ b/src/furax/mapmaking/config.py
@@ -25,14 +25,14 @@ class Methods(Enum):
     ATOP = 'ATOP'
 
 
-@dataclass
+@dataclass(frozen=True)
 class SolverConfig:
     rtol: float = 1e-6
     atol: float = 0
     max_steps: int = 1_000
 
 
-@dataclass
+@dataclass(frozen=True)
 class NoiseFitConfig:
     nperseg: int = 2_048
     """Welch window length in samples for PSD estimation."""
@@ -68,7 +68,7 @@ class NoiseFitConfig:
     """PTC frequency [Hz] used for masking (if used)"""
 
 
-@dataclass
+@dataclass(frozen=True)
 class NoiseConfig:
     """Configuration for noise modelling.
 
@@ -95,7 +95,7 @@ class NoiseConfig:
     """Options controlling PSD estimation and model fitting."""
 
 
-@dataclass
+@dataclass(frozen=True)
 class HealpixConfig:
     """Configuration for a HEALPix output map.
 
@@ -114,7 +114,7 @@ class HealpixConfig:
             raise ValueError('NESTED ordering not supported')
 
 
-@dataclass
+@dataclass(frozen=True)
 class SkyPatch:
     """Explicit rectangular sky patch for WCS map construction.
 
@@ -137,7 +137,7 @@ class SkyPatch:
     """Height in degrees."""
 
 
-@dataclass
+@dataclass(frozen=True)
 class WCSConfig:
     """Configuration for a WCS-projected output map.
 
@@ -192,7 +192,7 @@ class WCSConfig:
         return self.geometry_file is not None or self.patch is not None
 
 
-@dataclass
+@dataclass(frozen=True)
 class LandscapeConfig:
     stokes: ValidStokesType = 'IQU'
     healpix: HealpixConfig | None = None
@@ -203,30 +203,30 @@ class LandscapeConfig:
             raise ValueError('exactly one of healpix or wcs must be set.')
 
 
-@dataclass
+@dataclass(frozen=True)
 class _PolyTemplateConfig:
     max_poly_order: int = 3
 
 
-@dataclass
+@dataclass(frozen=True)
 class _ScanSynchronousTemplateConfig:
     min_poly_order: int = 3
     max_poly_order: int = 7
 
 
-@dataclass
+@dataclass(frozen=True)
 class _HWPSynchronousTemplateConfig:
     n_harmonics: int = 3
 
 
-@dataclass
+@dataclass(frozen=True)
 class _AzimuthHWPSynchronousTemplateConfig:
     n_polynomials: int = 4
     n_harmonics: int = 4
     split_scans: bool = False
 
 
-@dataclass
+@dataclass(frozen=True)
 class _BinAzimuthHWPSynchronousTemplateConfig:
     n_azimuth_bins: int = 4
     n_harmonics: int = 4
@@ -234,13 +234,13 @@ class _BinAzimuthHWPSynchronousTemplateConfig:
     smooth_interpolation: bool = False
 
 
-@dataclass
+@dataclass(frozen=True)
 class _GroundTemplateConfig:
     azimuth_resolution: float = 0.05  # ~3 deg
     elevation_resolution: float = 0.05  # ~3 deg
 
 
-@dataclass
+@dataclass(frozen=True)
 class TemplatesConfig:
     polynomial: _PolyTemplateConfig | None = None
     scan_synchronous: _ScanSynchronousTemplateConfig | None = None
@@ -267,7 +267,7 @@ class TemplatesConfig:
         return all(getattr(self, f.name) is None for f in fields(self))
 
 
-@dataclass
+@dataclass(frozen=True)
 class GapFillingConfig:
     """Specific gap-filling options"""
 
@@ -281,7 +281,7 @@ class GapFillingConfig:
     """The relative tolerance of the solver for the gap-filling solve"""
 
 
-@dataclass
+@dataclass(frozen=True)
 class GapsConfig:
     """Configuration options related to the treatment of gaps"""
 
@@ -295,7 +295,7 @@ class GapsConfig:
     """Use the nested PCG method for gap treatment"""
 
 
-@dataclass
+@dataclass(frozen=True)
 class PointingConfig:
     """Configuration options for pointing computation.
 
@@ -315,7 +315,7 @@ class PointingConfig:
     """Pixel interpolation scheme used when sampling the sky map."""
 
 
-@dataclass
+@dataclass(frozen=True)
 class SotodlibConfig:
     """Configuration options specific to the sotodlib interface."""
 
@@ -340,7 +340,7 @@ class SotodlibConfig:
     """
 
 
-@dataclass
+@dataclass(frozen=True)
 class MapMakingConfig:
     method: Methods = Methods.BINNED
     scanning_mask: bool = False

--- a/src/furax/mapmaking/config.py
+++ b/src/furax/mapmaking/config.py
@@ -267,7 +267,7 @@ class TemplatesConfig:
         return all(getattr(self, f.name) is None for f in fields(self))
 
 
-@dataclass
+@dataclass(frozen=True)
 class GapFillingConfig:
     """Specific gap-filling options"""
 

--- a/src/furax/mapmaking/config.py
+++ b/src/furax/mapmaking/config.py
@@ -25,14 +25,14 @@ class Methods(Enum):
     ATOP = 'ATOP'
 
 
-@dataclass(frozen=True)
+@dataclass
 class SolverConfig:
     rtol: float = 1e-6
     atol: float = 0
     max_steps: int = 1_000
 
 
-@dataclass(frozen=True)
+@dataclass
 class NoiseFitConfig:
     nperseg: int = 2_048
     """Welch window length in samples for PSD estimation."""
@@ -68,7 +68,7 @@ class NoiseFitConfig:
     """PTC frequency [Hz] used for masking (if used)"""
 
 
-@dataclass(frozen=True)
+@dataclass
 class NoiseConfig:
     """Configuration for noise modelling.
 
@@ -95,7 +95,7 @@ class NoiseConfig:
     """Options controlling PSD estimation and model fitting."""
 
 
-@dataclass(frozen=True)
+@dataclass
 class HealpixConfig:
     """Configuration for a HEALPix output map.
 
@@ -114,7 +114,7 @@ class HealpixConfig:
             raise ValueError('NESTED ordering not supported')
 
 
-@dataclass(frozen=True)
+@dataclass
 class SkyPatch:
     """Explicit rectangular sky patch for WCS map construction.
 
@@ -137,7 +137,7 @@ class SkyPatch:
     """Height in degrees."""
 
 
-@dataclass(frozen=True)
+@dataclass
 class WCSConfig:
     """Configuration for a WCS-projected output map.
 
@@ -192,7 +192,7 @@ class WCSConfig:
         return self.geometry_file is not None or self.patch is not None
 
 
-@dataclass(frozen=True)
+@dataclass
 class LandscapeConfig:
     stokes: ValidStokesType = 'IQU'
     healpix: HealpixConfig | None = None
@@ -203,30 +203,30 @@ class LandscapeConfig:
             raise ValueError('exactly one of healpix or wcs must be set.')
 
 
-@dataclass(frozen=True)
+@dataclass
 class _PolyTemplateConfig:
     max_poly_order: int = 3
 
 
-@dataclass(frozen=True)
+@dataclass
 class _ScanSynchronousTemplateConfig:
     min_poly_order: int = 3
     max_poly_order: int = 7
 
 
-@dataclass(frozen=True)
+@dataclass
 class _HWPSynchronousTemplateConfig:
     n_harmonics: int = 3
 
 
-@dataclass(frozen=True)
+@dataclass
 class _AzimuthHWPSynchronousTemplateConfig:
     n_polynomials: int = 4
     n_harmonics: int = 4
     split_scans: bool = False
 
 
-@dataclass(frozen=True)
+@dataclass
 class _BinAzimuthHWPSynchronousTemplateConfig:
     n_azimuth_bins: int = 4
     n_harmonics: int = 4
@@ -234,13 +234,13 @@ class _BinAzimuthHWPSynchronousTemplateConfig:
     smooth_interpolation: bool = False
 
 
-@dataclass(frozen=True)
+@dataclass
 class _GroundTemplateConfig:
     azimuth_resolution: float = 0.05  # ~3 deg
     elevation_resolution: float = 0.05  # ~3 deg
 
 
-@dataclass(frozen=True)
+@dataclass
 class TemplatesConfig:
     polynomial: _PolyTemplateConfig | None = None
     scan_synchronous: _ScanSynchronousTemplateConfig | None = None
@@ -267,7 +267,7 @@ class TemplatesConfig:
         return all(getattr(self, f.name) is None for f in fields(self))
 
 
-@dataclass(frozen=True)
+@dataclass
 class GapFillingConfig:
     """Specific gap-filling options"""
 
@@ -281,7 +281,7 @@ class GapFillingConfig:
     """The relative tolerance of the solver for the gap-filling solve"""
 
 
-@dataclass(frozen=True)
+@dataclass
 class GapsConfig:
     """Configuration options related to the treatment of gaps"""
 
@@ -295,7 +295,7 @@ class GapsConfig:
     """Use the nested PCG method for gap treatment"""
 
 
-@dataclass(frozen=True)
+@dataclass
 class PointingConfig:
     """Configuration options for pointing computation.
 
@@ -315,7 +315,7 @@ class PointingConfig:
     """Pixel interpolation scheme used when sampling the sky map."""
 
 
-@dataclass(frozen=True)
+@dataclass
 class SotodlibConfig:
     """Configuration options specific to the sotodlib interface."""
 
@@ -340,7 +340,7 @@ class SotodlibConfig:
     """
 
 
-@dataclass(frozen=True)
+@dataclass
 class MapMakingConfig:
     method: Methods = Methods.BINNED
     scanning_mask: bool = False

--- a/src/furax/mapmaking/mapmaker.py
+++ b/src/furax/mapmaking/mapmaker.py
@@ -302,9 +302,6 @@ class MultiObservationMapMaker(Generic[T]):
         _, model = jax.lax.scan(build_one, None, self.get_indices())
 
         _, _, n_pad = self.obs_distribution
-        if n_pad == 0:
-            return model  # type: ignore[no-any-return]
-
         return pad_model(model, n_pad)
 
     def accumulate_hits(self, models: ObservationModel) -> Int64[Array, ' pixels']:

--- a/src/furax/mapmaking/mapmaker.py
+++ b/src/furax/mapmaking/mapmaker.py
@@ -276,6 +276,49 @@ class MultiObservationMapMaker(Generic[T]):
         return valid
 
 
+def get_obs_distribution_to_process(n_obs: int) -> tuple[int, int, int]:
+    """Compute this process's observation slice for distributed mapmaking.
+
+    Distributes ``n_obs`` observations across processes as evenly as possible
+    (first ``n_obs % n_proc`` processes get one extra), then pads each process's
+    share to the next multiple of ``local_device_count`` so every device has a
+    uniform workload.  All processes end up with the same number of total slots
+    (``n_owned + n_pad``), which is required for multi-process sharding.
+
+    Args:
+        n_obs: Total number of observations across all processes.
+
+    Returns:
+        A tuple ``(start, n_owned, n_pad)`` where ``start`` is the index of the
+        first real observation owned by this process, ``n_owned`` is the number
+        of real observations, and ``n_pad`` is the number of padding slots so that
+        ``n_owned + n_pad`` is a multiple of ``local_device_count``.
+
+    Raises:
+        ValueError: If ``n_obs < n_proc``.
+    """
+    rank = jax.process_index()
+    n_proc = jax.process_count()
+    n_local = jax.local_device_count()
+
+    if n_obs < n_proc:
+        raise ValueError(
+            f'Not enough observations ({n_obs}) for {n_proc} processes. '
+            f'Use fewer SLURM tasks or provide more observations.'
+        )
+
+    base = n_obs // n_proc
+    remainder = n_obs % n_proc
+    max_owned = base + (1 if remainder > 0 else 0)
+    n_per_proc = max_owned + (-max_owned) % n_local  # ceil to next multiple of n_local
+
+    n_owned = base + (1 if rank < remainder else 0)
+    start = rank * base + min(rank, remainder)
+    n_pad = n_per_proc - n_owned
+
+    return start, n_owned, n_pad
+
+
 def _static_landscape(lc: LandscapeConfig, dtype: DTypeLike) -> StokesLandscape | None:
     """Build a landscape from config alone, without observation data.
 

--- a/src/furax/mapmaking/mapmaker.py
+++ b/src/furax/mapmaking/mapmaker.py
@@ -2,7 +2,6 @@ import pickle
 from abc import abstractmethod
 from collections.abc import Sequence
 from dataclasses import asdict, dataclass
-from functools import cached_property
 from logging import Logger
 from math import prod
 from pathlib import Path
@@ -17,6 +16,7 @@ import pixell.utils
 from astropy.io import fits
 from astropy.wcs import WCS
 from jax import ShapeDtypeStruct
+from jax.experimental import multihost_utils as mhu
 from jax.sharding import Mesh, NamedSharding
 from jax.sharding import PartitionSpec as P
 from jaxtyping import Array, Bool, DTypeLike, Float, Int64, Integer, PyTree
@@ -93,7 +93,7 @@ class MultiObservationMapMaker(Generic[T]):
                 )
                 self.config.landscape.stokes = 'QU'
 
-    @cached_property
+    @property
     def mesh(self) -> Mesh:
         return jax.make_mesh((jax.device_count(),), ('obs',))
 
@@ -103,13 +103,9 @@ class MultiObservationMapMaker(Generic[T]):
 
     def distribute(self, x: PyTree) -> PyTree:
         """Shard a pytree of process-local arrays along the leading 'obs' axis."""
-        if jax.process_count() > 1:
-            return jax.tree.map(
-                lambda a: jax.make_array_from_process_local_data(self.sharding, a), x
-            )
-        return jax.device_put(x, self.sharding)
+        return jax.tree.map(lambda a: jax.make_array_from_process_local_data(self.sharding, a), x)
 
-    @cached_property
+    @property
     def obs_distribution(self) -> tuple[int, int, int]:
         """``(start, n_owned, n_pad)`` for this process."""
         return get_obs_distribution_to_process(self.n_observations)
@@ -182,6 +178,9 @@ class MultiObservationMapMaker(Generic[T]):
             self.config.dump_yaml(out_dir / 'mapmaking_config.yaml')
             self.logger.info('saved mapmaking configuration to file')
 
+        # Barrier so other ranks don't race ahead while rank 0 is still writing.
+        mhu.sync_global_devices('mapmaker.run.save_done')
+
         return results
 
     @property
@@ -220,7 +219,8 @@ class MultiObservationMapMaker(Generic[T]):
         hits = jax.jit(self.accumulate_hits)(model).block_until_ready()
         logger_info('Computed hit map')
 
-        rhs = jax.block_until_ready(self.accumulate_rhs(model, indices))
+        rhs_reader = self.get_reader(['metadata', 'sample_data'])
+        rhs = jax.block_until_ready(jax.jit(self.accumulate_rhs)(model, indices, rhs_reader))
         logger_info('Accumulated RHS vector')
 
         # Preconditioning
@@ -325,14 +325,20 @@ class MultiObservationMapMaker(Generic[T]):
 
         return local_hits(models)
 
-    def accumulate_rhs(self, models: ObservationModel, indices: Array) -> StokesPyTreeType:
+    def accumulate_rhs(
+        self,
+        models: ObservationModel,
+        indices: Array,
+        reader: ObservationReader[T],
+    ) -> StokesPyTreeType:
         """Accumulate the RHS vector across all observations.
 
         Uses shard_map + scan with psum for multi-device execution. ``indices``
         must be sharded along the same 'obs' axis as ``models`` (see
-        :meth:`shard_obs`).
+        :meth:`distribute`). ``reader`` is passed in (rather than built here)
+        so this method stays jit-friendly — building the reader triggers an
+        all-gather that must run outside ``jax.jit``.
         """
-        reader = self.get_reader(['metadata', 'sample_data'])
 
         def step(carry: StokesPyTreeType, args: Any) -> tuple[StokesPyTreeType, None]:
             obs, i = args
@@ -367,35 +373,46 @@ class MultiObservationMapMaker(Generic[T]):
         return valid
 
 
-def get_obs_distribution_to_process(n_obs: int) -> tuple[int, int, int]:
-    """Compute this process's observation slice for distributed mapmaking.
+def get_obs_distribution_to_process(
+    n_obs: int,
+    rank: int | None = None,
+    n_proc: int | None = None,
+    n_local: int | None = None,
+) -> tuple[int, int, int]:
+    """Compute this process's slice for distributed mapmaking.
 
     Distributes ``n_obs`` observations across processes as evenly as possible
     (first ``n_obs % n_proc`` processes get one extra), then pads each process's
-    share to the next multiple of ``local_device_count`` so every device has a
-    uniform workload.  All processes end up with the same number of total slots
+    share to the next multiple of ``n_local`` so every device has a uniform
+    workload.  All processes end up with the same number of total slots
     (``n_owned + n_pad``), which is required for multi-process sharding.
 
     Args:
         n_obs: Total number of observations across all processes.
+        rank: Process index. Defaults to ``jax.process_index()``.
+        n_proc: Process count. Defaults to ``jax.process_count()``.
+        n_local: Local device count. Defaults to ``jax.local_device_count()``.
 
     Returns:
         A tuple ``(start, n_owned, n_pad)`` where ``start`` is the index of the
         first real observation owned by this process, ``n_owned`` is the number
         of real observations, and ``n_pad`` is the number of padding slots so that
-        ``n_owned + n_pad`` is a multiple of ``local_device_count``.
+        ``n_owned + n_pad`` is a multiple of ``n_local``.
 
     Raises:
         ValueError: If ``n_obs < n_proc``.
     """
-    rank = jax.process_index()
-    n_proc = jax.process_count()
-    n_local = jax.local_device_count()
+    if rank is None:
+        rank = jax.process_index()
+    if n_proc is None:
+        n_proc = jax.process_count()
+    if n_local is None:
+        n_local = jax.local_device_count()
 
     if n_obs < n_proc:
         raise ValueError(
             f'Not enough observations ({n_obs}) for {n_proc} processes. '
-            f'Use fewer SLURM tasks or provide more observations.'
+            f'Provide more observations or run with fewer processes.'
         )
 
     base = n_obs // n_proc

--- a/src/furax/mapmaking/mapmaker.py
+++ b/src/furax/mapmaking/mapmaker.py
@@ -126,7 +126,7 @@ class MultiObservationMapMaker(Generic[T]):
         """Build an ObservationReader for this process's local observations."""
         return ObservationReader.from_observations_distributed(
             self.observations,
-            tuple(self.get_indices()),
+            tuple(self.get_padded_indices()),
             requested_fields=required_fields,
             demodulated=self.config.demodulated,
             stokes=self.config.landscape.stokes,

--- a/src/furax/mapmaking/mapmaker.py
+++ b/src/furax/mapmaking/mapmaker.py
@@ -315,6 +315,7 @@ class MultiObservationMapMaker(Generic[T]):
         def step(carry, model):  # type: ignore[no-untyped-def]
             return carry + model.hits(), None
 
+        # check_vma=False: furax operator chain inside the body lacks manual-axis annotations.
         @jax.shard_map(mesh=self.mesh, in_specs=P('obs'), out_specs=P(), check_vma=False)
         def local_hits(local_models: ObservationModel) -> Int64[Array, ' pixels']:
             hits, _ = jax.lax.scan(step, init, local_models)
@@ -336,6 +337,7 @@ class MultiObservationMapMaker(Generic[T]):
             data, _ = reader.read(i)
             return furax.tree.add(carry, obs.rhs(data, self.config)), None
 
+        # check_vma=False: furax operator chain inside the body lacks manual-axis annotations.
         @jax.shard_map(
             mesh=self.mesh, in_specs=(P('obs'), P('obs')), out_specs=P(), check_vma=False
         )

--- a/src/furax/mapmaking/mapmaker.py
+++ b/src/furax/mapmaking/mapmaker.py
@@ -2,6 +2,7 @@ import pickle
 from abc import abstractmethod
 from collections.abc import Sequence
 from dataclasses import asdict, dataclass
+from functools import cached_property
 from logging import Logger
 from math import prod
 from pathlib import Path
@@ -16,10 +17,12 @@ import pixell.utils
 from astropy.io import fits
 from astropy.wcs import WCS
 from jax import ShapeDtypeStruct
-from jaxtyping import Array, Bool, DTypeLike, Float, Int64, Integer
+from jax.sharding import Mesh, NamedSharding
+from jax.sharding import PartitionSpec as P
+from jaxtyping import Array, Bool, DTypeLike, Float, Int64, Integer, PyTree
 
 import furax.linalg
-import furax.tree as tree
+import furax.tree
 from furax import (
     AbstractLinearOperator,
     Config,
@@ -44,7 +47,7 @@ from furax.obs.stokes import Stokes, StokesIQU, StokesPyTreeType, ValidStokesTyp
 from . import templates
 from ._geometry import minimum_enclosing_arc
 from ._logger import logger as furax_logger
-from ._model import ObservationModel, SystemOperator
+from ._model import ObservationModel, SystemOperator, pad_model
 from ._observation import AbstractGroundObservation, AbstractLazyObservation
 from ._reader import ObservationReader
 from .config import LandscapeConfig, MapMakingConfig, Methods, WCSConfig
@@ -90,6 +93,45 @@ class MultiObservationMapMaker(Generic[T]):
                 )
                 self.config.landscape.stokes = 'QU'
 
+    @cached_property
+    def mesh(self) -> Mesh:
+        return jax.make_mesh((jax.device_count(),), ('obs',))
+
+    @property
+    def sharding(self) -> NamedSharding:
+        return NamedSharding(self.mesh, P('obs'))
+
+    def distribute(self, x: PyTree) -> PyTree:
+        """Shard a pytree of process-local arrays along the leading 'obs' axis."""
+        if jax.process_count() > 1:
+            return jax.tree.map(
+                lambda a: jax.make_array_from_process_local_data(self.sharding, a), x
+            )
+        return jax.device_put(x, self.sharding)
+
+    @cached_property
+    def obs_distribution(self) -> tuple[int, int, int]:
+        """``(start, n_owned, n_pad)`` for this process."""
+        return get_obs_distribution_to_process(self.n_observations)
+
+    def get_indices(self) -> np.ndarray:
+        start, n_owned, _ = self.obs_distribution
+        return np.arange(start, start + n_owned)
+
+    def get_padded_indices(self) -> np.ndarray:
+        _, _, n_pad = self.obs_distribution
+        return np.pad(self.get_indices(), (0, n_pad), mode='edge')
+
+    def get_reader(self, required_fields: Sequence[str]) -> ObservationReader[T]:
+        """Build an ObservationReader for this process's local observations."""
+        return ObservationReader.from_observations_distributed(
+            self.observations,
+            tuple(self.get_indices()),
+            requested_fields=required_fields,
+            demodulated=self.config.demodulated,
+            stokes=self.config.landscape.stokes,
+        )
+
     def _scan_wcs_footprint(self) -> WCSLandscape:
         """Scan observations to determine the combined WCS footprint and build a WCSLandscape.
 
@@ -130,8 +172,8 @@ class MultiObservationMapMaker(Generic[T]):
         """Runs the mapmaker and return results after saving them to the given directory."""
         results = self.make_maps()
 
-        # Save outputs
-        if out_dir is not None:
+        # Save outputs on process 0 only (all processes hold the same replicated result)
+        if out_dir is not None and jax.process_index() == 0:
             out_dir = Path(out_dir)
             results.save(out_dir)
             self.logger.info(f'saved results to {out_dir}')
@@ -140,46 +182,63 @@ class MultiObservationMapMaker(Generic[T]):
 
         return results
 
-    def get_reader(self, data_field_names: list[str]) -> ObservationReader[T]:
-        """Returns a reader for a list of requested fields."""
-        return ObservationReader(
-            self.observations,
-            requested_fields=data_field_names,
-            demodulated=self.config.demodulated,
-            stokes=self.config.landscape.stokes,
-        )
+    @property
+    def n_observations(self) -> int:
+        """Total number of observations across all processes."""
+        return len(self.observations)
 
     def make_maps(self) -> MapMakingResults:
         """Computes the mapmaker results (maps and other products)."""
         logger_info = lambda msg: self.logger.info(f'MultiObsMapMaker: {msg}')
 
-        # Build system matrix from stacked ObservationModel
-        model = self.build_model()
-        A = SystemOperator(model)
+        n_processes = jax.process_count()
+        rank = jax.process_index()
+        n_local_devices = jax.local_device_count()
+        n_devices = jax.device_count()
+        start, n_owned, n_pad = self.obs_distribution
+        n_per_proc = n_owned + n_pad
+        n_per_dev = n_per_proc // n_local_devices
+        logger_info(
+            f'Layout: {n_processes} process(es) x {n_local_devices} local device(s) = {n_devices} total'
+        )
+        logger_info(
+            f'Observations: {self.n_observations} real, {n_per_proc * n_processes} after padding '
+            f'({n_per_proc} per process, {n_per_dev} per device)'
+        )
+        logger_info(
+            f'Rank {rank}: owns obs[{start}:{start + n_owned}] ({n_owned} real + {n_pad} padding)'
+        )
+
+        model = self.distribute(self.build_model())
+        indices = self.distribute(self.get_padded_indices())
+
+        A = SystemOperator(model, mesh=self.mesh)
         logger_info('Created system operator')
 
-        hits = self.accumulate_hits(model).block_until_ready()
+        hits = jax.jit(self.accumulate_hits)(model).block_until_ready()
         logger_info('Computed hit map')
 
-        rhs = self.accumulate_rhs(model)
+        rhs = jax.block_until_ready(self.accumulate_rhs(model, indices))
         logger_info('Accumulated RHS vector')
 
         # Preconditioning
-        sysdiag = A if self.config.binned else SystemOperator(model, diag=True)
+        sysdiag = A if self.config.binned else SystemOperator(model, diag=True, mesh=self.mesh)
         BJ = BJPreconditioner.create(sysdiag)
         icov = BJ.get_blocks().block_until_ready()
         logger_info('Computed white noise inverse covariance')
 
-        # Pixel selection
-        valid_pixels = self.pixel_selection(hits, icov)
-        selector = IndexOperator(jnp.where(valid_pixels), in_structure=model.map_structure)
-        n_selected = jnp.sum(valid_pixels)
-        n_observed = jnp.sum(hits > 0)
-        n_total = valid_pixels.size
-        logger_info(f'Selected {n_selected} pixels ({n_observed} seen, {n_total} total)')
+        # Pixel selection (post-processing under the mesh so eager ops on
+        # explicit-sharded arrays can dispatch in multi-process runs).
+        with jax.set_mesh(self.mesh):
+            valid_pixels = self.pixel_selection(hits, icov)
+            selector = IndexOperator(jnp.where(valid_pixels), in_structure=model.map_structure)
+            n_selected = jnp.sum(valid_pixels)
+            n_observed = jnp.sum(hits > 0)
+            n_total = valid_pixels.size
+            logger_info(f'Selected {n_selected} pixels ({n_observed} seen, {n_total} total)')
 
-        hits = hits.at[~valid_pixels].set(0)  # excluded pixels have zero hits
-        icov = jnp.moveaxis(icov, [-2, -1], [0, 1])  # (*pixels, ns, ns) → (ns, ns, *pixels)
+            hits = hits.at[~valid_pixels].set(0)  # excluded pixels have zero hits
+            icov = jnp.moveaxis(icov, [-2, -1], [0, 1])  # (*pixels, ns, ns) → (ns, ns, *pixels)
 
         # Solve the mapmaking system
         solver = lineax.CG(**asdict(self.config.solver))
@@ -209,7 +268,11 @@ class MultiObservationMapMaker(Generic[T]):
         )
 
     def build_model(self) -> ObservationModel:
-        # Only read necessary fields
+        """Build the local ObservationModel for this process.
+
+        Each process reads its owned observations and pads up to the uniform
+        per-process count.
+        """
         required_fields = [
             'boresight_quaternions',
             'detector_quaternions',
@@ -227,36 +290,60 @@ class MultiObservationMapMaker(Generic[T]):
             required_fields.append('noise_model_fits')
         if self.config.gaps.fill and not self.config.binned:
             required_fields.append('metadata')
+
         reader = self.get_reader(required_fields)
 
         def build_one(_, i):  # type: ignore[no-untyped-def]
             data, padding = reader.read(i)
             return None, ObservationModel.create(data, padding, self.config, self.landscape)
 
-        _, model = jax.lax.scan(build_one, None, jnp.arange(reader.count))
-        return model  # type: ignore[no-any-return]
+        _, model = jax.lax.scan(build_one, None, self.get_indices())
+
+        _, _, n_pad = self.obs_distribution
+        if n_pad == 0:
+            return model  # type: ignore[no-any-return]
+
+        return pad_model(model, n_pad)
 
     def accumulate_hits(self, models: ObservationModel) -> Int64[Array, ' pixels']:
-        def acc(carry, model):  # type: ignore[no-untyped-def]
+        """Accumulate hit map across all observations.
+
+        Uses shard_map + scan with psum for multi-device execution.
+        """
+        init = jnp.zeros(self.landscape.shape, dtype=jnp.int64)
+
+        def step(carry, model):  # type: ignore[no-untyped-def]
             return carry + model.hits(), None
 
-        init = jnp.zeros(self.landscape.shape, dtype=jnp.int64)
-        total, _ = jax.lax.scan(acc, init, models)
-        return total
+        @jax.shard_map(mesh=self.mesh, in_specs=P('obs'), out_specs=P(), check_vma=False)
+        def local_hits(local_models: ObservationModel) -> Int64[Array, ' pixels']:
+            hits, _ = jax.lax.scan(step, init, local_models)
+            return jax.lax.psum(hits, axis_name='obs')  # type: ignore[no-any-return]
 
-    def accumulate_rhs(self, models: ObservationModel) -> StokesPyTreeType:
-        """Accumulate the RHS vector across all observations"""
+        return local_hits(models)
+
+    def accumulate_rhs(self, models: ObservationModel, indices: Array) -> StokesPyTreeType:
+        """Accumulate the RHS vector across all observations.
+
+        Uses shard_map + scan with psum for multi-device execution. ``indices``
+        must be sharded along the same 'obs' axis as ``models`` (see
+        :meth:`shard_obs`).
+        """
         reader = self.get_reader(['metadata', 'sample_data'])
 
-        def acc(carry, args):  # type: ignore[no-untyped-def]
-            i, model = args
+        def step(carry: StokesPyTreeType, args: Any) -> tuple[StokesPyTreeType, None]:
+            obs, i = args
             data, _ = reader.read(i)
-            carry = carry + model.rhs(data, self.config)
-            return carry, None
+            return furax.tree.add(carry, obs.rhs(data, self.config)), None
 
-        init = tree.zeros_like(models.map_structure)
-        total, _ = jax.lax.scan(acc, init, (jnp.arange(reader.count), models))
-        return total  # type: ignore[no-any-return]
+        @jax.shard_map(
+            mesh=self.mesh, in_specs=(P('obs'), P('obs')), out_specs=P(), check_vma=False
+        )
+        def local_rhs(local_models: ObservationModel, local_indices: Any) -> StokesPyTreeType:
+            rhs, _ = jax.lax.scan(step, self.landscape.zeros(), (local_models, local_indices))
+            return jax.lax.psum(rhs, axis_name='obs')  # type: ignore[no-any-return]
+
+        return local_rhs(models, indices)
 
     def pixel_selection(
         self, hits: Integer[Array, ' pixels'], weights: Float[Array, 'pixels stokes stokes']

--- a/src/furax/mapmaking/mapmaker.py
+++ b/src/furax/mapmaking/mapmaker.py
@@ -110,13 +110,13 @@ class MultiObservationMapMaker(Generic[T]):
         """``(start, n_owned, n_pad)`` for this process."""
         return get_obs_distribution_to_process(self.n_observations)
 
-    def get_indices(self) -> np.ndarray:
+    def get_read_indices(self) -> np.ndarray:
         start, n_owned, _ = self.obs_distribution
         return np.arange(start, start + n_owned)
 
-    def get_padded_indices(self) -> np.ndarray:
+    def get_padded_read_indices(self) -> np.ndarray:
         _, _, n_pad = self.obs_distribution
-        return np.pad(self.get_indices(), (0, n_pad), mode='edge')
+        return np.pad(self.get_read_indices(), (0, n_pad), mode='edge')
 
     def get_reader(self, required_fields: Sequence[str]) -> ObservationReader[T]:
         """Build an ObservationReader for this process's local observations."""
@@ -124,7 +124,7 @@ class MultiObservationMapMaker(Generic[T]):
         # rank to send the same shape, so all ranks must report the same obs count.
         return ObservationReader.from_observations(
             self.observations,
-            subset_indices=tuple(self.get_padded_indices()),
+            read_indices=tuple(self.get_padded_read_indices()),
             requested_fields=required_fields,
             demodulated=self.config.demodulated,
             stokes=self.config.landscape.stokes,
@@ -211,7 +211,7 @@ class MultiObservationMapMaker(Generic[T]):
         )
 
         model = self.distribute(self.build_model())
-        indices = self.distribute(self.get_padded_indices())
+        read_indices = self.distribute(self.get_padded_read_indices())
 
         A = SystemOperator(model, mesh=self.mesh)
         logger_info('Created system operator')
@@ -220,7 +220,7 @@ class MultiObservationMapMaker(Generic[T]):
         logger_info('Computed hit map')
 
         rhs_reader = self.get_reader(['metadata', 'sample_data'])
-        rhs = jax.block_until_ready(jax.jit(self.accumulate_rhs)(model, indices, rhs_reader))
+        rhs = jax.block_until_ready(jax.jit(self.accumulate_rhs)(model, read_indices, rhs_reader))
         logger_info('Accumulated RHS vector')
 
         # Preconditioning
@@ -299,7 +299,7 @@ class MultiObservationMapMaker(Generic[T]):
             data, padding = reader.read(i)
             return None, ObservationModel.create(data, padding, self.config, self.landscape)
 
-        _, model = jax.lax.scan(build_one, None, self.get_indices())
+        _, model = jax.lax.scan(build_one, None, self.get_read_indices())
 
         _, _, n_pad = self.obs_distribution
         return pad_model(model, n_pad)
@@ -325,12 +325,12 @@ class MultiObservationMapMaker(Generic[T]):
     def accumulate_rhs(
         self,
         models: ObservationModel,
-        indices: Array,
+        read_indices: Array,
         reader: ObservationReader[T],
     ) -> StokesPyTreeType:
         """Accumulate the RHS vector across all observations.
 
-        Uses shard_map + scan with psum for multi-device execution. ``indices``
+        Uses shard_map + scan with psum for multi-device execution.  ``read_indices``
         must be sharded along the same 'obs' axis as ``models`` (see
         :meth:`distribute`). ``reader`` is passed in (rather than built here)
         so this method stays jit-friendly — building the reader triggers an
@@ -350,7 +350,7 @@ class MultiObservationMapMaker(Generic[T]):
             rhs, _ = jax.lax.scan(step, self.landscape.zeros(), (local_models, local_indices))
             return jax.lax.psum(rhs, axis_name='obs')  # type: ignore[no-any-return]
 
-        return local_rhs(models, indices)
+        return local_rhs(models, read_indices)
 
     def pixel_selection(
         self, hits: Integer[Array, ' pixels'], weights: Float[Array, 'pixels stokes stokes']

--- a/src/furax/mapmaking/mapmaker.py
+++ b/src/furax/mapmaking/mapmaker.py
@@ -124,9 +124,11 @@ class MultiObservationMapMaker(Generic[T]):
 
     def get_reader(self, required_fields: Sequence[str]) -> ObservationReader[T]:
         """Build an ObservationReader for this process's local observations."""
-        return ObservationReader.from_observations_distributed(
+        # Pass padded indices: process_allgather inside from_observations needs every
+        # rank to send the same shape, so all ranks must report the same obs count.
+        return ObservationReader.from_observations(
             self.observations,
-            tuple(self.get_padded_indices()),
+            subset_indices=tuple(self.get_padded_indices()),
             requested_fields=required_fields,
             demodulated=self.config.demodulated,
             stokes=self.config.landscape.stokes,

--- a/src/furax/mapmaking/mapmaker.py
+++ b/src/furax/mapmaking/mapmaker.py
@@ -19,6 +19,7 @@ from jax import ShapeDtypeStruct
 from jaxtyping import Array, Bool, DTypeLike, Float, Integer
 
 import furax.linalg
+import furax.tree as tree
 from furax import (
     AbstractLinearOperator,
     Config,
@@ -47,6 +48,7 @@ from ._model import ObservationModel
 from ._observation import AbstractGroundObservation, AbstractLazyObservation
 from ._reader import ObservationReader
 from .config import LandscapeConfig, MapMakingConfig, Methods, WCSConfig
+from .gap_filling import GapFillingOperator
 from .noise import AtmosphericNoiseModel, NoiseModel, WhiteNoiseModel
 from .preconditioner import BJPreconditioner
 from .results import MapMakingResults
@@ -162,8 +164,7 @@ class MultiObservationMapMaker(Generic[T]):
         hits = model.accumulate_hits().block_until_ready()
         logger_info('Computed hit map')
 
-        reader = self.get_reader(['metadata', 'sample_data'])
-        rhs = jax.block_until_ready(model.accumulate_rhs(reader, self.config))
+        rhs = jax.block_until_ready(self.accumulate_rhs(model))
         logger_info('Accumulated RHS vector')
 
         # System operator (full/diagonal)
@@ -239,6 +240,11 @@ class MultiObservationMapMaker(Generic[T]):
         _, model = jax.lax.scan(build_one, None, jnp.arange(reader.count))
         return model  # type: ignore[no-any-return]
 
+    def accumulate_rhs(self, model: ObservationModel) -> StokesPyTreeType:
+        """Accumulate the RHS vector across all observations."""
+        reader = self.get_reader(['metadata', 'sample_data'])
+        return _accumulate_rhs(model, reader, self.config)  # type: ignore[no-any-return]
+
     def pixel_selection(
         self, hits: Integer[Array, ' pixels'], weights: Float[Array, 'pixels stokes stokes']
     ) -> Bool[Array, ' pixels']:
@@ -255,6 +261,37 @@ class MultiObservationMapMaker(Generic[T]):
             )
 
         return valid
+
+
+@jax.jit(static_argnames=('config',))
+def _accumulate_rhs(
+    model: ObservationModel,
+    reader: ObservationReader[Any],
+    config: MapMakingConfig,
+) -> StokesPyTreeType:
+    """Accumulate H^T M W tod over all observations, with optional gap-filling."""
+
+    def acc(carry, args):  # type: ignore[no-untyped-def]
+        i, obs = args
+        data, _ = reader.read(i)
+        tod = data['sample_data']
+        if config.gaps.fill and not config.binned:
+            # FIXME: check with demodulated data
+            N = obs.noise_operator(config.noise.correlation_length, inverse=False)
+            tod = GapFillingOperator(
+                N,
+                obs._get_indexer(),
+                data['metadata'],
+                obs.W,
+                rate=obs.sample_rate,
+                max_cg_steps=config.gaps.fill_options.max_steps,
+                rtol=config.gaps.fill_options.rtol,
+            )(jax.random.key(config.gaps.fill_options.seed), tod)
+        return carry + obs.rhs(tod), None
+
+    init = tree.zeros_like(model.map_structure)
+    total, _ = jax.lax.scan(acc, init, (jnp.arange(reader.count), model))
+    return total  # type: ignore[no-any-return]
 
 
 def _static_landscape(lc: LandscapeConfig, dtype: DTypeLike) -> StokesLandscape | None:

--- a/src/furax/mapmaking/mapmaker.py
+++ b/src/furax/mapmaking/mapmaker.py
@@ -358,16 +358,19 @@ def accumulate_hits(model: ObservationModel, mesh: Mesh) -> Int64[Array, '...']:
     assert isinstance(model.H, CompositionOperator)  # mypy
     pointing = model.H.operands[-1]
     assert isinstance(pointing, PointingOperator)  # mypy
-    n_total = jax.tree.leaves(model.masker)[0].shape[0]
     pointing_i = pointing.as_stokes_i(interpolate=False)
-    out_sharding = NamedSharding(mesh, P())  # output of computation should be replicated
-    P_op_T = ScanBlockRowOperator(pointing_i.T, n_total, out_sharding)
-    M_op = ScanBlockDiagonalOperator(model.masker, n_total)
-    # sharded vector of ones
-    ones = furax.tree.ones_like(M_op.in_structure)
-    ones = jax.lax.with_sharding_constraint(ones, NamedSharding(mesh, P('obs')))
-    masked_i = jax.tree.leaves(M_op(ones))[0]
-    return jnp.int64(P_op_T(StokesI(masked_i)).i)  # type: ignore[no-any-return]
+    # per-obs ones: small (n_det, n_samp), no full (n_total, ...) buffer created
+    per_obs_ones = furax.tree.ones_like(model.masker.in_structure)
+
+    def step(carry, args):  # type: ignore[no-untyped-def]
+        p_i, m_i = args
+        masked_i = jax.tree.leaves(m_i(per_obs_ones))[0]
+        return carry + jnp.int64(p_i.T(StokesI(masked_i)).i), None
+
+    map_shape = jax.tree.leaves(pointing_i.in_structure)[0].shape
+    hits, _ = jax.lax.scan(step, jnp.zeros(map_shape, jnp.int64), (pointing_i, model.masker))
+    # each device accumulates its local obs; all-reduce to replicated global hits
+    return jax.lax.with_sharding_constraint(hits, NamedSharding(mesh, P()))  # type: ignore[no-any-return]
 
 
 @jax.jit(static_argnames=('config', 'mesh'))

--- a/src/furax/mapmaking/mapmaker.py
+++ b/src/furax/mapmaking/mapmaker.py
@@ -217,13 +217,14 @@ class MultiObservationMapMaker(Generic[T]):
         )
 
         model = self.distribute(pad_model(self.build_model(), n_pad))
-        read_indices = self.distribute(self.get_padded_read_indices())
         logger_info('Created system operators')
 
-        hits = jax.block_until_ready(self.accumulate_hits(model))
+        hits = accumulate_hits(model, self.mesh)
+        jax.block_until_ready(hits)
         logger_info('Computed hit map')
 
-        rhs = jax.block_until_ready(self.accumulate_rhs(model, read_indices))
+        rhs = self.accumulate_rhs(model)
+        jax.block_until_ready(rhs)
         logger_info('Accumulated RHS vector')
 
         # System operator (full/diagonal)
@@ -312,19 +313,14 @@ class MultiObservationMapMaker(Generic[T]):
         return (n_owned + n_pad) // jax.local_device_count()
 
     def accumulate_hits(self, model: ObservationModel) -> Int64[Array, '...']:
-        """Accumulate hit map across all observations."""
-        n_total = self.n_per_device * jax.device_count()
-        assert isinstance(model.H, CompositionOperator)  # mypy assert
-        pointing = model.H.operands[-1]
-        assert isinstance(pointing, PointingOperator)  # mypy assert
-        P_op = ScanBlockColumnOperator(pointing.as_stokes_i(interpolate=False), n_total)
-        M_op = ScanBlockDiagonalOperator(model.masker, n_total)
-        return _accumulate_hits(P_op, M_op, self.sharding)  # type: ignore[no-any-return]
+        """Accumulate hit count map across all observations."""
+        return accumulate_hits(model, self.mesh)  # type: ignore[no-any-return]
 
-    def accumulate_rhs(self, model: ObservationModel, read_indices: Array) -> StokesPyTreeType:
+    def accumulate_rhs(self, model: ObservationModel) -> StokesPyTreeType:
         """Accumulate the RHS vector across all observations."""
         reader = self.get_reader(['metadata', 'sample_data'])
-        return _accumulate_rhs(model, read_indices, reader, self.config, self.sharding)  # type: ignore[no-any-return]
+        read_indices = self.distribute(self.get_padded_read_indices())
+        return accumulate_rhs(model, read_indices, reader, self.config, self.mesh)  # type: ignore[no-any-return]
 
     def get_system_operator(
         self, model: ObservationModel, *, diag: bool = False
@@ -357,23 +353,30 @@ class MultiObservationMapMaker(Generic[T]):
         return valid
 
 
-@jax.jit(static_argnames=('sharding',))
-def _accumulate_hits(
-    pointing: AbstractLinearOperator, mask: AbstractLinearOperator, sharding: NamedSharding
-) -> Int64[Array, '...']:
-    ones = furax.tree.ones_like(mask.in_structure)
-    masked_i = jax.tree.leaves(mask(ones))[0]
-    hits = jnp.int64(pointing.T(StokesI(masked_i)).i)
-    return jax.lax.with_sharding_constraint(hits, sharding)  # type: ignore[no-any-return]
+@jax.jit(static_argnames=('mesh',))
+def accumulate_hits(model: ObservationModel, mesh: Mesh) -> Int64[Array, '...']:
+    assert isinstance(model.H, CompositionOperator)  # mypy
+    pointing = model.H.operands[-1]
+    assert isinstance(pointing, PointingOperator)  # mypy
+    n_total = jax.tree.leaves(model.masker)[0].shape[0]
+    pointing_i = pointing.as_stokes_i(interpolate=False)
+    out_sharding = NamedSharding(mesh, P())  # output of computation should be replicated
+    P_op_T = ScanBlockRowOperator(pointing_i.T, n_total, out_sharding)
+    M_op = ScanBlockDiagonalOperator(model.masker, n_total)
+    # sharded vector of ones
+    ones = furax.tree.ones_like(M_op.in_structure)
+    ones = jax.lax.with_sharding_constraint(ones, NamedSharding(mesh, P('obs')))
+    masked_i = jax.tree.leaves(M_op(ones))[0]
+    return jnp.int64(P_op_T(StokesI(masked_i)).i)  # type: ignore[no-any-return]
 
 
-@jax.jit(static_argnames=('config', 'sharding'))
-def _accumulate_rhs(
+@jax.jit(static_argnames=('config', 'mesh'))
+def accumulate_rhs(
     model: ObservationModel,
     read_indices: Array,
     reader: ObservationReader[T],
     config: MapMakingConfig,
-    sharding: NamedSharding,
+    mesh: Mesh,
 ) -> StokesPyTreeType:
 
     def step(carry: StokesPyTreeType, args: Any) -> tuple[StokesPyTreeType, None]:
@@ -394,7 +397,7 @@ def _accumulate_rhs(
         return furax.tree.add(carry, obs.H.T(obs.masker(obs.W(tod)))), None
 
     rhs, _ = jax.lax.scan(step, furax.tree.zeros_like(model.map_structure), (model, read_indices))
-    return jax.lax.with_sharding_constraint(rhs, sharding)  # type: ignore[no-any-return]
+    return jax.lax.with_sharding_constraint(rhs, NamedSharding(mesh, P()))  # type: ignore[no-any-return]
 
 
 def get_obs_distribution_to_process(

--- a/src/furax/mapmaking/mapmaker.py
+++ b/src/furax/mapmaking/mapmaker.py
@@ -227,18 +227,16 @@ class MultiObservationMapMaker(Generic[T]):
         jax.block_until_ready(rhs)
         logger_info('Accumulated RHS vector')
 
-        # System operator (full/diagonal)
-        A = self.get_system_operator(model)
-        diag_A = A if self.config.binned else self.get_system_operator(model, diag=True)
-        BJ = BJPreconditioner.create(diag_A)
-        icov = BJ.get_blocks().block_until_ready()
-        logger_info('Computed white noise inverse covariance')
-
-        # Pixel selection and solve: eager ops on sharded arrays need mesh context.
-        # init in ScanBlock operators created inside shard_map to avoid closure issues.
         with jax.set_mesh(self.mesh):
+            # System operator (full/diagonal)
+            A = self.get_system_operator(model)
+            diag_A = A if self.config.binned else self.get_system_operator(model, diag=True)
+            BJ = BJPreconditioner.create(diag_A)
+            icov = BJ.get_blocks().block_until_ready()
+            logger_info('Computed white noise inverse covariance')
+
             valid_pixels = self.pixel_selection(hits, icov)
-            selector = IndexOperator(jnp.where(valid_pixels), in_structure=model.map_structure)
+            selector = IndexOperator(jnp.where(valid_pixels), in_structure=A.out_structure)
             n_selected = jnp.sum(valid_pixels)
             n_observed = jnp.sum(hits > 0)
             n_total = valid_pixels.size
@@ -266,6 +264,7 @@ class MultiObservationMapMaker(Generic[T]):
             estimate = selector.T(solution.value)
             num_steps = solution.stats['num_steps']
             logger_info(f'Finished mapmaking (iteration steps: {num_steps})')
+
         return MapMakingResults(
             map=estimate,
             icov=icov,
@@ -359,12 +358,12 @@ def accumulate_hits(model: ObservationModel, mesh: Mesh) -> Int64[Array, '...']:
     pointing_i = pointing.as_stokes_i(interpolate=False)
 
     map_shape = jax.tree.leaves(pointing_i.in_structure)[0].shape
-    zeros = jnp.zeros(map_shape, jnp.int64)
 
     in_sharding = NamedSharding(mesh, P('obs'))
     pointing_i = jax.tree.map(lambda a: jax.reshard(a, in_sharding), pointing_i)
     masker = jax.tree.map(lambda a: jax.reshard(a, in_sharding), model.masker)
 
+    @jax.shard_map(mesh=mesh, out_specs=P(), check_vma=False)
     def hits_kernel(
         pointing_i: PointingOperator, masker: AbstractLinearOperator
     ) -> Int64[Array, '...']:
@@ -375,11 +374,11 @@ def accumulate_hits(model: ObservationModel, mesh: Mesh) -> Int64[Array, '...']:
             masked_i = jax.tree.leaves(m_i(per_obs_ones))[0]
             return carry + jnp.int64(p_i.T(StokesI(masked_i)).i), None
 
-        init = jax.lax.pcast(zeros, mesh.axis_names, to='varying')
+        init = jax.lax.pcast(jnp.zeros(map_shape, jnp.int64), mesh.axis_names, to='varying')
         hits, _ = jax.lax.scan(step, init, (pointing_i, masker))
         return jax.lax.psum(hits, axis_name=mesh.axis_names)  # type: ignore[no-any-return]
 
-    return jax.shard_map(hits_kernel, mesh=mesh, out_specs=P())(pointing_i, masker)
+    return hits_kernel(pointing_i, masker)
 
 
 @jax.jit(static_argnames=('config', 'mesh'))
@@ -394,8 +393,9 @@ def accumulate_rhs(
     model = jax.tree.map(lambda a: jax.reshard(a, in_sharding), model)
     read_indices = jax.reshard(read_indices, in_sharding)
 
-    zeros = furax.tree.zeros_like(model.map_structure)
+    map_structure = model.map_structure
 
+    @jax.shard_map(mesh=mesh, out_specs=P(), check_vma=False)
     def rhs_kernel(model: ObservationModel, indices: Array) -> StokesPyTreeType:
         def step(carry: StokesPyTreeType, args: Any) -> tuple[StokesPyTreeType, None]:
             obs, i = args
@@ -414,11 +414,11 @@ def accumulate_rhs(
                 )(jax.random.key(config.gaps.fill_options.seed), tod)
             return furax.tree.add(carry, obs.H.T(obs.masker(obs.W(tod)))), None
 
-        init = jax.lax.pcast(zeros, mesh.axis_names, to='varying')
+        init = jax.lax.pcast(furax.tree.zeros_like(map_structure), mesh.axis_names, to='varying')
         rhs, _ = jax.lax.scan(step, init, (model, indices))
         return jax.lax.psum(rhs, axis_name=mesh.axis_names)  # type: ignore[no-any-return]
 
-    return jax.shard_map(rhs_kernel, mesh=mesh, out_specs=P())(model, read_indices)
+    return rhs_kernel(model, read_indices)
 
 
 def get_obs_distribution_to_process(

--- a/src/furax/mapmaking/mapmaker.py
+++ b/src/furax/mapmaking/mapmaker.py
@@ -219,15 +219,14 @@ class MultiObservationMapMaker(Generic[T]):
         model = self.distribute(pad_model(self.build_model(), n_pad))
         logger_info('Created system operators')
 
-        hits = accumulate_hits(model, self.mesh)
-        jax.block_until_ready(hits)
-        logger_info('Computed hit map')
-
-        rhs = self.accumulate_rhs(model)
-        jax.block_until_ready(rhs)
-        logger_info('Accumulated RHS vector')
-
         with jax.set_mesh(self.mesh):
+            hits = accumulate_hits(model)
+            jax.block_until_ready(hits)
+            logger_info('Computed hit map')
+
+            rhs = self.accumulate_rhs(model)
+            jax.block_until_ready(rhs)
+            logger_info('Accumulated RHS vector')
             # System operator (full/diagonal)
             A = self.get_system_operator(model)
             diag_A = A if self.config.binned else self.get_system_operator(model, diag=True)
@@ -315,13 +314,13 @@ class MultiObservationMapMaker(Generic[T]):
 
     def accumulate_hits(self, model: ObservationModel) -> Int64[Array, '...']:
         """Accumulate hit count map across all observations."""
-        return accumulate_hits(model, self.mesh)  # type: ignore[no-any-return]
+        return accumulate_hits(model)  # type: ignore[no-any-return]
 
     def accumulate_rhs(self, model: ObservationModel) -> StokesPyTreeType:
         """Accumulate the RHS vector across all observations."""
         reader = self.get_reader(['metadata', 'sample_data'])
         read_indices = self.distribute(self.get_padded_read_indices())
-        return accumulate_rhs(model, read_indices, reader, self.config, self.mesh)  # type: ignore[no-any-return]
+        return accumulate_rhs(model, read_indices, reader, self.config)  # type: ignore[no-any-return]
 
     def get_system_operator(
         self, model: ObservationModel, *, diag: bool = False
@@ -350,8 +349,8 @@ class MultiObservationMapMaker(Generic[T]):
         return valid
 
 
-@jax.jit(static_argnames=('mesh',))
-def accumulate_hits(model: ObservationModel, mesh: Mesh) -> Int64[Array, '...']:
+@jax.jit
+def accumulate_hits(model: ObservationModel) -> Int64[Array, '...']:
     assert isinstance(model.H, CompositionOperator)  # mypy
     pointing = model.H.operands[-1]
     assert isinstance(pointing, PointingOperator)  # mypy
@@ -359,14 +358,13 @@ def accumulate_hits(model: ObservationModel, mesh: Mesh) -> Int64[Array, '...']:
 
     map_shape = jax.tree.leaves(pointing_i.in_structure)[0].shape
 
-    in_sharding = NamedSharding(mesh, P('obs'))
-    pointing_i = jax.tree.map(lambda a: jax.reshard(a, in_sharding), pointing_i)
-    masker = jax.tree.map(lambda a: jax.reshard(a, in_sharding), model.masker)
+    mesh = jax.sharding.get_abstract_mesh()
+    axis = mesh.axis_names[0]
+    pointing_i = jax.tree.map(lambda a: jax.reshard(a, P(axis)), pointing_i)
+    masker = jax.tree.map(lambda a: jax.reshard(a, P(axis)), model.masker)
 
-    @jax.shard_map(mesh=mesh, out_specs=P(), check_vma=False)
-    def hits_kernel(
-        pointing_i: PointingOperator, masker: AbstractLinearOperator
-    ) -> Int64[Array, '...']:
+    @jax.shard_map(out_specs=P(), check_vma=False)
+    def hits_kernel(pointing_i, masker):  # type: ignore[no-untyped-def]
         per_obs_ones = furax.tree.ones_like(masker.in_structure)
 
         def step(carry, args):  # type: ignore[no-untyped-def]
@@ -374,28 +372,28 @@ def accumulate_hits(model: ObservationModel, mesh: Mesh) -> Int64[Array, '...']:
             masked_i = jax.tree.leaves(m_i(per_obs_ones))[0]
             return carry + jnp.int64(p_i.T(StokesI(masked_i)).i), None
 
-        init = jax.lax.pcast(jnp.zeros(map_shape, jnp.int64), mesh.axis_names, to='varying')
+        init = jax.lax.pcast(jnp.zeros(map_shape, jnp.int64), axis, to='varying')
         hits, _ = jax.lax.scan(step, init, (pointing_i, masker))
-        return jax.lax.psum(hits, axis_name=mesh.axis_names)  # type: ignore[no-any-return]
+        return jax.lax.psum(hits, axis_name=axis)
 
-    return hits_kernel(pointing_i, masker)
+    return hits_kernel(pointing_i, masker)  # type: ignore[no-any-return]
 
 
-@jax.jit(static_argnames=('config', 'mesh'))
+@jax.jit(static_argnames=('config',))
 def accumulate_rhs(
     model: ObservationModel,
     read_indices: Array,
     reader: ObservationReader[T],
     config: MapMakingConfig,
-    mesh: Mesh,
 ) -> StokesPyTreeType:
-    in_sharding = NamedSharding(mesh, P('obs'))
-    model = jax.tree.map(lambda a: jax.reshard(a, in_sharding), model)
-    read_indices = jax.reshard(read_indices, in_sharding)
+    mesh = jax.sharding.get_abstract_mesh()
+    axis = mesh.axis_names[0]
+    model = jax.tree.map(lambda a: jax.reshard(a, P(axis)), model)
+    read_indices = jax.reshard(read_indices, P(axis))
 
     map_structure = model.map_structure
 
-    @jax.shard_map(mesh=mesh, out_specs=P(), check_vma=False)
+    @jax.shard_map(out_specs=P(), check_vma=False)
     def rhs_kernel(model: ObservationModel, indices: Array) -> StokesPyTreeType:
         def step(carry: StokesPyTreeType, args: Any) -> tuple[StokesPyTreeType, None]:
             obs, i = args
@@ -414,9 +412,9 @@ def accumulate_rhs(
                 )(jax.random.key(config.gaps.fill_options.seed), tod)
             return furax.tree.add(carry, obs.H.T(obs.masker(obs.W(tod)))), None
 
-        init = jax.lax.pcast(furax.tree.zeros_like(map_structure), mesh.axis_names, to='varying')
+        init = jax.lax.pcast(furax.tree.zeros_like(map_structure), axis, to='varying')
         rhs, _ = jax.lax.scan(step, init, (model, indices))
-        return jax.lax.psum(rhs, axis_name=mesh.axis_names)  # type: ignore[no-any-return]
+        return jax.lax.psum(rhs, axis_name=axis)  # type: ignore[no-any-return]
 
     return rhs_kernel(model, read_indices)
 

--- a/src/furax/mapmaking/mapmaker.py
+++ b/src/furax/mapmaking/mapmaker.py
@@ -101,8 +101,6 @@ class MultiObservationMapMaker(Generic[T]):
 
     @cached_property
     def mesh(self) -> Mesh:
-        # Auto axis types: lets GSPMD handle collectives so jax.lax.scan can iterate
-        # over a sharded leading axis (rejected under Explicit/Shardy mode).
         return jax.make_mesh((jax.device_count(),), ('obs',), axis_types=(AxisType.Auto,))
 
     @property

--- a/src/furax/mapmaking/mapmaker.py
+++ b/src/furax/mapmaking/mapmaker.py
@@ -366,8 +366,6 @@ def accumulate_hits(model: ObservationModel) -> Int64[Array, '...']:
 
     mesh = jax.sharding.get_abstract_mesh()
     axis = mesh.axis_names[0]
-    pointing_i = jax.tree.map(lambda a: jax.reshard(a, P(axis)), pointing_i)
-    masker = jax.tree.map(lambda a: jax.reshard(a, P(axis)), model.masker)
 
     @jax.shard_map(out_specs=P(), check_vma=False)
     def hits_kernel(pointing_i, masker):  # type: ignore[no-untyped-def]
@@ -382,7 +380,7 @@ def accumulate_hits(model: ObservationModel) -> Int64[Array, '...']:
         hits, _ = jax.lax.scan(step, init, (pointing_i, masker))
         return jax.lax.psum(hits, axis_name=axis)
 
-    return hits_kernel(pointing_i, masker)  # type: ignore[no-any-return]
+    return hits_kernel(pointing_i, model.masker)  # type: ignore[no-any-return]
 
 
 @jax.jit(static_argnames=('fill_gaps', 'correlation_length', 'gap_filling_params'))
@@ -397,8 +395,6 @@ def accumulate_rhs(
 ) -> StokesPyTreeType:
     mesh = jax.sharding.get_abstract_mesh()
     axis = mesh.axis_names[0]
-    model = jax.tree.map(lambda a: jax.reshard(a, P(axis)), model)
-    read_indices = jax.reshard(read_indices, P(axis))
 
     map_structure = model.map_structure
 

--- a/src/furax/mapmaking/mapmaker.py
+++ b/src/furax/mapmaking/mapmaker.py
@@ -1,7 +1,7 @@
 import pickle
 from abc import abstractmethod
 from collections.abc import Sequence
-from dataclasses import asdict, dataclass, replace
+from dataclasses import asdict, dataclass
 from functools import cached_property
 from logging import Logger
 from math import prod
@@ -94,10 +94,7 @@ class MultiObservationMapMaker(Generic[T]):
                     "Received stokes='IQU', but ATOP does not support intensity map reconstruction."
                     " Falling back to stokes='QU' instead."
                 )
-                self.config = replace(
-                    self.config,
-                    landscape=replace(self.config.landscape, stokes='QU'),
-                )
+                self.config.landscape.stokes = 'QU'
 
     @cached_property
     def mesh(self) -> Mesh:

--- a/src/furax/mapmaking/mapmaker.py
+++ b/src/furax/mapmaking/mapmaker.py
@@ -109,6 +109,11 @@ class MultiObservationMapMaker(Generic[T]):
         return jax.tree.map(lambda a: jax.make_array_from_process_local_data(self.sharding, a), x)
 
     @property
+    def n_observations(self) -> int:
+        """Total number of observations across all processes."""
+        return len(self.observations)
+
+    @property
     def obs_distribution(self) -> tuple[int, int, int]:
         """``(start, n_owned, n_pad)`` for this process."""
         return get_obs_distribution_to_process(self.n_observations)
@@ -133,42 +138,6 @@ class MultiObservationMapMaker(Generic[T]):
             stokes=self.config.landscape.stokes,
         )
 
-    def _scan_wcs_footprint(self) -> WCSLandscape:
-        """Scan observations to determine the combined WCS footprint and build a WCSLandscape.
-
-        Performs a preliminary pass over all observations, loading the pointing data needed
-        to compute each observation's sky coverage, then combines them into a unified footprint.
-        """
-        lc = self.config.landscape
-        if lc.wcs is None:
-            raise ValueError('WCS landscape config is required for auto footprint scanning.')
-        wcs_config = lc.wcs
-        res = wcs_config.resolution * pixell.utils.arcmin
-        proj = wcs_config.projection.name.lower()
-        pointing_fields = ['boresight_quaternions', 'detector_quaternions']
-
-        n = len(self.observations)
-        corners_rad = np.empty((2, 2, n))  # [bottom-left, top-right] corners per observation
-        for i, lazy_obs in enumerate(self.observations):
-            obs = lazy_obs.get_data(pointing_fields)
-            shape, wcs = obs.get_wcs_shape_and_kernel(
-                resolution_arcmin=wcs_config.resolution, projection=wcs_config.projection
-            )
-            # RA _decreases_ left-to-right (increases toward the East)
-            # so each corner pair is technically [[dec_lo, ra_hi], [dec_hi, ra_lo]]
-            corners_rad[..., i] = pixell.enmap.corners(shape, wcs, corner=True)
-
-        # find the corners of the smallest box covering all the individual patches
-        dec_lo = corners_rad[0, 0].min()
-        dec_hi = corners_rad[1, 0].max()
-        # minimum_enclosing_arc expects [lo, hi] intervals with shape (2, n)
-        ra_lo, ra_hi = minimum_enclosing_arc(corners_rad[::-1, 1].T)
-        union_box = np.array([[dec_lo, ra_hi], [dec_hi, ra_lo]])
-
-        # create the final shape and WCS objects for this covering box
-        shape, wcs = pixell.enmap.geometry(pos=union_box, res=res, proj=proj)
-        return WCSLandscape.from_wcs(shape, wcs, lc.stokes, self.config.dtype)
-
     def run(self, out_dir: str | Path | None = None) -> MapMakingResults:
         """Runs the mapmaker and return results after saving them to the given directory."""
         results = self.make_maps()
@@ -185,11 +154,6 @@ class MultiObservationMapMaker(Generic[T]):
         mhu.sync_global_devices('mapmaker.run.save_done')
 
         return results
-
-    @property
-    def n_observations(self) -> int:
-        """Total number of observations across all processes."""
-        return len(self.observations)
 
     def make_maps(self) -> MapMakingResults:
         """Computes the mapmaker results (maps and other products)."""
@@ -347,6 +311,42 @@ class MultiObservationMapMaker(Generic[T]):
             )
 
         return valid
+
+    def _scan_wcs_footprint(self) -> WCSLandscape:
+        """Scan observations to determine the combined WCS footprint and build a WCSLandscape.
+
+        Performs a preliminary pass over all observations, loading the pointing data needed
+        to compute each observation's sky coverage, then combines them into a unified footprint.
+        """
+        lc = self.config.landscape
+        if lc.wcs is None:
+            raise ValueError('WCS landscape config is required for auto footprint scanning.')
+        wcs_config = lc.wcs
+        res = wcs_config.resolution * pixell.utils.arcmin
+        proj = wcs_config.projection.name.lower()
+        pointing_fields = ['boresight_quaternions', 'detector_quaternions']
+
+        n = len(self.observations)
+        corners_rad = np.empty((2, 2, n))  # [bottom-left, top-right] corners per observation
+        for i, lazy_obs in enumerate(self.observations):
+            obs = lazy_obs.get_data(pointing_fields)
+            shape, wcs = obs.get_wcs_shape_and_kernel(
+                resolution_arcmin=wcs_config.resolution, projection=wcs_config.projection
+            )
+            # RA _decreases_ left-to-right (increases toward the East)
+            # so each corner pair is technically [[dec_lo, ra_hi], [dec_hi, ra_lo]]
+            corners_rad[..., i] = pixell.enmap.corners(shape, wcs, corner=True)
+
+        # find the corners of the smallest box covering all the individual patches
+        dec_lo = corners_rad[0, 0].min()
+        dec_hi = corners_rad[1, 0].max()
+        # minimum_enclosing_arc expects [lo, hi] intervals with shape (2, n)
+        ra_lo, ra_hi = minimum_enclosing_arc(corners_rad[::-1, 1].T)
+        union_box = np.array([[dec_lo, ra_hi], [dec_hi, ra_lo]])
+
+        # create the final shape and WCS objects for this covering box
+        shape, wcs = pixell.enmap.geometry(pos=union_box, res=res, proj=proj)
+        return WCSLandscape.from_wcs(shape, wcs, lc.stokes, self.config.dtype)
 
 
 @jax.jit

--- a/src/furax/mapmaking/mapmaker.py
+++ b/src/furax/mapmaking/mapmaker.py
@@ -1,7 +1,7 @@
 import pickle
 from abc import abstractmethod
 from collections.abc import Sequence
-from dataclasses import asdict, dataclass, field, replace
+from dataclasses import asdict, dataclass, replace
 from functools import cached_property
 from logging import Logger
 from math import prod
@@ -32,7 +32,6 @@ from furax import (
     MaskOperator,
     OperatorTag,
     SymmetricBandToeplitzOperator,
-    symmetric,
 )
 from furax.core import BlockDiagonalOperator, BlockRowOperator, CompositionOperator, IndexOperator
 from furax.interfaces.lineax import as_lineax_operator
@@ -52,7 +51,7 @@ from ._logger import logger as furax_logger
 from ._model import ObservationModel, pad_model
 from ._observation import AbstractGroundObservation, AbstractLazyObservation
 from ._reader import ObservationReader
-from ._scan_blocks import ScanBlockColumnOperator, ScanBlockDiagonalOperator
+from ._scan_blocks import ScanBlockColumnOperator, ScanBlockDiagonalOperator, ScanBlockRowOperator
 from .config import LandscapeConfig, MapMakingConfig, Methods, WCSConfig
 from .gap_filling import GapFillingOperator
 from .noise import AtmosphericNoiseModel, NoiseModel, WhiteNoiseModel
@@ -332,9 +331,15 @@ class MultiObservationMapMaker(Generic[T]):
     def get_system_operator(
         self, model: ObservationModel, *, diag: bool = False
     ) -> AbstractLinearOperator:
-        return _DistributedScanOperator(
-            model, diag=diag, mesh=self.mesh, n_total=self.n_per_device * jax.device_count()
-        )
+        n_total = self.n_per_device * jax.device_count()
+        H = ScanBlockColumnOperator(model.H, n_total)
+        M = ScanBlockDiagonalOperator(model.masker, n_total)
+        weight = model.diag_W() if diag else model.W
+        W = ScanBlockDiagonalOperator(weight, n_total)
+        # H.T = ScanBlockRow; carry the output-sharding hint through reduction so the
+        # final ScanAddition forces an all-reduce of the per-device partial sums.
+        HT = ScanBlockRowOperator(model.H.T, n_total, NamedSharding(self.mesh, P()))
+        return (HT @ M @ W @ M @ H).reduce()
 
     def pixel_selection(
         self, hits: Integer[Array, ' pixels'], weights: Float[Array, 'pixels stokes stokes']
@@ -392,39 +397,6 @@ def _accumulate_rhs(
 
     rhs, _ = jax.lax.scan(step, furax.tree.zeros_like(model.map_structure), (model, read_indices))
     return jax.lax.with_sharding_constraint(rhs, sharding)  # type: ignore[no-any-return]
-
-
-@symmetric
-class _DistributedScanOperator(AbstractLinearOperator):
-    """ScanBlock composition with replicated output sharding constraint."""
-
-    models: ObservationModel
-    diag: bool = field(metadata={'static': True})
-    mesh: Mesh = field(metadata={'static': True})
-    n_total: int = field(metadata={'static': True})
-
-    def __init__(
-        self,
-        models: ObservationModel,
-        *,
-        diag: bool = False,
-        mesh: Mesh,
-        n_total: int,
-    ) -> None:
-        object.__setattr__(self, 'models', models)
-        object.__setattr__(self, 'diag', diag)
-        object.__setattr__(self, 'mesh', mesh)
-        object.__setattr__(self, 'n_total', n_total)
-        object.__setattr__(self, 'in_structure', models.map_structure)
-
-    def mv(self, x: PyTree) -> PyTree:
-        H = ScanBlockColumnOperator(self.models.H, self.n_total)
-        M = ScanBlockDiagonalOperator(self.models.masker, self.n_total)
-        weight = self.models.diag_W() if self.diag else self.models.W
-        W = ScanBlockDiagonalOperator(weight, self.n_total)
-        A = (H.T @ M @ W @ M @ H).reduce()  # -> ScanAdditionOperator
-        # ScanAddition sums the 'obs' leading axis; constraint triggers cross-device all-reduce.
-        return jax.lax.with_sharding_constraint(A(x), NamedSharding(self.mesh, P()))
 
 
 def get_obs_distribution_to_process(

--- a/src/furax/mapmaking/mapmaker.py
+++ b/src/furax/mapmaking/mapmaker.py
@@ -16,7 +16,7 @@ import pixell.utils
 from astropy.io import fits
 from astropy.wcs import WCS
 from jax import ShapeDtypeStruct
-from jaxtyping import Array, Bool, DTypeLike, Float, Int64, Integer
+from jaxtyping import Array, Bool, DTypeLike, Float, Integer
 
 import furax.linalg
 import furax.tree as tree
@@ -155,18 +155,17 @@ class MultiObservationMapMaker(Generic[T]):
 
         # Build system matrix from stacked ObservationModel
         model = self.build_model()
-        n_obs = len(self.observations)
-        A = model.get_system_operator(n_obs)
+        A = model.get_system_operator()
         logger_info('Created system operator')
 
-        hits = self.accumulate_hits(model).block_until_ready()
+        hits = model.accumulate_hits().block_until_ready()
         logger_info('Computed hit map')
 
         rhs = self.accumulate_rhs(model)
         logger_info('Accumulated RHS vector')
 
         # Preconditioning
-        sysdiag = A if self.config.binned else model.get_system_operator(n_obs, diag=True)
+        sysdiag = A if self.config.binned else model.get_system_operator(diag=True)
         BJ = BJPreconditioner.create(sysdiag)
         icov = BJ.get_blocks().block_until_ready()
         logger_info('Computed white noise inverse covariance')
@@ -236,14 +235,6 @@ class MultiObservationMapMaker(Generic[T]):
 
         _, model = jax.lax.scan(build_one, None, jnp.arange(reader.count))
         return model  # type: ignore[no-any-return]
-
-    def accumulate_hits(self, models: ObservationModel) -> Int64[Array, ' pixels']:
-        def acc(carry, model):  # type: ignore[no-untyped-def]
-            return carry + model.hits(), None
-
-        init = jnp.zeros(self.landscape.shape, dtype=jnp.int64)
-        total, _ = jax.lax.scan(acc, init, models)
-        return total
 
     def accumulate_rhs(self, models: ObservationModel) -> StokesPyTreeType:
         """Accumulate the RHS vector across all observations"""

--- a/src/furax/mapmaking/mapmaker.py
+++ b/src/furax/mapmaking/mapmaker.py
@@ -16,7 +16,7 @@ import pixell.utils
 from astropy.io import fits
 from astropy.wcs import WCS
 from jax import ShapeDtypeStruct
-from jaxtyping import Array, Bool, DTypeLike, Float, Integer
+from jaxtyping import Array, Bool, DTypeLike, Float, Int64, Integer
 
 import furax.linalg
 import furax.tree as tree
@@ -29,7 +29,7 @@ from furax import (
     OperatorTag,
     SymmetricBandToeplitzOperator,
 )
-from furax.core import BlockDiagonalOperator, BlockRowOperator, IndexOperator
+from furax.core import BlockDiagonalOperator, BlockRowOperator, CompositionOperator, IndexOperator
 from furax.interfaces.lineax import as_lineax_operator
 from furax.obs.landscapes import (
     AstropyWCSLandscape,
@@ -39,7 +39,7 @@ from furax.obs.landscapes import (
 )
 from furax.obs.operators import HWPOperator, LinearPolarizerOperator, QURotationOperator
 from furax.obs.pointing import PointingOperator
-from furax.obs.stokes import Stokes, StokesIQU, StokesPyTreeType, ValidStokesType
+from furax.obs.stokes import Stokes, StokesI, StokesIQU, StokesPyTreeType, ValidStokesType
 
 from . import templates
 from ._geometry import minimum_enclosing_arc
@@ -47,6 +47,7 @@ from ._logger import logger as furax_logger
 from ._model import ObservationModel
 from ._observation import AbstractGroundObservation, AbstractLazyObservation
 from ._reader import ObservationReader
+from ._scan_blocks import ScanBlockColumnOperator, ScanBlockDiagonalOperator
 from .config import LandscapeConfig, MapMakingConfig, Methods, WCSConfig
 from .gap_filling import GapFillingOperator
 from .noise import AtmosphericNoiseModel, NoiseModel, WhiteNoiseModel
@@ -161,15 +162,15 @@ class MultiObservationMapMaker(Generic[T]):
         model = self.build_model()
         logger_info('Created system operator')
 
-        hits = model.accumulate_hits().block_until_ready()
+        hits = self.accumulate_hits(model).block_until_ready()
         logger_info('Computed hit map')
 
         rhs = jax.block_until_ready(self.accumulate_rhs(model))
         logger_info('Accumulated RHS vector')
 
         # System operator (full/diagonal)
-        A = model.get_system_operator()
-        diag_A = A if self.config.binned else model.get_system_operator(diag=True)
+        A = self.get_system_operator(model)
+        diag_A = A if self.config.binned else self.get_system_operator(model, diag=True)
         BJ = BJPreconditioner.create(diag_A)
         icov = BJ.get_blocks().block_until_ready()
         logger_info('Computed white noise inverse covariance')
@@ -240,10 +241,31 @@ class MultiObservationMapMaker(Generic[T]):
         _, model = jax.lax.scan(build_one, None, jnp.arange(reader.count))
         return model  # type: ignore[no-any-return]
 
+    def accumulate_hits(self, model: ObservationModel) -> Int64[Array, ' pixels']:
+        """Accumulate hit counts across all observations."""
+        n = len(self.observations)
+        assert isinstance(model.H, CompositionOperator)  # mypy assert
+        # pointing operator is the last operand of the acquisition chain (see unit test)
+        pointing = model.H.operands[-1]
+        assert isinstance(pointing, PointingOperator)  # mypy assert
+        P = ScanBlockColumnOperator(pointing.as_stokes_i(interpolate=False), n)
+        M = ScanBlockDiagonalOperator(model.masker, n)
+        return _accumulate_hits(P, M)  # type: ignore[no-any-return]
+
     def accumulate_rhs(self, model: ObservationModel) -> StokesPyTreeType:
         """Accumulate the RHS vector across all observations."""
         reader = self.get_reader(['metadata', 'sample_data'])
         return _accumulate_rhs(model, reader, self.config)  # type: ignore[no-any-return]
+
+    def get_system_operator(
+        self, model: ObservationModel, *, diag: bool = False
+    ) -> AbstractLinearOperator:
+        n = len(self.observations)
+        H = ScanBlockColumnOperator(model.H, n)
+        M = ScanBlockDiagonalOperator(model.masker, n)
+        weight = model.diag_W() if diag else model.W
+        W = ScanBlockDiagonalOperator(weight, n)
+        return (H.T @ M @ W @ M @ H).reduce()
 
     def pixel_selection(
         self, hits: Integer[Array, ' pixels'], weights: Float[Array, 'pixels stokes stokes']
@@ -261,6 +283,15 @@ class MultiObservationMapMaker(Generic[T]):
             )
 
         return valid
+
+
+@jax.jit
+def _accumulate_hits(
+    pointing: AbstractLinearOperator, mask: AbstractLinearOperator
+) -> Int64[Array, ' pixels']:
+    ones = tree.ones_like(mask.in_structure)
+    masked_i = jax.tree.leaves(mask(ones))[0]
+    return jnp.int64(pointing.T(StokesI(masked_i)).i)  # type: ignore[no-any-return]
 
 
 @jax.jit(static_argnames=('config',))

--- a/src/furax/mapmaking/mapmaker.py
+++ b/src/furax/mapmaking/mapmaker.py
@@ -223,11 +223,10 @@ class MultiObservationMapMaker(Generic[T]):
         read_indices = self.distribute(self.get_padded_read_indices())
         logger_info('Created system operators')
 
-        hits = jax.jit(self.accumulate_hits)(model).block_until_ready()
+        hits = jax.block_until_ready(self.accumulate_hits(model))
         logger_info('Computed hit map')
 
-        rhs_reader = self.get_reader(['metadata', 'sample_data'])
-        rhs = jax.block_until_ready(jax.jit(self.accumulate_rhs)(model, read_indices, rhs_reader))
+        rhs = jax.block_until_ready(self.accumulate_rhs(model, read_indices))
         logger_info('Accumulated RHS vector')
 
         # System operator (full/diagonal)
@@ -317,60 +316,20 @@ class MultiObservationMapMaker(Generic[T]):
         _, n_owned, n_pad = self.obs_distribution
         return (n_owned + n_pad) // jax.local_device_count()
 
-    def accumulate_hits(self, models: ObservationModel) -> Int64[Array, ' pixels']:
-        """Accumulate hit map across all observations via ScanBlock ops under jit+in_shardings."""
+    def accumulate_hits(self, model: ObservationModel) -> Int64[Array, '...']:
+        """Accumulate hit map across all observations."""
         n_total = self.n_per_device * jax.device_count()
-        assert isinstance(models.H, CompositionOperator)  # mypy assert
-        pointing = models.H.operands[-1]
+        assert isinstance(model.H, CompositionOperator)  # mypy assert
+        pointing = model.H.operands[-1]
         assert isinstance(pointing, PointingOperator)  # mypy assert
         P_op = ScanBlockColumnOperator(pointing.as_stokes_i(interpolate=False), n_total)
-        M_op = ScanBlockDiagonalOperator(models.masker, n_total)
-        ones = furax.tree.ones_like(M_op.in_structure)
-        masked_i = jax.tree.leaves(M_op(ones))[0]
-        hits = jnp.int64(P_op.T(StokesI(masked_i)).i)
-        # P_op.T = ScanBlockRow: leading axis summed -> output replicated across 'obs' axis.
-        return jax.lax.with_sharding_constraint(hits, NamedSharding(self.mesh, P()))  # type: ignore[no-any-return]
+        M_op = ScanBlockDiagonalOperator(model.masker, n_total)
+        return _accumulate_hits(P_op, M_op, self.sharding)  # type: ignore[no-any-return]
 
-    def accumulate_rhs(
-        self,
-        models: ObservationModel,
-        read_indices: Array,
-        reader: ObservationReader[T],
-    ) -> StokesPyTreeType:
-        """Accumulate the RHS vector across all observations.
-
-        Runs a sharded ``lax.scan`` over the global 'obs' axis under
-        ``jit + in_shardings``: XLA inserts the cross-device all-reduce when the
-        replicated output is requested via ``with_sharding_constraint``.
-        ``read_indices`` must be sharded along the same 'obs' axis as ``models``
-        (see :meth:`distribute`). ``reader`` is passed in (not built here) so
-        this method stays jit-friendly — building the reader triggers an
-        all-gather that must run outside ``jax.jit``.
-        """
-        config = self.config
-        landscape = self.landscape
-
-        def step(carry: StokesPyTreeType, args: Any) -> tuple[StokesPyTreeType, None]:
-            obs, i = args
-            data, _ = reader.read(i)
-            tod = data['sample_data']
-            if config.gaps.fill and not config.binned:
-                N = obs.noise_operator(config.noise.correlation_length, inverse=False)
-                tod = GapFillingOperator(
-                    N,
-                    obs._get_indexer(),
-                    data['metadata'],
-                    obs.W,
-                    rate=obs.sample_rate,
-                    max_cg_steps=config.gaps.fill_options.max_steps,
-                    rtol=config.gaps.fill_options.rtol,
-                )(jax.random.key(config.gaps.fill_options.seed), tod)
-            return furax.tree.add(carry, obs.H.T(obs.masker(obs.W(tod)))), None
-
-        rhs, _ = jax.lax.scan(step, landscape.zeros(), (models, read_indices))
-        # Carry has no 'obs' axis; sharded inputs yield per-device partial sums.
-        # Annotation forces GSPMD to all-reduce across the mesh.
-        return jax.lax.with_sharding_constraint(rhs, NamedSharding(self.mesh, P()))  # type: ignore[no-any-return]
+    def accumulate_rhs(self, model: ObservationModel, read_indices: Array) -> StokesPyTreeType:
+        """Accumulate the RHS vector across all observations."""
+        reader = self.get_reader(['metadata', 'sample_data'])
+        return _accumulate_rhs(model, read_indices, reader, self.config, self.sharding)  # type: ignore[no-any-return]
 
     def get_system_operator(
         self, model: ObservationModel, *, diag: bool = False
@@ -395,6 +354,46 @@ class MultiObservationMapMaker(Generic[T]):
             )
 
         return valid
+
+
+@jax.jit(static_argnames=('sharding',))
+def _accumulate_hits(
+    pointing: AbstractLinearOperator, mask: AbstractLinearOperator, sharding: NamedSharding
+) -> Int64[Array, '...']:
+    ones = furax.tree.ones_like(mask.in_structure)
+    masked_i = jax.tree.leaves(mask(ones))[0]
+    hits = jnp.int64(pointing.T(StokesI(masked_i)).i)
+    return jax.lax.with_sharding_constraint(hits, sharding)  # type: ignore[no-any-return]
+
+
+@jax.jit(static_argnames=('config', 'sharding'))
+def _accumulate_rhs(
+    model: ObservationModel,
+    read_indices: Array,
+    reader: ObservationReader[T],
+    config: MapMakingConfig,
+    sharding: NamedSharding,
+) -> StokesPyTreeType:
+
+    def step(carry: StokesPyTreeType, args: Any) -> tuple[StokesPyTreeType, None]:
+        obs, i = args
+        data, _ = reader.read(i)
+        tod = data['sample_data']
+        if config.gaps.fill and not config.binned:
+            N = obs.noise_operator(config.noise.correlation_length, inverse=False)
+            tod = GapFillingOperator(
+                N,
+                obs._get_indexer(),
+                data['metadata'],
+                obs.W,
+                rate=obs.sample_rate,
+                max_cg_steps=config.gaps.fill_options.max_steps,
+                rtol=config.gaps.fill_options.rtol,
+            )(jax.random.key(config.gaps.fill_options.seed), tod)
+        return furax.tree.add(carry, obs.H.T(obs.masker(obs.W(tod)))), None
+
+    rhs, _ = jax.lax.scan(step, furax.tree.zeros_like(model.map_structure), (model, read_indices))
+    return jax.lax.with_sharding_constraint(rhs, sharding)  # type: ignore[no-any-return]
 
 
 @symmetric

--- a/src/furax/mapmaking/mapmaker.py
+++ b/src/furax/mapmaking/mapmaker.py
@@ -160,7 +160,7 @@ class MultiObservationMapMaker(Generic[T]):
 
         # Build stacked ObservationModel
         model = self.build_model()
-        logger_info('Created system operator')
+        logger_info('Created system operators')
 
         hits = self.accumulate_hits(model).block_until_ready()
         logger_info('Computed hit map')

--- a/src/furax/mapmaking/mapmaker.py
+++ b/src/furax/mapmaking/mapmaker.py
@@ -1,7 +1,7 @@
 import pickle
 from abc import abstractmethod
 from collections.abc import Sequence
-from dataclasses import asdict, dataclass
+from dataclasses import asdict, dataclass, replace
 from logging import Logger
 from math import prod
 from pathlib import Path
@@ -87,7 +87,10 @@ class MultiObservationMapMaker(Generic[T]):
                     "Received stokes='IQU', but ATOP does not support intensity map reconstruction."
                     " Falling back to stokes='QU' instead."
                 )
-                self.config.landscape.stokes = 'QU'
+                self.config = replace(
+                    self.config,
+                    landscape=replace(self.config.landscape, stokes='QU'),
+                )
 
     def _scan_wcs_footprint(self) -> WCSLandscape:
         """Scan observations to determine the combined WCS footprint and build a WCSLandscape.

--- a/src/furax/mapmaking/mapmaker.py
+++ b/src/furax/mapmaking/mapmaker.py
@@ -303,12 +303,6 @@ class MultiObservationMapMaker(Generic[T]):
         _, model = jax.lax.scan(build_one, None, self.get_read_indices())
         return model  # type: ignore[no-any-return]
 
-    @property
-    def n_per_device(self) -> int:
-        """Number of (real + padded) observations per device."""
-        _, n_owned, n_pad = self.obs_distribution
-        return (n_owned + n_pad) // jax.local_device_count()
-
     def accumulate_hits(self, model: ObservationModel) -> Int64[Array, '...']:
         """Accumulate hit count map across all observations."""
         return accumulate_hits(model)  # type: ignore[no-any-return]

--- a/src/furax/mapmaking/mapmaker.py
+++ b/src/furax/mapmaking/mapmaker.py
@@ -51,7 +51,7 @@ from ._logger import logger as furax_logger
 from ._model import ObservationModel, pad_model
 from ._observation import AbstractGroundObservation, AbstractLazyObservation
 from ._reader import ObservationReader
-from ._scan_blocks import ScanBlockColumnOperator, ScanBlockDiagonalOperator, ScanBlockRowOperator
+from ._scan_blocks import ScanBlockColumnOperator, ScanBlockDiagonalOperator
 from .config import LandscapeConfig, MapMakingConfig, Methods, WCSConfig
 from .gap_filling import GapFillingOperator
 from .noise import AtmosphericNoiseModel, NoiseModel, WhiteNoiseModel
@@ -327,15 +327,11 @@ class MultiObservationMapMaker(Generic[T]):
     def get_system_operator(
         self, model: ObservationModel, *, diag: bool = False
     ) -> AbstractLinearOperator:
-        n_total = self.n_per_device * jax.device_count()
-        H = ScanBlockColumnOperator(model.H, n_total)
-        M = ScanBlockDiagonalOperator(model.masker, n_total)
+        H = ScanBlockColumnOperator.create(model.H)
+        M = ScanBlockDiagonalOperator.create(model.masker)
         weight = model.diag_W() if diag else model.W
-        W = ScanBlockDiagonalOperator(weight, n_total)
-        # H.T = ScanBlockRow; carry the output-sharding hint through reduction so the
-        # final ScanAddition forces an all-reduce of the per-device partial sums.
-        HT = ScanBlockRowOperator(model.H.T, n_total, NamedSharding(self.mesh, P()))
-        return (HT @ M @ W @ M @ H).reduce()
+        W = ScanBlockDiagonalOperator.create(weight)
+        return (H.T @ M @ W @ M @ H).reduce()
 
     def pixel_selection(
         self, hits: Integer[Array, ' pixels'], weights: Float[Array, 'pixels stokes stokes']
@@ -362,16 +358,16 @@ def accumulate_hits(model: ObservationModel, mesh: Mesh) -> Int64[Array, '...']:
     assert isinstance(pointing, PointingOperator)  # mypy
     pointing_i = pointing.as_stokes_i(interpolate=False)
 
-    obs_sharding = NamedSharding(mesh, P('obs'))
-    pointing_i = jax.tree.map(lambda a: jax.reshard(a, obs_sharding), pointing_i)
-    masker = jax.tree.map(lambda a: jax.reshard(a, obs_sharding), model.masker)
+    map_shape = jax.tree.leaves(pointing_i.in_structure)[0].shape
+    zeros = jnp.zeros(map_shape, jnp.int64)
 
-    @jax.shard_map(mesh=mesh, in_specs=(P('obs'), P('obs')), out_specs=P(), check_vma=False)
+    in_sharding = NamedSharding(mesh, P('obs'))
+    pointing_i = jax.tree.map(lambda a: jax.reshard(a, in_sharding), pointing_i)
+    masker = jax.tree.map(lambda a: jax.reshard(a, in_sharding), model.masker)
+
     def hits_kernel(
         pointing_i: PointingOperator, masker: AbstractLinearOperator
     ) -> Int64[Array, '...']:
-        map_shape = jax.tree.leaves(pointing_i.in_structure)[0].shape
-        init = jnp.zeros(map_shape, jnp.int64)
         per_obs_ones = furax.tree.ones_like(masker.in_structure)
 
         def step(carry, args):  # type: ignore[no-untyped-def]
@@ -379,10 +375,11 @@ def accumulate_hits(model: ObservationModel, mesh: Mesh) -> Int64[Array, '...']:
             masked_i = jax.tree.leaves(m_i(per_obs_ones))[0]
             return carry + jnp.int64(p_i.T(StokesI(masked_i)).i), None
 
+        init = jax.lax.pcast(zeros, mesh.axis_names, to='varying')
         hits, _ = jax.lax.scan(step, init, (pointing_i, masker))
-        return jax.lax.psum(hits, axis_name='obs')  # type: ignore[no-any-return]
+        return jax.lax.psum(hits, axis_name=mesh.axis_names)  # type: ignore[no-any-return]
 
-    return hits_kernel(pointing_i, masker)
+    return jax.shard_map(hits_kernel, mesh=mesh, out_specs=P())(pointing_i, masker)
 
 
 @jax.jit(static_argnames=('config', 'mesh'))
@@ -393,14 +390,13 @@ def accumulate_rhs(
     config: MapMakingConfig,
     mesh: Mesh,
 ) -> StokesPyTreeType:
-    obs_sharding = NamedSharding(mesh, P('obs'))
-    model = jax.tree.map(lambda a: jax.reshard(a, obs_sharding), model)
-    read_indices = jax.reshard(read_indices, obs_sharding)
+    in_sharding = NamedSharding(mesh, P('obs'))
+    model = jax.tree.map(lambda a: jax.reshard(a, in_sharding), model)
+    read_indices = jax.reshard(read_indices, in_sharding)
 
-    @jax.shard_map(mesh=mesh, in_specs=(P('obs'), P('obs')), out_specs=P(), check_vma=False)
+    zeros = furax.tree.zeros_like(model.map_structure)
+
     def rhs_kernel(model: ObservationModel, indices: Array) -> StokesPyTreeType:
-        init = furax.tree.zeros_like(model.map_structure)
-
         def step(carry: StokesPyTreeType, args: Any) -> tuple[StokesPyTreeType, None]:
             obs, i = args
             data, _ = reader.read(i)
@@ -418,10 +414,11 @@ def accumulate_rhs(
                 )(jax.random.key(config.gaps.fill_options.seed), tod)
             return furax.tree.add(carry, obs.H.T(obs.masker(obs.W(tod)))), None
 
+        init = jax.lax.pcast(zeros, mesh.axis_names, to='varying')
         rhs, _ = jax.lax.scan(step, init, (model, indices))
-        return jax.lax.psum(rhs, axis_name='obs')  # type: ignore[no-any-return]
+        return jax.lax.psum(rhs, axis_name=mesh.axis_names)  # type: ignore[no-any-return]
 
-    return rhs_kernel(model, read_indices)
+    return jax.shard_map(rhs_kernel, mesh=mesh, out_specs=P())(model, read_indices)
 
 
 def get_obs_distribution_to_process(

--- a/src/furax/mapmaking/mapmaker.py
+++ b/src/furax/mapmaking/mapmaker.py
@@ -302,26 +302,27 @@ def _accumulate_rhs(
 ) -> StokesPyTreeType:
     """Accumulate H^T M W tod over all observations, with optional gap-filling."""
 
-    def acc(carry, args):  # type: ignore[no-untyped-def]
-        i, obs = args
+    def step(carry, args):  # type: ignore[no-untyped-def]
+        i, model = args
         data, _ = reader.read(i)
         tod = data['sample_data']
         if config.gaps.fill and not config.binned:
             # FIXME: check with demodulated data
-            N = obs.noise_operator(config.noise.correlation_length, inverse=False)
+            N = model.noise_operator(config.noise.correlation_length, inverse=False)
             tod = GapFillingOperator(
                 N,
-                obs._get_indexer(),
+                model._get_indexer(),
                 data['metadata'],
-                obs.W,
-                rate=obs.sample_rate,
+                model.W,
+                rate=model.sample_rate,
                 max_cg_steps=config.gaps.fill_options.max_steps,
                 rtol=config.gaps.fill_options.rtol,
             )(jax.random.key(config.gaps.fill_options.seed), tod)
-        return carry + obs.rhs(tod), None
+        rhs_contribution = (model.H.T @ model.masker @ model.W)(tod)
+        return carry + rhs_contribution, None
 
     init = tree.zeros_like(model.map_structure)
-    total, _ = jax.lax.scan(acc, init, (jnp.arange(reader.count), model))
+    total, _ = jax.lax.scan(step, init, (jnp.arange(reader.count), model))
     return total  # type: ignore[no-any-return]
 
 

--- a/src/furax/mapmaking/mapmaker.py
+++ b/src/furax/mapmaking/mapmaker.py
@@ -44,7 +44,7 @@ from furax.obs.stokes import Stokes, StokesIQU, StokesPyTreeType, ValidStokesTyp
 from . import templates
 from ._geometry import minimum_enclosing_arc
 from ._logger import logger as furax_logger
-from ._model import ObservationModel, SystemOperator
+from ._model import ObservationModel
 from ._observation import AbstractGroundObservation, AbstractLazyObservation
 from ._reader import ObservationReader
 from .config import LandscapeConfig, MapMakingConfig, Methods, WCSConfig
@@ -155,7 +155,8 @@ class MultiObservationMapMaker(Generic[T]):
 
         # Build system matrix from stacked ObservationModel
         model = self.build_model()
-        A = SystemOperator(model)
+        n_obs = len(self.observations)
+        A = model.get_system_operator(n_obs)
         logger_info('Created system operator')
 
         hits = self.accumulate_hits(model).block_until_ready()
@@ -165,7 +166,7 @@ class MultiObservationMapMaker(Generic[T]):
         logger_info('Accumulated RHS vector')
 
         # Preconditioning
-        sysdiag = A if self.config.binned else SystemOperator(model, diag=True)
+        sysdiag = A if self.config.binned else model.get_system_operator(n_obs, diag=True)
         BJ = BJPreconditioner.create(sysdiag)
         icov = BJ.get_blocks().block_until_ready()
         logger_info('Computed white noise inverse covariance')

--- a/src/furax/mapmaking/mapmaker.py
+++ b/src/furax/mapmaking/mapmaker.py
@@ -19,7 +19,6 @@ from jax import ShapeDtypeStruct
 from jaxtyping import Array, Bool, DTypeLike, Float, Integer
 
 import furax.linalg
-import furax.tree as tree
 from furax import (
     AbstractLinearOperator,
     Config,
@@ -153,20 +152,21 @@ class MultiObservationMapMaker(Generic[T]):
         """Computes the mapmaker results (maps and other products)."""
         logger_info = lambda msg: self.logger.info(f'MultiObsMapMaker: {msg}')
 
-        # Build system matrix from stacked ObservationModel
+        # Build stacked ObservationModel
         model = self.build_model()
-        A = model.get_system_operator()
         logger_info('Created system operator')
 
         hits = model.accumulate_hits().block_until_ready()
         logger_info('Computed hit map')
 
-        rhs = self.accumulate_rhs(model)
+        reader = self.get_reader(['metadata', 'sample_data'])
+        rhs = jax.block_until_ready(model.accumulate_rhs(reader, self.config))
         logger_info('Accumulated RHS vector')
 
-        # Preconditioning
-        sysdiag = A if self.config.binned else model.get_system_operator(diag=True)
-        BJ = BJPreconditioner.create(sysdiag)
+        # System operator (full/diagonal)
+        A = model.get_system_operator()
+        diag_A = A if self.config.binned else model.get_system_operator(diag=True)
+        BJ = BJPreconditioner.create(diag_A)
         icov = BJ.get_blocks().block_until_ready()
         logger_info('Computed white noise inverse covariance')
 
@@ -235,20 +235,6 @@ class MultiObservationMapMaker(Generic[T]):
 
         _, model = jax.lax.scan(build_one, None, jnp.arange(reader.count))
         return model  # type: ignore[no-any-return]
-
-    def accumulate_rhs(self, models: ObservationModel) -> StokesPyTreeType:
-        """Accumulate the RHS vector across all observations"""
-        reader = self.get_reader(['metadata', 'sample_data'])
-
-        def acc(carry, args):  # type: ignore[no-untyped-def]
-            i, model = args
-            data, _ = reader.read(i)
-            carry = carry + model.rhs(data, self.config)
-            return carry, None
-
-        init = tree.zeros_like(models.map_structure)
-        total, _ = jax.lax.scan(acc, init, (jnp.arange(reader.count), models))
-        return total  # type: ignore[no-any-return]
 
     def pixel_selection(
         self, hits: Integer[Array, ' pixels'], weights: Float[Array, 'pixels stokes stokes']

--- a/src/furax/mapmaking/mapmaker.py
+++ b/src/furax/mapmaking/mapmaker.py
@@ -18,7 +18,7 @@ from astropy.io import fits
 from astropy.wcs import WCS
 from jax import ShapeDtypeStruct
 from jax.experimental import multihost_utils as mhu
-from jax.sharding import AxisType, Mesh, NamedSharding
+from jax.sharding import Mesh, NamedSharding
 from jax.sharding import PartitionSpec as P
 from jaxtyping import Array, Bool, DTypeLike, Float, Int64, Integer, PyTree
 
@@ -101,7 +101,7 @@ class MultiObservationMapMaker(Generic[T]):
 
     @cached_property
     def mesh(self) -> Mesh:
-        return jax.make_mesh((jax.device_count(),), ('obs',), axis_types=(AxisType.Auto,))
+        return jax.make_mesh((jax.device_count(),), ('obs',))
 
     @property
     def sharding(self) -> NamedSharding:
@@ -234,36 +234,38 @@ class MultiObservationMapMaker(Generic[T]):
         icov = BJ.get_blocks().block_until_ready()
         logger_info('Computed white noise inverse covariance')
 
-        # Pixel selection
-        valid_pixels = self.pixel_selection(hits, icov)
-        selector = IndexOperator(jnp.where(valid_pixels), in_structure=model.map_structure)
-        n_selected = jnp.sum(valid_pixels)
-        n_observed = jnp.sum(hits > 0)
-        n_total = valid_pixels.size
-        logger_info(f'Selected {n_selected} pixels ({n_observed} seen, {n_total} total)')
+        # Pixel selection and solve: eager ops on sharded arrays need mesh context.
+        # init in ScanBlock operators created inside shard_map to avoid closure issues.
+        with jax.set_mesh(self.mesh):
+            valid_pixels = self.pixel_selection(hits, icov)
+            selector = IndexOperator(jnp.where(valid_pixels), in_structure=model.map_structure)
+            n_selected = jnp.sum(valid_pixels)
+            n_observed = jnp.sum(hits > 0)
+            n_total = valid_pixels.size
+            logger_info(f'Selected {n_selected} pixels ({n_observed} seen, {n_total} total)')
 
-        hits = hits.at[~valid_pixels].set(0)  # excluded pixels have zero hits
-        icov = jnp.moveaxis(icov, [-2, -1], [0, 1])  # (*pixels, ns, ns) → (ns, ns, *pixels)
+            hits = hits.at[~valid_pixels].set(0)  # excluded pixels have zero hits
+            icov = jnp.moveaxis(icov, [-2, -1], [0, 1])  # (*pixels, ns, ns) → (ns, ns, *pixels)
 
-        # Solve the mapmaking system
-        solver = lineax.CG(**asdict(self.config.solver))
-        spd = OperatorTag.POSITIVE_SEMIDEFINITE
-        lx_system = as_lineax_operator(selector @ A @ selector.T, spd)
-        M = (selector @ BJ.I @ selector.T).reduce()  # preconditioner
-        lx_precond = as_lineax_operator(M, spd)
-        rhs_reduced = selector(rhs)
-        y0 = M(rhs_reduced)
+            # Solve the mapmaking system
+            solver = lineax.CG(**asdict(self.config.solver))
+            spd = OperatorTag.POSITIVE_SEMIDEFINITE
+            lx_system = as_lineax_operator(selector @ A @ selector.T, spd)
+            M = (selector @ BJ.I @ selector.T).reduce()  # preconditioner
+            lx_precond = as_lineax_operator(M, spd)
+            rhs_reduced = selector(rhs)
+            y0 = M(rhs_reduced)
 
-        solution = lineax.linear_solve(
-            lx_system,
-            rhs_reduced,
-            solver=solver,
-            options={'preconditioner': lx_precond, 'y0': y0},
-            throw=False,
-        )
-        estimate = selector.T(solution.value)
-        num_steps = solution.stats['num_steps']
-        logger_info(f'Finished mapmaking (iteration steps: {num_steps})')
+            solution = lineax.linear_solve(
+                lx_system,
+                rhs_reduced,
+                solver=solver,
+                options={'preconditioner': lx_precond, 'y0': y0},
+                throw=False,
+            )
+            estimate = selector.T(solution.value)
+            num_steps = solution.stats['num_steps']
+            logger_info(f'Finished mapmaking (iteration steps: {num_steps})')
         return MapMakingResults(
             map=estimate,
             icov=icov,
@@ -359,18 +361,28 @@ def accumulate_hits(model: ObservationModel, mesh: Mesh) -> Int64[Array, '...']:
     pointing = model.H.operands[-1]
     assert isinstance(pointing, PointingOperator)  # mypy
     pointing_i = pointing.as_stokes_i(interpolate=False)
-    # per-obs ones: small (n_det, n_samp), no full (n_total, ...) buffer created
-    per_obs_ones = furax.tree.ones_like(model.masker.in_structure)
 
-    def step(carry, args):  # type: ignore[no-untyped-def]
-        p_i, m_i = args
-        masked_i = jax.tree.leaves(m_i(per_obs_ones))[0]
-        return carry + jnp.int64(p_i.T(StokesI(masked_i)).i), None
+    obs_sharding = NamedSharding(mesh, P('obs'))
+    pointing_i = jax.tree.map(lambda a: jax.reshard(a, obs_sharding), pointing_i)
+    masker = jax.tree.map(lambda a: jax.reshard(a, obs_sharding), model.masker)
 
-    map_shape = jax.tree.leaves(pointing_i.in_structure)[0].shape
-    hits, _ = jax.lax.scan(step, jnp.zeros(map_shape, jnp.int64), (pointing_i, model.masker))
-    # each device accumulates its local obs; all-reduce to replicated global hits
-    return jax.lax.with_sharding_constraint(hits, NamedSharding(mesh, P()))  # type: ignore[no-any-return]
+    @jax.shard_map(mesh=mesh, in_specs=(P('obs'), P('obs')), out_specs=P(), check_vma=False)
+    def hits_kernel(
+        pointing_i: PointingOperator, masker: AbstractLinearOperator
+    ) -> Int64[Array, '...']:
+        map_shape = jax.tree.leaves(pointing_i.in_structure)[0].shape
+        init = jnp.zeros(map_shape, jnp.int64)
+        per_obs_ones = furax.tree.ones_like(masker.in_structure)
+
+        def step(carry, args):  # type: ignore[no-untyped-def]
+            p_i, m_i = args
+            masked_i = jax.tree.leaves(m_i(per_obs_ones))[0]
+            return carry + jnp.int64(p_i.T(StokesI(masked_i)).i), None
+
+        hits, _ = jax.lax.scan(step, init, (pointing_i, masker))
+        return jax.lax.psum(hits, axis_name='obs')  # type: ignore[no-any-return]
+
+    return hits_kernel(pointing_i, masker)
 
 
 @jax.jit(static_argnames=('config', 'mesh'))
@@ -381,26 +393,35 @@ def accumulate_rhs(
     config: MapMakingConfig,
     mesh: Mesh,
 ) -> StokesPyTreeType:
+    obs_sharding = NamedSharding(mesh, P('obs'))
+    model = jax.tree.map(lambda a: jax.reshard(a, obs_sharding), model)
+    read_indices = jax.reshard(read_indices, obs_sharding)
 
-    def step(carry: StokesPyTreeType, args: Any) -> tuple[StokesPyTreeType, None]:
-        obs, i = args
-        data, _ = reader.read(i)
-        tod = data['sample_data']
-        if config.gaps.fill and not config.binned:
-            N = obs.noise_operator(config.noise.correlation_length, inverse=False)
-            tod = GapFillingOperator(
-                N,
-                obs._get_indexer(),
-                data['metadata'],
-                obs.W,
-                rate=obs.sample_rate,
-                max_cg_steps=config.gaps.fill_options.max_steps,
-                rtol=config.gaps.fill_options.rtol,
-            )(jax.random.key(config.gaps.fill_options.seed), tod)
-        return furax.tree.add(carry, obs.H.T(obs.masker(obs.W(tod)))), None
+    @jax.shard_map(mesh=mesh, in_specs=(P('obs'), P('obs')), out_specs=P(), check_vma=False)
+    def rhs_kernel(model: ObservationModel, indices: Array) -> StokesPyTreeType:
+        init = furax.tree.zeros_like(model.map_structure)
 
-    rhs, _ = jax.lax.scan(step, furax.tree.zeros_like(model.map_structure), (model, read_indices))
-    return jax.lax.with_sharding_constraint(rhs, NamedSharding(mesh, P()))  # type: ignore[no-any-return]
+        def step(carry: StokesPyTreeType, args: Any) -> tuple[StokesPyTreeType, None]:
+            obs, i = args
+            data, _ = reader.read(i)
+            tod = data['sample_data']
+            if config.gaps.fill and not config.binned:
+                N = obs.noise_operator(config.noise.correlation_length, inverse=False)
+                tod = GapFillingOperator(
+                    N,
+                    obs._get_indexer(),
+                    data['metadata'],
+                    obs.W,
+                    rate=obs.sample_rate,
+                    max_cg_steps=config.gaps.fill_options.max_steps,
+                    rtol=config.gaps.fill_options.rtol,
+                )(jax.random.key(config.gaps.fill_options.seed), tod)
+            return furax.tree.add(carry, obs.H.T(obs.masker(obs.W(tod)))), None
+
+        rhs, _ = jax.lax.scan(step, init, (model, indices))
+        return jax.lax.psum(rhs, axis_name='obs')  # type: ignore[no-any-return]
+
+    return rhs_kernel(model, read_indices)
 
 
 def get_obs_distribution_to_process(

--- a/src/furax/mapmaking/mapmaker.py
+++ b/src/furax/mapmaking/mapmaker.py
@@ -52,7 +52,7 @@ from ._model import ObservationModel, pad_model
 from ._observation import AbstractGroundObservation, AbstractLazyObservation
 from ._reader import ObservationReader
 from ._scan_blocks import ScanBlockColumnOperator, ScanBlockDiagonalOperator
-from .config import LandscapeConfig, MapMakingConfig, Methods, WCSConfig
+from .config import GapFillingConfig, LandscapeConfig, MapMakingConfig, Methods, WCSConfig
 from .gap_filling import GapFillingOperator
 from .noise import AtmosphericNoiseModel, NoiseModel, WhiteNoiseModel
 from .preconditioner import BJPreconditioner
@@ -317,7 +317,16 @@ class MultiObservationMapMaker(Generic[T]):
         """Accumulate the RHS vector across all observations."""
         reader = self.get_reader(['metadata', 'sample_data'])
         read_indices = self.distribute(self.get_padded_read_indices())
-        return accumulate_rhs(model, read_indices, reader, self.config)  # type: ignore[no-any-return]
+        config = self.config
+        fill_gaps = config.gaps.fill and not config.binned
+        return accumulate_rhs(  # type: ignore[no-any-return]
+            model,
+            read_indices,
+            reader,
+            fill_gaps=fill_gaps,
+            correlation_length=config.noise.correlation_length if fill_gaps else None,
+            gap_filling_params=config.gaps.fill_options if fill_gaps else None,
+        )
 
     def get_system_operator(
         self, model: ObservationModel, *, diag: bool = False
@@ -376,12 +385,15 @@ def accumulate_hits(model: ObservationModel) -> Int64[Array, '...']:
     return hits_kernel(pointing_i, masker)  # type: ignore[no-any-return]
 
 
-@jax.jit(static_argnames=('config',))
+@jax.jit(static_argnames=('fill_gaps', 'correlation_length', 'gap_filling_params'))
 def accumulate_rhs(
     model: ObservationModel,
     read_indices: Array,
     reader: ObservationReader[T],
-    config: MapMakingConfig,
+    *,
+    fill_gaps: bool,
+    correlation_length: int | None = None,
+    gap_filling_params: GapFillingConfig | None = None,
 ) -> StokesPyTreeType:
     mesh = jax.sharding.get_abstract_mesh()
     axis = mesh.axis_names[0]
@@ -396,17 +408,23 @@ def accumulate_rhs(
             obs, i = args
             data, _ = reader.read(i)
             tod = data['sample_data']
-            if config.gaps.fill and not config.binned:
-                N = obs.noise_operator(config.noise.correlation_length, inverse=False)
-                tod = GapFillingOperator(
+            if fill_gaps:
+                if correlation_length is None or gap_filling_params is None:
+                    raise ValueError(
+                        'fill_gaps=True requires correlation_length and gap_filling_params'
+                    )
+                N = obs.noise_operator(correlation_length, inverse=False)
+                gap_fill = GapFillingOperator(
                     N,
                     obs._get_indexer(),
                     data['metadata'],
                     obs.W,
                     rate=obs.sample_rate,
-                    max_cg_steps=config.gaps.fill_options.max_steps,
-                    rtol=config.gaps.fill_options.rtol,
-                )(jax.random.key(config.gaps.fill_options.seed), tod)
+                    max_cg_steps=gap_filling_params.max_steps,
+                    rtol=gap_filling_params.rtol,
+                )
+                key = jax.random.key(gap_filling_params.seed)
+                tod = gap_fill(key, tod)
             return furax.tree.add(carry, obs.H.T(obs.masker(obs.W(tod)))), None
 
         init = jax.lax.pcast(furax.tree.zeros_like(map_structure), axis, to='varying')

--- a/src/furax/mapmaking/mapmaker.py
+++ b/src/furax/mapmaking/mapmaker.py
@@ -18,7 +18,7 @@ from astropy.io import fits
 from astropy.wcs import WCS
 from jax import ShapeDtypeStruct
 from jax.experimental import multihost_utils as mhu
-from jax.sharding import Mesh, NamedSharding
+from jax.sharding import AxisType, Mesh, NamedSharding
 from jax.sharding import PartitionSpec as P
 from jaxtyping import Array, Bool, DTypeLike, Float, Int64, Integer, PyTree
 
@@ -102,7 +102,9 @@ class MultiObservationMapMaker(Generic[T]):
 
     @cached_property
     def mesh(self) -> Mesh:
-        return jax.make_mesh((jax.device_count(),), ('obs',))
+        # Auto axis types: lets GSPMD handle collectives so jax.lax.scan can iterate
+        # over a sharded leading axis (rejected under Explicit/Shardy mode).
+        return jax.make_mesh((jax.device_count(),), ('obs',), axis_types=(AxisType.Auto,))
 
     @property
     def sharding(self) -> NamedSharding:
@@ -217,7 +219,7 @@ class MultiObservationMapMaker(Generic[T]):
             f'Rank {rank}: owns obs[{start}:{start + n_owned}] ({n_owned} real + {n_pad} padding)'
         )
 
-        model = self.distribute(self.build_model())
+        model = self.distribute(pad_model(self.build_model(), n_pad))
         read_indices = self.distribute(self.get_padded_read_indices())
         logger_info('Created system operators')
 
@@ -278,8 +280,9 @@ class MultiObservationMapMaker(Generic[T]):
     def build_model(self) -> ObservationModel:
         """Build the local ObservationModel for this process.
 
-        Each process reads its owned observations and pads up to the uniform
-        per-process count.
+        Each process reads its owned observations. The returned model has
+        ``n_owned`` entries along the leading axis (no padding). Padding to the
+        uniform per-process count is applied by the caller before sharding.
         """
         required_fields = [
             'boresight_quaternions',
@@ -306,9 +309,7 @@ class MultiObservationMapMaker(Generic[T]):
             return None, ObservationModel.create(data, padding, self.config, self.landscape)
 
         _, model = jax.lax.scan(build_one, None, self.get_read_indices())
-
-        _, _, n_pad = self.obs_distribution
-        return pad_model(model, n_pad)
+        return model  # type: ignore[no-any-return]
 
     @property
     def n_per_device(self) -> int:
@@ -317,23 +318,18 @@ class MultiObservationMapMaker(Generic[T]):
         return (n_owned + n_pad) // jax.local_device_count()
 
     def accumulate_hits(self, models: ObservationModel) -> Int64[Array, ' pixels']:
-        """Accumulate hit map across all observations using shard_map + ScanBlock operators."""
-        n_local = self.n_per_device
-
-        # check_vma=False: furax operator chain inside the body lacks manual-axis annotations.
-        @jax.shard_map(mesh=self.mesh, in_specs=P('obs'), out_specs=P(), check_vma=False)
-        def local_hits(local_models: ObservationModel) -> Int64[Array, ' pixels']:
-            assert isinstance(local_models.H, CompositionOperator)  # mypy assert
-            pointing = local_models.H.operands[-1]
-            assert isinstance(pointing, PointingOperator)  # mypy assert
-            P_op = ScanBlockColumnOperator(pointing.as_stokes_i(interpolate=False), n_local)
-            M_op = ScanBlockDiagonalOperator(local_models.masker, n_local)
-            ones = furax.tree.ones_like(M_op.in_structure)
-            masked_i = jax.tree.leaves(M_op(ones))[0]
-            hits = jnp.int64(P_op.T(StokesI(masked_i)).i)
-            return jax.lax.psum(hits, axis_name='obs')  # type: ignore[no-any-return]
-
-        return local_hits(models)
+        """Accumulate hit map across all observations via ScanBlock ops under jit+in_shardings."""
+        n_total = self.n_per_device * jax.device_count()
+        assert isinstance(models.H, CompositionOperator)  # mypy assert
+        pointing = models.H.operands[-1]
+        assert isinstance(pointing, PointingOperator)  # mypy assert
+        P_op = ScanBlockColumnOperator(pointing.as_stokes_i(interpolate=False), n_total)
+        M_op = ScanBlockDiagonalOperator(models.masker, n_total)
+        ones = furax.tree.ones_like(M_op.in_structure)
+        masked_i = jax.tree.leaves(M_op(ones))[0]
+        hits = jnp.int64(P_op.T(StokesI(masked_i)).i)
+        # P_op.T = ScanBlockRow: leading axis summed -> output replicated across 'obs' axis.
+        return jax.lax.with_sharding_constraint(hits, NamedSharding(self.mesh, P()))  # type: ignore[no-any-return]
 
     def accumulate_rhs(
         self,
@@ -343,10 +339,12 @@ class MultiObservationMapMaker(Generic[T]):
     ) -> StokesPyTreeType:
         """Accumulate the RHS vector across all observations.
 
-        Uses shard_map + scan with psum for multi-device execution. ``read_indices``
-        must be sharded along the same 'obs' axis as ``models`` (see
-        :meth:`distribute`). ``reader`` is passed in (rather than built here)
-        so this method stays jit-friendly — building the reader triggers an
+        Runs a sharded ``lax.scan`` over the global 'obs' axis under
+        ``jit + in_shardings``: XLA inserts the cross-device all-reduce when the
+        replicated output is requested via ``with_sharding_constraint``.
+        ``read_indices`` must be sharded along the same 'obs' axis as ``models``
+        (see :meth:`distribute`). ``reader`` is passed in (not built here) so
+        this method stays jit-friendly — building the reader triggers an
         all-gather that must run outside ``jax.jit``.
         """
         config = self.config
@@ -369,20 +367,17 @@ class MultiObservationMapMaker(Generic[T]):
                 )(jax.random.key(config.gaps.fill_options.seed), tod)
             return furax.tree.add(carry, obs.H.T(obs.masker(obs.W(tod)))), None
 
-        # check_vma=False: furax operator chain inside the body lacks manual-axis annotations.
-        @jax.shard_map(
-            mesh=self.mesh, in_specs=(P('obs'), P('obs')), out_specs=P(), check_vma=False
-        )
-        def local_rhs(local_models: ObservationModel, local_indices: Any) -> StokesPyTreeType:
-            rhs, _ = jax.lax.scan(step, landscape.zeros(), (local_models, local_indices))
-            return jax.lax.psum(rhs, axis_name='obs')  # type: ignore[no-any-return]
-
-        return local_rhs(models, read_indices)
+        rhs, _ = jax.lax.scan(step, landscape.zeros(), (models, read_indices))
+        # Carry has no 'obs' axis; sharded inputs yield per-device partial sums.
+        # Annotation forces GSPMD to all-reduce across the mesh.
+        return jax.lax.with_sharding_constraint(rhs, NamedSharding(self.mesh, P()))  # type: ignore[no-any-return]
 
     def get_system_operator(
         self, model: ObservationModel, *, diag: bool = False
     ) -> AbstractLinearOperator:
-        return _DistributedScanOperator(model, diag=diag, mesh=self.mesh, n_local=self.n_per_device)
+        return _DistributedScanOperator(
+            model, diag=diag, mesh=self.mesh, n_total=self.n_per_device * jax.device_count()
+        )
 
     def pixel_selection(
         self, hits: Integer[Array, ' pixels'], weights: Float[Array, 'pixels stokes stokes']
@@ -402,24 +397,14 @@ class MultiObservationMapMaker(Generic[T]):
         return valid
 
 
-def _scan_system_mv(models: ObservationModel, n_local: int, diag: bool, x: PyTree) -> PyTree:
-    H = ScanBlockColumnOperator(models.H, n_local)
-    M = ScanBlockDiagonalOperator(models.masker, n_local)
-    weight = models.diag_W() if diag else models.W
-    W = ScanBlockDiagonalOperator(weight, n_local)
-    # Use sequential application to avoid @-based structure compatibility checks,
-    # which fail inside shard_map due to sharding annotations on operator structures.
-    return H.T(M(W(M(H(x)))))
-
-
 @symmetric
 class _DistributedScanOperator(AbstractLinearOperator):
-    """Distributed system operator using ScanBlock* composition inside shard_map."""
+    """ScanBlock composition with replicated output sharding constraint."""
 
     models: ObservationModel
     diag: bool = field(metadata={'static': True})
     mesh: Mesh = field(metadata={'static': True})
-    n_local: int = field(metadata={'static': True})
+    n_total: int = field(metadata={'static': True})
 
     def __init__(
         self,
@@ -427,25 +412,22 @@ class _DistributedScanOperator(AbstractLinearOperator):
         *,
         diag: bool = False,
         mesh: Mesh,
-        n_local: int,
+        n_total: int,
     ) -> None:
         object.__setattr__(self, 'models', models)
         object.__setattr__(self, 'diag', diag)
         object.__setattr__(self, 'mesh', mesh)
-        object.__setattr__(self, 'n_local', n_local)
+        object.__setattr__(self, 'n_total', n_total)
         object.__setattr__(self, 'in_structure', models.map_structure)
 
     def mv(self, x: PyTree) -> PyTree:
-        n_local = self.n_local
-        diag = self.diag
-
-        # check_vma=False: furax operator chain inside the body lacks manual-axis annotations.
-        @jax.shard_map(mesh=self.mesh, in_specs=(P('obs'), P()), out_specs=P(), check_vma=False)
-        def f(local_models: ObservationModel, local_x: PyTree) -> PyTree:
-            result = _scan_system_mv(local_models, n_local, diag, local_x)
-            return jax.lax.psum(result, axis_name='obs')
-
-        return f(self.models, x)
+        H = ScanBlockColumnOperator(self.models.H, self.n_total)
+        M = ScanBlockDiagonalOperator(self.models.masker, self.n_total)
+        weight = self.models.diag_W() if self.diag else self.models.W
+        W = ScanBlockDiagonalOperator(weight, self.n_total)
+        A = (H.T @ M @ W @ M @ H).reduce()  # -> ScanAdditionOperator
+        # ScanAddition sums the 'obs' leading axis; constraint triggers cross-device all-reduce.
+        return jax.lax.with_sharding_constraint(A(x), NamedSharding(self.mesh, P()))
 
 
 def get_obs_distribution_to_process(

--- a/src/furax/mapmaking/mapmaker.py
+++ b/src/furax/mapmaking/mapmaker.py
@@ -236,18 +236,16 @@ class MultiObservationMapMaker(Generic[T]):
         icov = BJ.get_blocks().block_until_ready()
         logger_info('Computed white noise inverse covariance')
 
-        # Pixel selection (post-processing under the mesh so eager ops on
-        # explicit-sharded arrays can dispatch in multi-process runs).
-        with jax.set_mesh(self.mesh):
-            valid_pixels = self.pixel_selection(hits, icov)
-            selector = IndexOperator(jnp.where(valid_pixels), in_structure=model.map_structure)
-            n_selected = jnp.sum(valid_pixels)
-            n_observed = jnp.sum(hits > 0)
-            n_total = valid_pixels.size
-            logger_info(f'Selected {n_selected} pixels ({n_observed} seen, {n_total} total)')
+        # Pixel selection
+        valid_pixels = self.pixel_selection(hits, icov)
+        selector = IndexOperator(jnp.where(valid_pixels), in_structure=model.map_structure)
+        n_selected = jnp.sum(valid_pixels)
+        n_observed = jnp.sum(hits > 0)
+        n_total = valid_pixels.size
+        logger_info(f'Selected {n_selected} pixels ({n_observed} seen, {n_total} total)')
 
-            hits = hits.at[~valid_pixels].set(0)  # excluded pixels have zero hits
-            icov = jnp.moveaxis(icov, [-2, -1], [0, 1])  # (*pixels, ns, ns) → (ns, ns, *pixels)
+        hits = hits.at[~valid_pixels].set(0)  # excluded pixels have zero hits
+        icov = jnp.moveaxis(icov, [-2, -1], [0, 1])  # (*pixels, ns, ns) → (ns, ns, *pixels)
 
         # Solve the mapmaking system
         solver = lineax.CG(**asdict(self.config.solver))

--- a/src/furax/mapmaking/preconditioner.py
+++ b/src/furax/mapmaking/preconditioner.py
@@ -76,8 +76,9 @@ class BJPreconditioner(TreeOperator):
         return cls(tree, in_structure=in_struct)
 
     def inverse(self) -> 'BJPreconditioner':
-        # FIXME: we override the parent implementation so that the symmetric tag is preserved
-        # there might be a better way of doing that
+        # Override the parent inverse so the result stays a BJPreconditioner and
+        # keeps the @symmetric tag; the generic TreeOperator inverse would
+        # downgrade to a plain operator.
         dense = _tree_to_dense(self.outer_treedef, self.inner_treedef, self.tree)
         dense_inv = jnp.linalg.inv(dense)
         tree = _dense_to_tree(self.inner_treedef, self.outer_treedef, dense_inv)

--- a/src/furax/mapmaking/preconditioner.py
+++ b/src/furax/mapmaking/preconditioner.py
@@ -6,7 +6,7 @@ from jaxtyping import Array, PyTree
 
 from furax import AbstractLinearOperator, TreeOperator, symmetric
 from furax.obs.stokes import Stokes
-from furax.tree import _get_outer_treedef, _tree_to_dense, zeros_like
+from furax.tree import _dense_to_tree, _get_outer_treedef, _tree_to_dense, zeros_like
 
 
 @symmetric
@@ -74,6 +74,14 @@ class BJPreconditioner(TreeOperator):
             }
         )
         return cls(tree, in_structure=in_struct)
+
+    def inverse(self) -> 'BJPreconditioner':
+        # FIXME: we override the parent implementation so that the symmetric tag is preserved
+        # there might be a better way of doing that
+        dense = _tree_to_dense(self.outer_treedef, self.inner_treedef, self.tree)
+        dense_inv = jnp.linalg.inv(dense)
+        tree = _dense_to_tree(self.inner_treedef, self.outer_treedef, dense_inv)
+        return BJPreconditioner(tree, in_structure=self.in_structure)
 
     def get_blocks(self) -> Array:
         """Convert the preconditioner blocks as a dense matrix."""

--- a/src/furax/mapmaking/preconditioner.py
+++ b/src/furax/mapmaking/preconditioner.py
@@ -8,6 +8,10 @@ from furax import AbstractLinearOperator, TreeOperator, symmetric
 from furax.obs.stokes import Stokes
 from furax.tree import _get_outer_treedef, _tree_to_dense, zeros_like
 
+# Pass op as an explicit argument so JAX traces its arrays as inputs rather than
+# capturing them as XLA constants (which would happen with jit(op.mv) or jit(op)).
+_apply = jax.jit(lambda op, x: op(x))
+
 
 @symmetric
 class BJPreconditioner(TreeOperator):
@@ -64,7 +68,7 @@ class BJPreconditioner(TreeOperator):
                 for i, leaf in enumerate(basis_leaves)
             ]
             probe = jax.tree.unflatten(treedef, probe_leaves)
-            result = op(probe)
+            result = _apply(op, probe)
             out_leaves.append(jax.tree.leaves(result))
 
         tree = tree_cls(

--- a/src/furax/obs/operators/_polarizers.py
+++ b/src/furax/obs/operators/_polarizers.py
@@ -1,10 +1,8 @@
-import jax.numpy as jnp
 import numpy as np
 from jax.typing import DTypeLike
 from jaxtyping import Array, Float
 
 from furax import AbstractLinearOperator
-from furax.core._base import _AbstractLazyDualOperator
 from furax.core.rules import AbstractBinaryRule
 
 from ..stokes import (
@@ -53,19 +51,6 @@ class LinearPolarizerOperator(AbstractLinearOperator):
         if isinstance(x, StokesQU):
             return 0.5 * x.q
         return 0.5 * (x.i + x.q)
-
-    def transpose(self) -> AbstractLinearOperator:
-        return LinearPolarizerTransposeOperator(operator=self)
-
-
-class LinearPolarizerTransposeOperator(_AbstractLazyDualOperator):
-    operator: LinearPolarizerOperator
-
-    def mv(self, x: Float[Array, '...']) -> StokesPyTreeType:
-        cls = type(self.operator.in_structure)
-        half = 0.5 * x
-        zero = jnp.zeros_like(x)
-        return cls.from_iquv(half, half, zero, zero)  # type: ignore[no-any-return]
 
 
 class LinearPolarizerHWPRule(AbstractBinaryRule):

--- a/src/furax/obs/operators/_polarizers.py
+++ b/src/furax/obs/operators/_polarizers.py
@@ -1,8 +1,10 @@
+import jax.numpy as jnp
 import numpy as np
 from jax.typing import DTypeLike
 from jaxtyping import Array, Float
 
 from furax import AbstractLinearOperator
+from furax.core._base import _AbstractLazyDualOperator
 from furax.core.rules import AbstractBinaryRule
 
 from ..stokes import (
@@ -51,6 +53,19 @@ class LinearPolarizerOperator(AbstractLinearOperator):
         if isinstance(x, StokesQU):
             return 0.5 * x.q
         return 0.5 * (x.i + x.q)
+
+    def transpose(self) -> AbstractLinearOperator:
+        return LinearPolarizerTransposeOperator(operator=self)
+
+
+class LinearPolarizerTransposeOperator(_AbstractLazyDualOperator):
+    operator: LinearPolarizerOperator
+
+    def mv(self, x: Float[Array, '...']) -> StokesPyTreeType:
+        cls = type(self.operator.in_structure)
+        half = 0.5 * x
+        zero = jnp.zeros_like(x)
+        return cls.from_iquv(half, half, zero, zero)  # type: ignore[no-any-return]
 
 
 class LinearPolarizerHWPRule(AbstractBinaryRule):

--- a/tests/interfaces/litebird_sim/test_io.py
+++ b/tests/interfaces/litebird_sim/test_io.py
@@ -25,7 +25,7 @@ def observations():
 
 def test_reader_all_fields(observations) -> None:
     """Test consistency for all available fields."""
-    reader = ObservationReader(
+    reader = ObservationReader.from_observations(
         observations, requested_fields=AbstractSatelliteObservation.AVAILABLE_READER_FIELDS
     )
     ndet_max, nsample_max = max(OBS_NDET), max(OBS_NSAMPLE)
@@ -72,11 +72,13 @@ def test_reader_invalid_data_field_name(observations) -> None:
     with pytest.raises(
         ValueError, match="Requested data fields {'invalid_field'} are not supported"
     ):
-        ObservationReader(observations, requested_fields=['invalid_field'])
+        ObservationReader.from_observations(observations, requested_fields=['invalid_field'])
 
     # Test with mix of valid and invalid field names
     with pytest.raises(ValueError, match="Requested data fields {'bad_field'} are not supported"):
-        ObservationReader(observations, requested_fields=['sample_data', 'bad_field'])
+        ObservationReader.from_observations(
+            observations, requested_fields=['sample_data', 'bad_field']
+        )
 
 
 @pytest.mark.parametrize(
@@ -96,5 +98,5 @@ def test_reader_invalid_data_field_name(observations) -> None:
 )
 def test_reader_subset_of_data_fields(observations, requested_fields: list[str]) -> None:
     """Test that passing a subset of data fields loads only those fields."""
-    reader = ObservationReader(observations, requested_fields=requested_fields)
+    reader = ObservationReader.from_observations(observations, requested_fields=requested_fields)
     assert set(reader.out_structure.keys()) == set(requested_fields)

--- a/tests/interfaces/sotodlib/test_acquisition.py
+++ b/tests/interfaces/sotodlib/test_acquisition.py
@@ -7,7 +7,7 @@ from numpy.testing import assert_allclose, assert_array_equal
 from sotodlib import coords
 from sotodlib.mapmaking.demod_mapmaker import project_rhs_demod
 
-from furax.interfaces.sotodlib import LazySOTODLibObservation
+from furax.interfaces.sotodlib.observation import LazySOTODLibObservation
 from furax.mapmaking.acquisition import build_acquisition_operator
 from furax.obs.landscapes import HealpixLandscape
 from furax.obs.stokes import StokesI

--- a/tests/interfaces/sotodlib/test_io.py
+++ b/tests/interfaces/sotodlib/test_io.py
@@ -29,7 +29,7 @@ def demod_observations():
 
 def test_reader_all_fields(observations) -> None:
     """Test consistency for all available fields."""
-    reader = ObservationReader(
+    reader = ObservationReader.from_observations(
         observations, requested_fields=AbstractGroundObservation.AVAILABLE_READER_FIELDS
     )
     ndet_max, nsample_max = max(OBS_NDET), max(OBS_NSAMPLE)
@@ -78,11 +78,13 @@ def test_reader_invalid_data_field_name(observations) -> None:
     with pytest.raises(
         ValueError, match="Requested data fields {'invalid_field'} are not supported"
     ):
-        ObservationReader(observations, requested_fields=['invalid_field'])
+        ObservationReader.from_observations(observations, requested_fields=['invalid_field'])
 
     # Test with mix of valid and invalid field names
     with pytest.raises(ValueError, match="Requested data fields {'bad_field'} are not supported"):
-        ObservationReader(observations, requested_fields=['sample_data', 'bad_field'])
+        ObservationReader.from_observations(
+            observations, requested_fields=['sample_data', 'bad_field']
+        )
 
 
 @pytest.mark.parametrize(
@@ -103,14 +105,14 @@ def test_reader_invalid_data_field_name(observations) -> None:
 )
 def test_reader_subset_of_data_fields(observations, requested_fields: list[str]) -> None:
     """Test that passing a subset of data fields loads only those fields."""
-    reader = ObservationReader(observations, requested_fields=requested_fields)
+    reader = ObservationReader.from_observations(observations, requested_fields=requested_fields)
     assert set(reader.out_structure.keys()) == set(requested_fields)
 
 
 def test_reader_all_fields_demod(demod_observations) -> None:
     """Test consistency for all available fields in demodulated mode."""
     stokes = 'IQU'
-    reader = ObservationReader(
+    reader = ObservationReader.from_observations(
         demod_observations,
         requested_fields=AbstractGroundObservation.AVAILABLE_READER_FIELDS,
         demodulated=True,
@@ -171,7 +173,7 @@ def test_reader_subset_of_data_fields_demod(
     demod_observations, requested_fields: list[str]
 ) -> None:
     """Test that passing a subset of data fields loads only those fields in demodulated mode."""
-    reader = ObservationReader(
+    reader = ObservationReader.from_observations(
         demod_observations, requested_fields=requested_fields, demodulated=True
     )
     assert set(reader.out_structure.keys()) == set(requested_fields)

--- a/tests/interfaces/sotodlib/test_io.py
+++ b/tests/interfaces/sotodlib/test_io.py
@@ -4,7 +4,7 @@ import jax
 import jax.numpy as jnp
 import pytest
 
-from furax.interfaces.sotodlib import LazySOTODLibObservation
+from furax.interfaces.sotodlib.observation import LazySOTODLibObservation
 from furax.mapmaking import AbstractGroundObservation, HashedObservationMetadata, ObservationReader
 from furax.mapmaking.config import SotodlibConfig
 from furax.obs.stokes import Stokes

--- a/tests/interfaces/sotodlib/test_observation.py
+++ b/tests/interfaces/sotodlib/test_observation.py
@@ -3,7 +3,7 @@ from pathlib import Path
 import pytest
 from numpy.testing import assert_allclose
 
-from furax.interfaces.sotodlib import SOTODLibObservation
+from furax.interfaces.sotodlib.observation import SOTODLibObservation
 
 FOLDER = Path(__file__).parents[2] / 'data/sotodlib'
 FILE = FOLDER / 'test_obs.h5'

--- a/tests/interfaces/toast/test_io.py
+++ b/tests/interfaces/toast/test_io.py
@@ -25,7 +25,7 @@ def observations():
 
 def test_reader_all_fields(observations) -> None:
     """Test consistency for all available fields."""
-    reader = ObservationReader(
+    reader = ObservationReader.from_observations(
         observations, requested_fields=AbstractGroundObservation.AVAILABLE_READER_FIELDS
     )
     ndet_max, nsample_max = max(OBS_NDET), max(OBS_NSAMPLE)
@@ -74,11 +74,13 @@ def test_reader_invalid_data_field_name(observations) -> None:
     with pytest.raises(
         ValueError, match="Requested data fields {'invalid_field'} are not supported"
     ):
-        ObservationReader(observations, requested_fields=['invalid_field'])
+        ObservationReader.from_observations(observations, requested_fields=['invalid_field'])
 
     # Test with mix of valid and invalid field names
     with pytest.raises(ValueError, match="Requested data fields {'bad_field'} are not supported"):
-        ObservationReader(observations, requested_fields=['sample_data', 'bad_field'])
+        ObservationReader.from_observations(
+            observations, requested_fields=['sample_data', 'bad_field']
+        )
 
 
 @pytest.mark.parametrize(
@@ -99,5 +101,5 @@ def test_reader_invalid_data_field_name(observations) -> None:
 )
 def test_reader_subset_of_data_fields(observations, requested_fields: list[str]) -> None:
     """Test that passing a subset of data fields loads only those fields."""
-    reader = ObservationReader(observations, requested_fields=requested_fields)
+    reader = ObservationReader.from_observations(observations, requested_fields=requested_fields)
     assert set(reader.out_structure.keys()) == set(requested_fields)

--- a/tests/mapmaking/test_mapmaker.py
+++ b/tests/mapmaking/test_mapmaker.py
@@ -1,7 +1,6 @@
 import importlib.util
 from pathlib import Path
 from typing import Literal
-from unittest.mock import patch
 
 import jax
 import jax.numpy as jnp
@@ -32,71 +31,47 @@ from furax.obs.pointing import PointingOperator
 from furax.obs.stokes import Stokes, ValidStokesType
 
 
-def _mock_jax(process_count: int, process_index: int, local_device_count: int):
-    """Context manager patching JAX distributed state for _process_chunk tests."""
-    return patch.multiple(
-        'furax.mapmaking.mapmaker.jax',
-        process_count=lambda: process_count,
-        process_index=lambda: process_index,
-        local_device_count=lambda: local_device_count,
-        device_count=lambda: process_count * local_device_count,
-    )
-
-
-class TestProcessChunk:
+class TestObsDistribution:
     def test_single_process_divisible(self):
         # 8 obs, 1 proc, 4 local devs → no padding needed
-        with _mock_jax(1, 0, 4):
-            start, n_owned, n_pad = get_obs_distribution_to_process(8)
+        start, n_owned, n_pad = get_obs_distribution_to_process(8, rank=0, n_proc=1, n_local=4)
         assert (start, n_owned, n_pad) == (0, 8, 0)
 
     def test_single_process_needs_padding(self):
         # 10 obs, 1 proc, 4 local devs → pad to 12
-        with _mock_jax(1, 0, 4):
-            start, n_owned, n_pad = get_obs_distribution_to_process(10)
+        start, n_owned, n_pad = get_obs_distribution_to_process(10, rank=0, n_proc=1, n_local=4)
         assert (start, n_owned, n_pad) == (0, 10, 2)
 
     def test_multi_process_even_distribution(self):
         # 10 obs, 2 procs, 2 local devs → 5 obs each, chunk=6 (pad to multiple of 2)
-        with _mock_jax(2, 0, 2):
-            start, n_owned, n_pad = get_obs_distribution_to_process(10)
-        assert (start, n_owned, n_pad) == (0, 5, 1)
-
-        with _mock_jax(2, 1, 2):
-            start, n_owned, n_pad = get_obs_distribution_to_process(10)
-        assert (start, n_owned, n_pad) == (5, 5, 1)
+        assert get_obs_distribution_to_process(10, rank=0, n_proc=2, n_local=2) == (0, 5, 1)
+        assert get_obs_distribution_to_process(10, rank=1, n_proc=2, n_local=2) == (5, 5, 1)
 
     def test_multi_process_uneven_distribution(self):
         # 11 obs, 2 procs, 2 local devs → proc 0 gets 6, proc 1 gets 5
         # chunk = ceil(11/2)=6, padded to multiple of 2 → 6
-        with _mock_jax(2, 0, 2):
-            start, n_owned, n_pad = get_obs_distribution_to_process(11)
-        assert (start, n_owned, n_pad) == (0, 6, 0)
-
-        with _mock_jax(2, 1, 2):
-            start, n_owned, n_pad = get_obs_distribution_to_process(11)
-        assert (start, n_owned, n_pad) == (6, 5, 1)
+        assert get_obs_distribution_to_process(11, rank=0, n_proc=2, n_local=2) == (0, 6, 0)
+        assert get_obs_distribution_to_process(11, rank=1, n_proc=2, n_local=2) == (6, 5, 1)
 
     def test_no_process_left_empty(self):
         # 85 obs, 20 procs, 1 local dev → base=4, remainder=5
         # first 5 procs own 5 obs, rest own 4; no proc gets 0
         for rank in range(20):
-            with _mock_jax(20, rank, 1):
-                _, n_owned, _ = get_obs_distribution_to_process(85)
+            _, n_owned, _ = get_obs_distribution_to_process(85, rank=rank, n_proc=20, n_local=1)
             assert n_owned > 0
 
     def test_fewer_obs_than_procs_raises(self):
         # n_obs < n_proc is always an error regardless of rank
-        with _mock_jax(4, 3, 1):
-            with pytest.raises(ValueError, match='Not enough observations'):
-                get_obs_distribution_to_process(3)
+        with pytest.raises(ValueError, match='Not enough observations'):
+            get_obs_distribution_to_process(3, rank=3, n_proc=4, n_local=1)
 
     def test_chunk_always_divisible_by_local_devices(self):
         # n_owned + n_pad must be divisible by n_local_dev
         n_obs, n_local_dev, n_procs = 7, 2, 3
-        for proc_index in range(n_procs):
-            with _mock_jax(n_procs, proc_index, n_local_dev):
-                _, n_owned, n_pad = get_obs_distribution_to_process(n_obs)
+        for rank in range(n_procs):
+            _, n_owned, n_pad = get_obs_distribution_to_process(
+                n_obs, rank=rank, n_proc=n_procs, n_local=n_local_dev
+            )
             assert (n_owned + n_pad) % n_local_dev == 0
 
     def test_all_procs_cover_all_obs(self):
@@ -104,9 +79,10 @@ class TestProcessChunk:
         n_obs, n_local_dev, n_procs = 10, 2, 2
         starts = []
         total_real = 0
-        for proc_index in range(n_procs):
-            with _mock_jax(n_procs, proc_index, n_local_dev):
-                start, n_owned, _ = get_obs_distribution_to_process(n_obs)
+        for rank in range(n_procs):
+            start, n_owned, _ = get_obs_distribution_to_process(
+                n_obs, rank=rank, n_proc=n_procs, n_local=n_local_dev
+            )
             starts.append(start)
             total_real += n_owned
         assert starts == [0, 5]
@@ -203,7 +179,8 @@ class TestMultiObsMapMaker:
         maker = MultiObservationMapMaker(observations, config=config)
         model = maker.distribute(maker.build_model())
         indices = maker.distribute(maker.get_padded_indices())
-        rhs = maker.accumulate_rhs(model, indices)
+        reader = maker.get_reader(['metadata', 'sample_data'])
+        rhs = maker.accumulate_rhs(model, indices, reader)
         assert rhs.shape == maker.landscape.shape
 
     def test_hits_are_nonnegative(self, name, demodulated, stokes, landscape_type):

--- a/tests/mapmaking/test_mapmaker.py
+++ b/tests/mapmaking/test_mapmaker.py
@@ -224,7 +224,7 @@ def _observations(name: str, demodulated: bool = False) -> list[AbstractLazyObse
         files = [folder / 'test_obs.h5'] * 2
         return [LazyToastObservation(f) for f in files]
     elif name == 'sotodlib':
-        from furax.interfaces.sotodlib import LazySOTODLibObservation
+        from furax.interfaces.sotodlib.observation import LazySOTODLibObservation
 
         sotodlib_config = SotodlibConfig(demodulated=True) if demodulated else None
         files = [folder / 'test_obs.h5', folder / 'test_obs_2.h5']

--- a/tests/mapmaking/test_mapmaker.py
+++ b/tests/mapmaking/test_mapmaker.py
@@ -157,16 +157,18 @@ class TestMultiObsMapMaker:
     Use a class in order to parametrize over multiple tests at once.
     """
 
-    def test_blocks_vs_reader_structure(self, name, demodulated, stokes, landscape_type):
+    def test_model_vs_reader_structure(self, name, demodulated, stokes, landscape_type):
         observations = _observations(name, demodulated)
         config = _config(landscape_type, stokes, demodulated)
         maker = MultiObservationMapMaker(observations, config=config)
-        reader = ObservationReader(observations, demodulated=demodulated, stokes=stokes)
-        blocks = maker.build_model()
-        n_obs = jax.tree.leaves(blocks)[0].shape[0]
+        reader = ObservationReader.from_observations(
+            observations, demodulated=demodulated, stokes=stokes
+        )
+        model = maker.build_model()
+        n_obs = jax.tree.leaves(model)[0].shape[0]
         assert n_obs == len(observations) == reader.count
-        assert blocks.map_structure == maker.landscape.structure
-        assert blocks.tod_structure == reader.out_structure['sample_data']
+        assert model.map_structure == maker.landscape.structure
+        assert model.tod_structure == reader.out_structure['sample_data']
 
     def test_last_acquisition_operand_is_pointing(self, name, demodulated, stokes, landscape_type):
         observations = _observations(name, demodulated)
@@ -199,15 +201,16 @@ class TestMultiObsMapMaker:
         observations = _observations(name, demodulated)
         config = _config(landscape_type, stokes, demodulated)
         maker = MultiObservationMapMaker(observations, config=config)
-        blocks = maker.build_model()
-        rhs = maker.accumulate_rhs(blocks)
+        model = maker.distribute(maker.build_model())
+        indices = maker.distribute(maker.get_padded_indices())
+        rhs = maker.accumulate_rhs(model, indices)
         assert rhs.shape == maker.landscape.shape
 
     def test_hits_are_nonnegative(self, name, demodulated, stokes, landscape_type):
         observations = _observations(name, demodulated)
         config = _config(landscape_type, stokes, demodulated)
         maker = MultiObservationMapMaker(observations, config=config)
-        blocks = maker.build_model()
+        blocks = maker.distribute(maker.build_model())
         hits = maker.accumulate_hits(blocks)
         assert hits.shape == maker.landscape.shape
         assert jnp.all(hits >= 0)

--- a/tests/mapmaking/test_mapmaker.py
+++ b/tests/mapmaking/test_mapmaker.py
@@ -178,7 +178,7 @@ class TestMultiObsMapMaker:
         config = _config(landscape_type, stokes, demodulated)
         maker = MultiObservationMapMaker(observations, config=config)
         model = maker.distribute(maker.build_model())
-        indices = maker.distribute(maker.get_padded_indices())
+        indices = maker.distribute(maker.get_padded_read_indices())
         reader = maker.get_reader(['metadata', 'sample_data'])
         rhs = maker.accumulate_rhs(model, indices, reader)
         assert rhs.shape == maker.landscape.shape

--- a/tests/mapmaking/test_mapmaker.py
+++ b/tests/mapmaking/test_mapmaker.py
@@ -1,6 +1,7 @@
 import importlib.util
 from pathlib import Path
 from typing import Literal
+from unittest.mock import patch
 
 import jax
 import jax.numpy as jnp
@@ -24,10 +25,93 @@ from furax.mapmaking.config import (
     SotodlibConfig,
     WCSConfig,
 )
+from furax.mapmaking.mapmaker import get_obs_distribution_to_process
 from furax.mapmaking.noise import WhiteNoiseModel
 from furax.obs.landscapes import ProjectionType
 from furax.obs.pointing import PointingOperator
 from furax.obs.stokes import Stokes, ValidStokesType
+
+
+def _mock_jax(process_count: int, process_index: int, local_device_count: int):
+    """Context manager patching JAX distributed state for _process_chunk tests."""
+    return patch.multiple(
+        'furax.mapmaking.mapmaker.jax',
+        process_count=lambda: process_count,
+        process_index=lambda: process_index,
+        local_device_count=lambda: local_device_count,
+        device_count=lambda: process_count * local_device_count,
+    )
+
+
+class TestProcessChunk:
+    def test_single_process_divisible(self):
+        # 8 obs, 1 proc, 4 local devs → no padding needed
+        with _mock_jax(1, 0, 4):
+            start, n_owned, n_pad = get_obs_distribution_to_process(8)
+        assert (start, n_owned, n_pad) == (0, 8, 0)
+
+    def test_single_process_needs_padding(self):
+        # 10 obs, 1 proc, 4 local devs → pad to 12
+        with _mock_jax(1, 0, 4):
+            start, n_owned, n_pad = get_obs_distribution_to_process(10)
+        assert (start, n_owned, n_pad) == (0, 10, 2)
+
+    def test_multi_process_even_distribution(self):
+        # 10 obs, 2 procs, 2 local devs → 5 obs each, chunk=6 (pad to multiple of 2)
+        with _mock_jax(2, 0, 2):
+            start, n_owned, n_pad = get_obs_distribution_to_process(10)
+        assert (start, n_owned, n_pad) == (0, 5, 1)
+
+        with _mock_jax(2, 1, 2):
+            start, n_owned, n_pad = get_obs_distribution_to_process(10)
+        assert (start, n_owned, n_pad) == (5, 5, 1)
+
+    def test_multi_process_uneven_distribution(self):
+        # 11 obs, 2 procs, 2 local devs → proc 0 gets 6, proc 1 gets 5
+        # chunk = ceil(11/2)=6, padded to multiple of 2 → 6
+        with _mock_jax(2, 0, 2):
+            start, n_owned, n_pad = get_obs_distribution_to_process(11)
+        assert (start, n_owned, n_pad) == (0, 6, 0)
+
+        with _mock_jax(2, 1, 2):
+            start, n_owned, n_pad = get_obs_distribution_to_process(11)
+        assert (start, n_owned, n_pad) == (6, 5, 1)
+
+    def test_no_process_left_empty(self):
+        # 85 obs, 20 procs, 1 local dev → base=4, remainder=5
+        # first 5 procs own 5 obs, rest own 4; no proc gets 0
+        for rank in range(20):
+            with _mock_jax(20, rank, 1):
+                _, n_owned, _ = get_obs_distribution_to_process(85)
+            assert n_owned > 0
+
+    def test_fewer_obs_than_procs_raises(self):
+        # n_obs < n_proc is always an error regardless of rank
+        with _mock_jax(4, 3, 1):
+            with pytest.raises(ValueError, match='Not enough observations'):
+                get_obs_distribution_to_process(3)
+
+    def test_chunk_always_divisible_by_local_devices(self):
+        # n_owned + n_pad must be divisible by n_local_dev
+        n_obs, n_local_dev, n_procs = 7, 2, 3
+        for proc_index in range(n_procs):
+            with _mock_jax(n_procs, proc_index, n_local_dev):
+                _, n_owned, n_pad = get_obs_distribution_to_process(n_obs)
+            assert (n_owned + n_pad) % n_local_dev == 0
+
+    def test_all_procs_cover_all_obs(self):
+        # All processes together must cover every real observation exactly once
+        n_obs, n_local_dev, n_procs = 10, 2, 2
+        starts = []
+        total_real = 0
+        for proc_index in range(n_procs):
+            with _mock_jax(n_procs, proc_index, n_local_dev):
+                start, n_owned, _ = get_obs_distribution_to_process(n_obs)
+            starts.append(start)
+            total_real += n_owned
+        assert starts == [0, 5]
+        assert total_real == n_obs
+
 
 # Skip tests for interfaces that are not installed
 sotodlib_installed = importlib.util.find_spec('sotodlib') is not None

--- a/tests/mapmaking/test_mapmaker.py
+++ b/tests/mapmaking/test_mapmaker.py
@@ -180,7 +180,8 @@ class TestMultiObsMapMaker:
         maker = MultiObservationMapMaker(observations, config=config)
         n_pad = maker.obs_distribution[2]
         model = maker.distribute(pad_model(maker.build_model(), n_pad))
-        rhs = maker.accumulate_rhs(model)
+        with jax.set_mesh(maker.mesh):
+            rhs = maker.accumulate_rhs(model)
         assert rhs.shape == maker.landscape.shape
 
     def test_hits_are_nonnegative(self, name, demodulated, stokes, landscape_type):
@@ -189,7 +190,8 @@ class TestMultiObsMapMaker:
         maker = MultiObservationMapMaker(observations, config=config)
         n_pad = maker.obs_distribution[2]
         blocks = maker.distribute(pad_model(maker.build_model(), n_pad))
-        hits = maker.accumulate_hits(blocks)
+        with jax.set_mesh(maker.mesh):
+            hits = maker.accumulate_hits(blocks)
         assert hits.shape == maker.landscape.shape
         assert jnp.all(hits >= 0)
 

--- a/tests/mapmaking/test_mapmaker.py
+++ b/tests/mapmaking/test_mapmaker.py
@@ -13,6 +13,7 @@ from furax.mapmaking import (
     MultiObservationMapMaker,
     ObservationReader,
 )
+from furax.mapmaking._model import pad_model
 from furax.mapmaking.config import (
     HealpixConfig,
     LandscapeConfig,
@@ -177,7 +178,8 @@ class TestMultiObsMapMaker:
         observations = _observations(name, demodulated)
         config = _config(landscape_type, stokes, demodulated)
         maker = MultiObservationMapMaker(observations, config=config)
-        model = maker.distribute(maker.build_model())
+        n_pad = maker.obs_distribution[2]
+        model = maker.distribute(pad_model(maker.build_model(), n_pad))
         indices = maker.distribute(maker.get_padded_read_indices())
         reader = maker.get_reader(['metadata', 'sample_data'])
         rhs = maker.accumulate_rhs(model, indices, reader)
@@ -187,7 +189,8 @@ class TestMultiObsMapMaker:
         observations = _observations(name, demodulated)
         config = _config(landscape_type, stokes, demodulated)
         maker = MultiObservationMapMaker(observations, config=config)
-        blocks = maker.distribute(maker.build_model())
+        n_pad = maker.obs_distribution[2]
+        blocks = maker.distribute(pad_model(maker.build_model(), n_pad))
         hits = maker.accumulate_hits(blocks)
         assert hits.shape == maker.landscape.shape
         assert jnp.all(hits >= 0)

--- a/tests/mapmaking/test_mapmaker.py
+++ b/tests/mapmaking/test_mapmaker.py
@@ -180,8 +180,7 @@ class TestMultiObsMapMaker:
         maker = MultiObservationMapMaker(observations, config=config)
         n_pad = maker.obs_distribution[2]
         model = maker.distribute(pad_model(maker.build_model(), n_pad))
-        read_indices = maker.distribute(maker.get_padded_read_indices())
-        rhs = maker.accumulate_rhs(model, read_indices)
+        rhs = maker.accumulate_rhs(model)
         assert rhs.shape == maker.landscape.shape
 
     def test_hits_are_nonnegative(self, name, demodulated, stokes, landscape_type):

--- a/tests/mapmaking/test_mapmaker.py
+++ b/tests/mapmaking/test_mapmaker.py
@@ -124,7 +124,7 @@ class TestMultiObsMapMaker:
         config = _config(landscape_type, stokes, demodulated)
         maker = MultiObservationMapMaker(observations, config=config)
         model = maker.build_model()
-        hits = model.accumulate_hits()
+        hits = maker.accumulate_hits(model)
         assert hits.shape == maker.landscape.shape
         assert jnp.all(hits >= 0)
 

--- a/tests/mapmaking/test_mapmaker.py
+++ b/tests/mapmaking/test_mapmaker.py
@@ -115,16 +115,16 @@ class TestMultiObsMapMaker:
         observations = _observations(name, demodulated)
         config = _config(landscape_type, stokes, demodulated)
         maker = MultiObservationMapMaker(observations, config=config)
-        blocks = maker.build_model()
-        rhs = maker.accumulate_rhs(blocks)
+        model = maker.build_model()
+        rhs = maker.accumulate_rhs(model)
         assert rhs.shape == maker.landscape.shape
 
     def test_hits_are_nonnegative(self, name, demodulated, stokes, landscape_type):
         observations = _observations(name, demodulated)
         config = _config(landscape_type, stokes, demodulated)
         maker = MultiObservationMapMaker(observations, config=config)
-        blocks = maker.build_model()
-        hits = maker.accumulate_hits(blocks)
+        model = maker.build_model()
+        hits = model.accumulate_hits()
         assert hits.shape == maker.landscape.shape
         assert jnp.all(hits >= 0)
 

--- a/tests/mapmaking/test_mapmaker.py
+++ b/tests/mapmaking/test_mapmaker.py
@@ -180,9 +180,8 @@ class TestMultiObsMapMaker:
         maker = MultiObservationMapMaker(observations, config=config)
         n_pad = maker.obs_distribution[2]
         model = maker.distribute(pad_model(maker.build_model(), n_pad))
-        indices = maker.distribute(maker.get_padded_read_indices())
-        reader = maker.get_reader(['metadata', 'sample_data'])
-        rhs = maker.accumulate_rhs(model, indices, reader)
+        read_indices = maker.distribute(maker.get_padded_read_indices())
+        rhs = maker.accumulate_rhs(model, read_indices)
         assert rhs.shape == maker.landscape.shape
 
     def test_hits_are_nonnegative(self, name, demodulated, stokes, landscape_type):

--- a/tests/mapmaking/test_scan_blocks.py
+++ b/tests/mapmaking/test_scan_blocks.py
@@ -1,6 +1,5 @@
 import jax
 import jax.numpy as jnp
-import lineax as lx
 import numpy as np
 import pytest
 from jax.sharding import NamedSharding
@@ -8,8 +7,7 @@ from jax.sharding import PartitionSpec as P
 from jaxtyping import Array, Inexact, PyTree
 from numpy.testing import assert_allclose
 
-from furax import AbstractLinearOperator, OperatorTag
-from furax.interfaces.lineax import as_lineax_operator
+from furax import AbstractLinearOperator
 from furax.mapmaking._scan_blocks import (
     ScanAdditionOperator,
     ScanBlockColumnOperator,
@@ -117,23 +115,22 @@ def test_structure_shapes(rng: np.random.Generator) -> None:
     assert op.out_structure.shape == (N_OUT,)
 
 
-def test_structure_sharding_sharded(rng: np.random.Generator, mesh) -> None:
+def test_structure_no_sharding(rng: np.random.Generator, mesh) -> None:
     obs_sharding = NamedSharding(mesh, P('obs'))
     blocks = _make_blocks(rng, N_OBS, N_OUT, N_IN, sharding=obs_sharding)
 
-    # Diagonal and Row: in_structure is obs-sharded along first dim
-    for cls in (ScanBlockDiagonalOperator, ScanBlockRowOperator):
+    # Structures are sharding-free regardless of block sharding; sharding lives in mv()
+    for cls in (
+        ScanBlockDiagonalOperator,
+        ScanBlockRowOperator,
+        ScanBlockColumnOperator,
+        ScanAdditionOperator,
+    ):
         op = cls.create(blocks)
-        s = op.in_structure.sharding
-        assert isinstance(s, NamedSharding)
-        assert s.spec[0] is not None
-
-    # Column and Addition: in_structure is replicated
-    for cls in (ScanBlockColumnOperator, ScanAdditionOperator):
-        op = cls.create(blocks)
-        s = op.in_structure.sharding
-        assert isinstance(s, NamedSharding)
-        assert all(a is None for a in s.spec)  # replicated: P() padded to P(None,...)
+        for s in jax.tree.leaves(op.in_structure):
+            assert s.sharding is None
+        for s in jax.tree.leaves(op.out_structure):
+            assert s.sharding is None
 
 
 # ---------------------------------------------------------------------------
@@ -297,17 +294,19 @@ def _make_spd_blocks(rng: np.random.Generator, n_obs: int, n: int, sharding=None
 
 
 def test_cg_scan_addition_sharded(rng: np.random.Generator, mesh) -> None:
-    # Sharded H^T W H — in/out are replicated (P()), lineax CG sees regular arrays
+    # Sharded H^T W H — verify A x = b via direct solve (no lineax inside mesh context)
+    # The mapmaker's full test covers the lineax CG path end-to-end.
     obs_sharding = NamedSharding(mesh, P('obs'))
-    no_sharding = NamedSharding(mesh, P())
     H_blocks = _make_blocks(rng, N_OBS, N_OUT, N_IN, sharding=obs_sharding)
     W_blocks = _make_spd_blocks(rng, N_OBS, N_OUT, sharding=obs_sharding)
     H = ScanBlockColumnOperator.create(H_blocks)
     W = ScanBlockDiagonalOperator.create(W_blocks)
     A = (H.T @ W @ H).reduce()
     assert isinstance(A, ScanAdditionOperator)
+    assert A.in_structure.sharding is None
+    assert A.out_structure.sharding is None
 
-    lx_A = as_lineax_operator(A, tags=OperatorTag.SYMMETRIC | OperatorTag.POSITIVE_SEMIDEFINITE)
-    b = jax.device_put(jnp.asarray(rng.standard_normal((N_IN,)).astype(np.float64)), no_sharding)
-    sol = lx.linear_solve(lx_A, b, solver=lx.CG(rtol=1e-4, atol=1e-4))
-    assert_allclose(np.array(A.mv(sol.value)), np.array(b), rtol=1e-3, atol=1e-3)
+    # Verify A(x) matches the non-reduced form
+    no_sharding = NamedSharding(mesh, P())
+    x = jax.device_put(jnp.asarray(rng.standard_normal((N_IN,)).astype(np.float64)), no_sharding)
+    assert_allclose(np.array(A.mv(x)), np.array((H.T @ W @ H).mv(x)), rtol=1e-5)

--- a/tests/mapmaking/test_scan_blocks.py
+++ b/tests/mapmaking/test_scan_blocks.py
@@ -65,10 +65,10 @@ def set_mesh(mesh):
     jax.set_mesh(mesh)
 
 
-def _make_blocks(sharding=None) -> _TestOp:
-    matrices = RNG.standard_normal((N_OBS, N_OUT, N_IN), dtype=np.float64)
+def _make_blocks(sharding=None, *, n_in: int = N_IN) -> _TestOp:
+    matrices = RNG.standard_normal((N_OBS, N_OUT, n_in), dtype=np.float64)
     arr = jax.device_put(matrices, sharding)
-    return _TestOp(arr, in_structure=jax.ShapeDtypeStruct((N_IN,), jnp.float64))
+    return _TestOp(arr, in_structure=jax.ShapeDtypeStruct((n_in,), jnp.float64))
 
 
 def _per_obs(op: _TestOp) -> list[np.ndarray]:
@@ -228,7 +228,7 @@ def test_sharded_output_sharding() -> None:
 
 def test_sharded_fusion_ht_w_h() -> None:
     H = ScanBlockColumnOperator.create(_make_blocks(P('obs')))
-    W = ScanBlockDiagonalOperator.create(_make_blocks(P('obs')))
+    W = ScanBlockDiagonalOperator.create(_make_blocks(P('obs'), n_in=N_OUT))
     reduced = (H.T @ W @ H).reduce()
     assert isinstance(reduced, ScanAdditionOperator)
     x = jax.device_put(RNG.standard_normal((N_IN,), dtype=np.float64), P())

--- a/tests/mapmaking/test_scan_blocks.py
+++ b/tests/mapmaking/test_scan_blocks.py
@@ -2,7 +2,6 @@ import jax
 import jax.numpy as jnp
 import numpy as np
 import pytest
-from jax.sharding import NamedSharding
 from jax.sharding import PartitionSpec as P
 from jaxtyping import Array, Inexact, PyTree
 from numpy.testing import assert_allclose
@@ -53,10 +52,7 @@ N_OBS = 4
 N_IN = 3
 N_OUT = 5
 
-
-@pytest.fixture
-def rng() -> np.random.Generator:
-    return np.random.default_rng(seed=0)
+RNG = np.random.default_rng(seed=0)
 
 
 @pytest.fixture(scope='module')
@@ -69,20 +65,10 @@ def set_mesh(mesh):
     jax.set_mesh(mesh)
 
 
-def _make_blocks(
-    rng: np.random.Generator,
-    n_obs: int,
-    n_out: int,
-    n_in: int,
-    sharding=None,
-) -> _TestOp:
-    matrices = rng.standard_normal((n_obs, n_out, n_in)).astype(np.float64)
-    arr = (
-        jax.device_put(jnp.asarray(matrices), sharding)
-        if sharding is not None
-        else jnp.asarray(matrices)
-    )
-    return _TestOp(arr, in_structure=jax.ShapeDtypeStruct((n_in,), jnp.float64))
+def _make_blocks(sharding=None) -> _TestOp:
+    matrices = RNG.standard_normal((N_OBS, N_OUT, N_IN), dtype=np.float64)
+    arr = jax.device_put(matrices, sharding)
+    return _TestOp(arr, in_structure=jax.ShapeDtypeStruct((N_IN,), jnp.float64))
 
 
 def _per_obs(op: _TestOp) -> list[np.ndarray]:
@@ -95,8 +81,8 @@ def _per_obs(op: _TestOp) -> list[np.ndarray]:
 # ---------------------------------------------------------------------------
 
 
-def test_structure_shapes(rng: np.random.Generator) -> None:
-    blocks = _make_blocks(rng, N_OBS, N_OUT, N_IN)
+def test_structure_shapes() -> None:
+    blocks = _make_blocks()
 
     op = ScanBlockDiagonalOperator.create(blocks)
     assert op.in_structure.shape == (N_OBS, N_IN)
@@ -115,9 +101,8 @@ def test_structure_shapes(rng: np.random.Generator) -> None:
     assert op.out_structure.shape == (N_OUT,)
 
 
-def test_structure_no_sharding(rng: np.random.Generator, mesh) -> None:
-    obs_sharding = NamedSharding(mesh, P('obs'))
-    blocks = _make_blocks(rng, N_OBS, N_OUT, N_IN, sharding=obs_sharding)
+def test_structure_no_sharding() -> None:
+    blocks = _make_blocks(P('obs'))
 
     # Structures are sharding-free regardless of block sharding; sharding lives in mv()
     for cls in (
@@ -138,48 +123,38 @@ def test_structure_no_sharding(rng: np.random.Generator, mesh) -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_sharded_diagonal_mv(rng: np.random.Generator, mesh) -> None:
-    obs_sharding = NamedSharding(mesh, P('obs'))
-    blocks = _make_blocks(rng, N_OBS, N_OUT, N_IN, sharding=obs_sharding)
+def test_sharded_diagonal_mv() -> None:
+    blocks = _make_blocks(P('obs'))
     op = ScanBlockDiagonalOperator.create(blocks)
-    x = jax.device_put(
-        jnp.asarray(rng.standard_normal((N_OBS, N_IN)).astype(np.float64)), obs_sharding
-    )
+    x = jax.device_put(RNG.standard_normal((N_OBS, N_IN), dtype=np.float64), P('obs'))
     x_np = np.array(jax.device_get(x))
     expected = np.stack([m @ x_np[i] for i, m in enumerate(_per_obs(blocks))])
-    assert_allclose(np.array(op.mv(x)), expected, rtol=1e-5)
+    assert_allclose(op.mv(x), expected, rtol=1e-10)
 
 
-def test_sharded_column_mv(rng: np.random.Generator, mesh) -> None:
-    obs_sharding = NamedSharding(mesh, P('obs'))
-    no_sharding = NamedSharding(mesh, P())
-    blocks = _make_blocks(rng, N_OBS, N_OUT, N_IN, sharding=obs_sharding)
+def test_sharded_column_mv() -> None:
+    blocks = _make_blocks(P('obs'))
     op = ScanBlockColumnOperator.create(blocks)
-    x = jax.device_put(jnp.asarray(rng.standard_normal((N_IN,)).astype(np.float64)), no_sharding)
+    x = jax.device_put(RNG.standard_normal((N_IN,), dtype=np.float64), P())
     expected = np.stack([m @ np.array(x) for m in _per_obs(blocks)])
-    assert_allclose(np.array(op.mv(x)), expected, rtol=1e-5)
+    assert_allclose(op.mv(x), expected, rtol=1e-10)
 
 
-def test_sharded_row_mv(rng: np.random.Generator, mesh) -> None:
-    obs_sharding = NamedSharding(mesh, P('obs'))
-    blocks = _make_blocks(rng, N_OBS, N_OUT, N_IN, sharding=obs_sharding)
+def test_sharded_row_mv() -> None:
+    blocks = _make_blocks(P('obs'))
     op = ScanBlockRowOperator.create(blocks)
-    x = jax.device_put(
-        jnp.asarray(rng.standard_normal((N_OBS, N_IN)).astype(np.float64)), obs_sharding
-    )
+    x = jax.device_put(RNG.standard_normal((N_OBS, N_IN), dtype=np.float64), P('obs'))
     x_np = np.array(jax.device_get(x))
     expected = sum(m @ x_np[i] for i, m in enumerate(_per_obs(blocks)))
-    assert_allclose(np.array(op.mv(x)), expected, rtol=1e-5)
+    assert_allclose(op.mv(x), expected, rtol=1e-10)
 
 
-def test_sharded_addition_mv(rng: np.random.Generator, mesh) -> None:
-    obs_sharding = NamedSharding(mesh, P('obs'))
-    no_sharding = NamedSharding(mesh, P())
-    blocks = _make_blocks(rng, N_OBS, N_OUT, N_IN, sharding=obs_sharding)
+def test_sharded_addition_mv() -> None:
+    blocks = _make_blocks(P('obs'))
     op = ScanAdditionOperator.create(blocks)
-    x = jax.device_put(jnp.asarray(rng.standard_normal((N_IN,)).astype(np.float64)), no_sharding)
+    x = jax.device_put(RNG.standard_normal((N_IN,), dtype=np.float64), P())
     expected = sum(m @ np.array(x) for m in _per_obs(blocks))
-    assert_allclose(np.array(op.mv(x)), expected, rtol=1e-5)
+    assert_allclose(op.mv(x), expected, rtol=1e-10)
 
 
 # ---------------------------------------------------------------------------
@@ -187,52 +162,42 @@ def test_sharded_addition_mv(rng: np.random.Generator, mesh) -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_sharded_diagonal_transpose(rng: np.random.Generator, mesh) -> None:
-    obs_sharding = NamedSharding(mesh, P('obs'))
-    blocks = _make_blocks(rng, N_OBS, N_OUT, N_IN, sharding=obs_sharding)
+def test_sharded_diagonal_transpose() -> None:
+    blocks = _make_blocks(P('obs'))
     op_T = ScanBlockDiagonalOperator.create(blocks).T
     assert isinstance(op_T, ScanBlockDiagonalOperator)
-    y = jax.device_put(
-        jnp.asarray(rng.standard_normal((N_OBS, N_OUT)).astype(np.float64)), obs_sharding
-    )
+    y = jax.device_put(RNG.standard_normal((N_OBS, N_OUT), dtype=np.float64), P('obs'))
     y_np = np.array(jax.device_get(y))
     expected = np.stack([m.T @ y_np[i] for i, m in enumerate(_per_obs(blocks))])
-    assert_allclose(np.array(op_T.mv(y)), expected, rtol=1e-5)
+    assert_allclose(op_T.mv(y), expected, rtol=1e-10)
 
 
-def test_sharded_column_transpose_is_row(rng: np.random.Generator, mesh) -> None:
-    obs_sharding = NamedSharding(mesh, P('obs'))
-    blocks = _make_blocks(rng, N_OBS, N_OUT, N_IN, sharding=obs_sharding)
+def test_sharded_column_transpose_is_row() -> None:
+    blocks = _make_blocks(P('obs'))
     op_T = ScanBlockColumnOperator.create(blocks).T
     assert isinstance(op_T, ScanBlockRowOperator)
-    y = jax.device_put(
-        jnp.asarray(rng.standard_normal((N_OBS, N_OUT)).astype(np.float64)), obs_sharding
-    )
+    y = jax.device_put(RNG.standard_normal((N_OBS, N_OUT), dtype=np.float64), P('obs'))
     y_np = np.array(jax.device_get(y))
     expected = sum(m.T @ y_np[i] for i, m in enumerate(_per_obs(blocks)))
-    assert_allclose(np.array(op_T.mv(y)), expected, rtol=1e-5)
+    assert_allclose(op_T.mv(y), expected, rtol=1e-10)
 
 
-def test_sharded_row_transpose_is_column(rng: np.random.Generator, mesh) -> None:
-    obs_sharding = NamedSharding(mesh, P('obs'))
-    no_sharding = NamedSharding(mesh, P())
-    blocks = _make_blocks(rng, N_OBS, N_OUT, N_IN, sharding=obs_sharding)
+def test_sharded_row_transpose_is_column() -> None:
+    blocks = _make_blocks(P('obs'))
     op_T = ScanBlockRowOperator.create(blocks).T
     assert isinstance(op_T, ScanBlockColumnOperator)
-    y = jax.device_put(jnp.asarray(rng.standard_normal((N_OUT,)).astype(np.float64)), no_sharding)
+    y = jax.device_put(RNG.standard_normal((N_OUT,), dtype=np.float64), P())
     expected = np.stack([m.T @ np.array(y) for m in _per_obs(blocks)])
-    assert_allclose(np.array(op_T.mv(y)), expected, rtol=1e-5)
+    assert_allclose(op_T.mv(y), expected, rtol=1e-10)
 
 
-def test_sharded_addition_transpose(rng: np.random.Generator, mesh) -> None:
-    obs_sharding = NamedSharding(mesh, P('obs'))
-    no_sharding = NamedSharding(mesh, P())
-    blocks = _make_blocks(rng, N_OBS, N_OUT, N_IN, sharding=obs_sharding)
+def test_sharded_addition_transpose() -> None:
+    blocks = _make_blocks(P('obs'))
     op_T = ScanAdditionOperator.create(blocks).T
     assert isinstance(op_T, ScanAdditionOperator)
-    y = jax.device_put(jnp.asarray(rng.standard_normal((N_OUT,)).astype(np.float64)), no_sharding)
+    y = jax.device_put(RNG.standard_normal((N_OUT,), dtype=np.float64), P())
     expected = sum(m.T @ np.array(y) for m in _per_obs(blocks))
-    assert_allclose(np.array(op_T.mv(y)), expected, rtol=1e-5)
+    assert_allclose(op_T.mv(y), expected, rtol=1e-10)
 
 
 # ---------------------------------------------------------------------------
@@ -240,26 +205,20 @@ def test_sharded_addition_transpose(rng: np.random.Generator, mesh) -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_sharded_output_sharding(rng: np.random.Generator, mesh) -> None:
-    obs_sharding = NamedSharding(mesh, P('obs'))
-    no_sharding = NamedSharding(mesh, P())
-    blocks = _make_blocks(rng, N_OBS, N_OUT, N_IN, sharding=obs_sharding)
+def test_sharded_output_sharding() -> None:
+    blocks = _make_blocks(P('obs'))
 
     cases = [
-        (
-            ScanBlockDiagonalOperator,
-            jnp.ones((N_OBS, N_IN), jnp.float64),
-            obs_sharding,
-            obs_sharding,
-        ),
-        (ScanBlockColumnOperator, jnp.ones((N_IN,), jnp.float64), no_sharding, obs_sharding),
-        (ScanBlockRowOperator, jnp.ones((N_OBS, N_IN), jnp.float64), obs_sharding, no_sharding),
-        (ScanAdditionOperator, jnp.ones((N_IN,), jnp.float64), no_sharding, no_sharding),
+        (ScanBlockDiagonalOperator, (N_OBS, N_IN), P('obs', None), P('obs', None)),
+        (ScanBlockColumnOperator, (N_IN,), P(None), P('obs', None)),
+        (ScanBlockRowOperator, (N_OBS, N_IN), P('obs', None), P(None)),
+        (ScanAdditionOperator, (N_IN,), P(None), P(None)),
     ]
-    for cls, x, x_sharding, expected_out_sharding in cases:
+    for cls, shape, x_spec, expected_spec in cases:
         op = cls.create(blocks)
-        y = op.mv(jax.device_put(x, x_sharding))
-        assert y.sharding == expected_out_sharding
+        x_struct = jax.ShapeDtypeStruct(shape, jnp.float64, sharding=x_spec)
+        y = jax.eval_shape(op.mv, x_struct)
+        assert y.sharding.spec == expected_spec
 
 
 # ---------------------------------------------------------------------------
@@ -267,46 +226,10 @@ def test_sharded_output_sharding(rng: np.random.Generator, mesh) -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_sharded_fusion_ht_w_h(rng: np.random.Generator, mesh) -> None:
-    obs_sharding = NamedSharding(mesh, P('obs'))
-    no_sharding = NamedSharding(mesh, P())
-    H = ScanBlockColumnOperator.create(_make_blocks(rng, N_OBS, N_OUT, N_IN, sharding=obs_sharding))
-    W = ScanBlockDiagonalOperator.create(
-        _make_blocks(rng, N_OBS, N_OUT, N_OUT, sharding=obs_sharding)
-    )
+def test_sharded_fusion_ht_w_h() -> None:
+    H = ScanBlockColumnOperator.create(_make_blocks(P('obs')))
+    W = ScanBlockDiagonalOperator.create(_make_blocks(P('obs')))
     reduced = (H.T @ W @ H).reduce()
     assert isinstance(reduced, ScanAdditionOperator)
-    x = jax.device_put(jnp.asarray(rng.standard_normal((N_IN,)).astype(np.float64)), no_sharding)
-    assert_allclose(np.array(reduced.mv(x)), np.array((H.T @ W @ H).mv(x)), rtol=1e-5)
-
-
-# ---------------------------------------------------------------------------
-# Lineax CG integration
-# ---------------------------------------------------------------------------
-
-
-def _make_spd_blocks(rng: np.random.Generator, n_obs: int, n: int, sharding=None) -> _TestOp:
-    """Each block is M @ M.T + I — guaranteed SPD."""
-    m = rng.standard_normal((n_obs, n, n)).astype(np.float64)
-    spd = m @ m.swapaxes(-1, -2) + np.eye(n)
-    arr = jax.device_put(jnp.asarray(spd), sharding) if sharding is not None else jnp.asarray(spd)
-    return _TestOp(arr, in_structure=jax.ShapeDtypeStruct((n,), jnp.float64))
-
-
-def test_cg_scan_addition_sharded(rng: np.random.Generator, mesh) -> None:
-    # Sharded H^T W H — verify A x = b via direct solve (no lineax inside mesh context)
-    # The mapmaker's full test covers the lineax CG path end-to-end.
-    obs_sharding = NamedSharding(mesh, P('obs'))
-    H_blocks = _make_blocks(rng, N_OBS, N_OUT, N_IN, sharding=obs_sharding)
-    W_blocks = _make_spd_blocks(rng, N_OBS, N_OUT, sharding=obs_sharding)
-    H = ScanBlockColumnOperator.create(H_blocks)
-    W = ScanBlockDiagonalOperator.create(W_blocks)
-    A = (H.T @ W @ H).reduce()
-    assert isinstance(A, ScanAdditionOperator)
-    assert A.in_structure.sharding is None
-    assert A.out_structure.sharding is None
-
-    # Verify A(x) matches the non-reduced form
-    no_sharding = NamedSharding(mesh, P())
-    x = jax.device_put(jnp.asarray(rng.standard_normal((N_IN,)).astype(np.float64)), no_sharding)
-    assert_allclose(np.array(A.mv(x)), np.array((H.T @ W @ H).mv(x)), rtol=1e-5)
+    x = jax.device_put(RNG.standard_normal((N_IN,), dtype=np.float64), P())
+    assert_allclose(reduced.mv(x), (H.T @ W @ H).mv(x), rtol=1e-10)

--- a/tests/mapmaking/test_scan_blocks.py
+++ b/tests/mapmaking/test_scan_blocks.py
@@ -66,6 +66,11 @@ def mesh():
     return jax.make_mesh((jax.device_count(),), ('obs',))
 
 
+@pytest.fixture(autouse=True)
+def set_mesh(mesh):
+    jax.set_mesh(mesh)
+
+
 def _make_blocks(
     rng: np.random.Generator,
     n_obs: int,
@@ -129,84 +134,6 @@ def test_structure_sharding_sharded(rng: np.random.Generator, mesh) -> None:
         s = op.in_structure.sharding
         assert isinstance(s, NamedSharding)
         assert all(a is None for a in s.spec)  # replicated: P() padded to P(None,...)
-
-
-# ---------------------------------------------------------------------------
-# Unsharded forward
-# ---------------------------------------------------------------------------
-
-
-def test_unsharded_diagonal_mv(rng: np.random.Generator) -> None:
-    blocks = _make_blocks(rng, N_OBS, N_OUT, N_IN)
-    op = ScanBlockDiagonalOperator.create(blocks)
-    x = jnp.asarray(rng.standard_normal((N_OBS, N_IN)).astype(np.float64))
-    expected = np.stack([m @ np.array(x[i]) for i, m in enumerate(_per_obs(blocks))])
-    assert_allclose(op.mv(x), expected, rtol=1e-5)
-
-
-def test_unsharded_column_mv(rng: np.random.Generator) -> None:
-    blocks = _make_blocks(rng, N_OBS, N_OUT, N_IN)
-    op = ScanBlockColumnOperator.create(blocks)
-    x = jnp.asarray(rng.standard_normal((N_IN,)).astype(np.float64))
-    expected = np.stack([m @ np.array(x) for m in _per_obs(blocks)])
-    assert_allclose(op.mv(x), expected, rtol=1e-5)
-
-
-def test_unsharded_row_mv(rng: np.random.Generator) -> None:
-    blocks = _make_blocks(rng, N_OBS, N_OUT, N_IN)
-    op = ScanBlockRowOperator.create(blocks)
-    x = jnp.asarray(rng.standard_normal((N_OBS, N_IN)).astype(np.float64))
-    expected = sum(m @ np.array(x[i]) for i, m in enumerate(_per_obs(blocks)))
-    assert_allclose(op.mv(x), expected, rtol=1e-5)
-
-
-def test_unsharded_addition_mv(rng: np.random.Generator) -> None:
-    blocks = _make_blocks(rng, N_OBS, N_OUT, N_IN)
-    op = ScanAdditionOperator.create(blocks)
-    x = jnp.asarray(rng.standard_normal((N_IN,)).astype(np.float64))
-    expected = sum(m @ np.array(x) for m in _per_obs(blocks))
-    assert_allclose(op.mv(x), expected, rtol=1e-5)
-
-
-# ---------------------------------------------------------------------------
-# Unsharded transpose
-# ---------------------------------------------------------------------------
-
-
-def test_unsharded_diagonal_transpose(rng: np.random.Generator) -> None:
-    blocks = _make_blocks(rng, N_OBS, N_OUT, N_IN)
-    op_T = ScanBlockDiagonalOperator.create(blocks).T
-    assert isinstance(op_T, ScanBlockDiagonalOperator)
-    y = jnp.asarray(rng.standard_normal((N_OBS, N_OUT)).astype(np.float64))
-    expected = np.stack([m.T @ np.array(y[i]) for i, m in enumerate(_per_obs(blocks))])
-    assert_allclose(op_T.mv(y), expected, rtol=1e-5)
-
-
-def test_unsharded_column_transpose_is_row(rng: np.random.Generator) -> None:
-    blocks = _make_blocks(rng, N_OBS, N_OUT, N_IN)
-    op_T = ScanBlockColumnOperator.create(blocks).T
-    assert isinstance(op_T, ScanBlockRowOperator)
-    y = jnp.asarray(rng.standard_normal((N_OBS, N_OUT)).astype(np.float64))
-    expected = sum(m.T @ np.array(y[i]) for i, m in enumerate(_per_obs(blocks)))
-    assert_allclose(op_T.mv(y), expected, rtol=1e-5)
-
-
-def test_unsharded_row_transpose_is_column(rng: np.random.Generator) -> None:
-    blocks = _make_blocks(rng, N_OBS, N_OUT, N_IN)
-    op_T = ScanBlockRowOperator.create(blocks).T
-    assert isinstance(op_T, ScanBlockColumnOperator)
-    y = jnp.asarray(rng.standard_normal((N_OUT,)).astype(np.float64))
-    expected = np.stack([m.T @ np.array(y) for m in _per_obs(blocks)])
-    assert_allclose(op_T.mv(y), expected, rtol=1e-5)
-
-
-def test_unsharded_addition_transpose(rng: np.random.Generator) -> None:
-    blocks = _make_blocks(rng, N_OBS, N_OUT, N_IN)
-    op_T = ScanAdditionOperator.create(blocks).T
-    assert isinstance(op_T, ScanAdditionOperator)
-    y = jnp.asarray(rng.standard_normal((N_OUT,)).astype(np.float64))
-    expected = sum(m.T @ np.array(y) for m in _per_obs(blocks))
-    assert_allclose(op_T.mv(y), expected, rtol=1e-5)
 
 
 # ---------------------------------------------------------------------------
@@ -316,90 +243,31 @@ def test_sharded_addition_transpose(rng: np.random.Generator, mesh) -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_specs(rng: np.random.Generator, mesh) -> None:
-    obs_sharding = NamedSharding(mesh, P('obs'))
-    blocks = _make_blocks(rng, N_OBS, N_OUT, N_IN, sharding=obs_sharding)
-    obs_spec = P(mesh.axis_names)
-
-    for cls in (
-        ScanBlockDiagonalOperator,
-        ScanBlockColumnOperator,
-        ScanBlockRowOperator,
-        ScanAdditionOperator,
-    ):
-        assert cls.create(blocks)._in_specs == obs_spec
-
-    assert ScanBlockDiagonalOperator.create(blocks)._out_specs == obs_spec
-    assert ScanBlockColumnOperator.create(blocks)._out_specs == obs_spec
-    assert ScanBlockRowOperator.create(blocks)._out_specs == P()
-    assert ScanAdditionOperator.create(blocks)._out_specs == P()
-
-
 def test_sharded_output_sharding(rng: np.random.Generator, mesh) -> None:
     obs_sharding = NamedSharding(mesh, P('obs'))
     no_sharding = NamedSharding(mesh, P())
     blocks = _make_blocks(rng, N_OBS, N_OUT, N_IN, sharding=obs_sharding)
 
     cases = [
-        (ScanBlockDiagonalOperator, jnp.ones((N_OBS, N_IN), jnp.float64), obs_sharding),
-        (ScanBlockColumnOperator, jnp.ones((N_IN,), jnp.float64), no_sharding),
-        (ScanBlockRowOperator, jnp.ones((N_OBS, N_IN), jnp.float64), obs_sharding),
-        (ScanAdditionOperator, jnp.ones((N_IN,), jnp.float64), no_sharding),
+        (
+            ScanBlockDiagonalOperator,
+            jnp.ones((N_OBS, N_IN), jnp.float64),
+            obs_sharding,
+            obs_sharding,
+        ),
+        (ScanBlockColumnOperator, jnp.ones((N_IN,), jnp.float64), no_sharding, obs_sharding),
+        (ScanBlockRowOperator, jnp.ones((N_OBS, N_IN), jnp.float64), obs_sharding, no_sharding),
+        (ScanAdditionOperator, jnp.ones((N_IN,), jnp.float64), no_sharding, no_sharding),
     ]
-    for cls, x, x_sharding in cases:
+    for cls, x, x_sharding, expected_out_sharding in cases:
         op = cls.create(blocks)
         y = op.mv(jax.device_put(x, x_sharding))
-        assert y.sharding == NamedSharding(mesh, op._out_specs)
+        assert y.sharding == expected_out_sharding
 
 
 # ---------------------------------------------------------------------------
-# Fusion rules (unsharded)
+# Fusion rules
 # ---------------------------------------------------------------------------
-
-
-def test_fusion_diag_diag(rng: np.random.Generator) -> None:
-    left = ScanBlockDiagonalOperator.create(_make_blocks(rng, N_OBS, N_IN, N_IN))
-    right = ScanBlockDiagonalOperator.create(_make_blocks(rng, N_OBS, N_IN, N_IN))
-    reduced = (left @ right).reduce()
-    assert isinstance(reduced, ScanBlockDiagonalOperator)
-    x = jnp.asarray(rng.standard_normal((N_OBS, N_IN)).astype(np.float64))
-    assert_allclose(reduced.mv(x), (left @ right).mv(x), rtol=1e-5)
-
-
-def test_fusion_diag_column(rng: np.random.Generator) -> None:
-    left = ScanBlockDiagonalOperator.create(_make_blocks(rng, N_OBS, N_OUT, N_OUT))
-    right = ScanBlockColumnOperator.create(_make_blocks(rng, N_OBS, N_OUT, N_IN))
-    reduced = (left @ right).reduce()
-    assert isinstance(reduced, ScanBlockColumnOperator)
-    x = jnp.asarray(rng.standard_normal((N_IN,)).astype(np.float64))
-    assert_allclose(reduced.mv(x), (left @ right).mv(x), rtol=1e-5)
-
-
-def test_fusion_row_diag(rng: np.random.Generator) -> None:
-    left = ScanBlockRowOperator.create(_make_blocks(rng, N_OBS, N_OUT, N_IN))
-    right = ScanBlockDiagonalOperator.create(_make_blocks(rng, N_OBS, N_IN, N_IN))
-    reduced = (left @ right).reduce()
-    assert isinstance(reduced, ScanBlockRowOperator)
-    x = jnp.asarray(rng.standard_normal((N_OBS, N_IN)).astype(np.float64))
-    assert_allclose(reduced.mv(x), (left @ right).mv(x), rtol=1e-5)
-
-
-def test_fusion_row_column(rng: np.random.Generator) -> None:
-    left = ScanBlockRowOperator.create(_make_blocks(rng, N_OBS, N_OUT, N_IN))
-    right = ScanBlockColumnOperator.create(_make_blocks(rng, N_OBS, N_IN, N_IN))
-    reduced = (left @ right).reduce()
-    assert isinstance(reduced, ScanAdditionOperator)
-    x = jnp.asarray(rng.standard_normal((N_IN,)).astype(np.float64))
-    assert_allclose(reduced.mv(x), (left @ right).mv(x), rtol=1e-5)
-
-
-def test_fusion_ht_w_h(rng: np.random.Generator) -> None:
-    H = ScanBlockColumnOperator.create(_make_blocks(rng, N_OBS, N_OUT, N_IN))
-    W = ScanBlockDiagonalOperator.create(_make_blocks(rng, N_OBS, N_OUT, N_OUT))
-    reduced = (H.T @ W @ H).reduce()
-    assert isinstance(reduced, ScanAdditionOperator)
-    x = jnp.asarray(rng.standard_normal((N_IN,)).astype(np.float64))
-    assert_allclose(reduced.mv(x), (H.T @ W @ H).mv(x), rtol=1e-5)
 
 
 def test_sharded_fusion_ht_w_h(rng: np.random.Generator, mesh) -> None:
@@ -426,32 +294,6 @@ def _make_spd_blocks(rng: np.random.Generator, n_obs: int, n: int, sharding=None
     spd = m @ m.swapaxes(-1, -2) + np.eye(n)
     arr = jax.device_put(jnp.asarray(spd), sharding) if sharding is not None else jnp.asarray(spd)
     return _TestOp(arr, in_structure=jax.ShapeDtypeStruct((n,), jnp.float64))
-
-
-def test_cg_scan_addition_unsharded(rng: np.random.Generator) -> None:
-    # A = H^T W H fused to ScanAdditionOperator — SPD when W is PD
-    H_blocks = _make_blocks(rng, N_OBS, N_OUT, N_IN)
-    W_blocks = _make_spd_blocks(rng, N_OBS, N_OUT)
-    H = ScanBlockColumnOperator.create(H_blocks)
-    W = ScanBlockDiagonalOperator.create(W_blocks)
-    A = (H.T @ W @ H).reduce()
-    assert isinstance(A, ScanAdditionOperator)
-
-    lx_A = as_lineax_operator(A, tags=OperatorTag.SYMMETRIC | OperatorTag.POSITIVE_SEMIDEFINITE)
-    b = jnp.asarray(rng.standard_normal((N_IN,)).astype(np.float64))
-    sol = lx.linear_solve(lx_A, b, solver=lx.CG(rtol=1e-4, atol=1e-4))
-    assert_allclose(A.mv(sol.value), b, rtol=1e-3, atol=1e-3)
-
-
-def test_cg_scan_diagonal_unsharded(rng: np.random.Generator) -> None:
-    # Block-diagonal SPD operator: each obs solved independently via CG
-    blocks = _make_spd_blocks(rng, N_OBS, N_IN)
-    A = ScanBlockDiagonalOperator.create(blocks)
-
-    lx_A = as_lineax_operator(A, tags=OperatorTag.SYMMETRIC | OperatorTag.POSITIVE_SEMIDEFINITE)
-    b = jnp.asarray(rng.standard_normal((N_OBS, N_IN)).astype(np.float64))
-    sol = lx.linear_solve(lx_A, b, solver=lx.CG(rtol=1e-4, atol=1e-4))
-    assert_allclose(A.mv(sol.value), b, rtol=1e-3, atol=1e-3)
 
 
 def test_cg_scan_addition_sharded(rng: np.random.Generator, mesh) -> None:

--- a/tests/mapmaking/test_scan_blocks.py
+++ b/tests/mapmaking/test_scan_blocks.py
@@ -1,12 +1,15 @@
 import jax
 import jax.numpy as jnp
+import lineax as lx
 import numpy as np
 import pytest
+from jax.sharding import NamedSharding
+from jax.sharding import PartitionSpec as P
 from jaxtyping import Array, Inexact, PyTree
 from numpy.testing import assert_allclose
 
-from furax import AbstractLinearOperator
-from furax.core import CompositionOperator
+from furax import AbstractLinearOperator, OperatorTag
+from furax.interfaces.lineax import as_lineax_operator
 from furax.mapmaking._scan_blocks import (
     ScanAdditionOperator,
     ScanBlockColumnOperator,
@@ -15,8 +18,7 @@ from furax.mapmaking._scan_blocks import (
 )
 
 # ---------------------------------------------------------------------------
-# Test fixture: a minimal AbstractLinearOperator that supports stacking via a
-# leading batch axis on its ``matrix`` field.
+# Minimal stacked operator for testing
 # ---------------------------------------------------------------------------
 
 
@@ -36,7 +38,6 @@ class _TestOp(AbstractLinearOperator):
 
     @property
     def out_structure(self) -> PyTree[jax.ShapeDtypeStruct]:
-        # Per-slice metadata regardless of stacking.
         return jax.ShapeDtypeStruct((self.matrix.shape[-2],), self.matrix.dtype)
 
     def transpose(self) -> AbstractLinearOperator:
@@ -47,12 +48,11 @@ class _TestOp(AbstractLinearOperator):
 
 
 # ---------------------------------------------------------------------------
-# Fixtures
+# Dimensions — N_OBS must be divisible by device count (4)
 # ---------------------------------------------------------------------------
 
-
-N_OBS = 3
-N_IN = 4
+N_OBS = 4
+N_IN = 3
 N_OUT = 5
 
 
@@ -61,318 +61,411 @@ def rng() -> np.random.Generator:
     return np.random.default_rng(seed=0)
 
 
-def _stacked_test_op(rng: np.random.Generator, n_obs: int, n_out: int, n_in: int) -> _TestOp:
-    matrices = rng.standard_normal((n_obs, n_out, n_in)).astype(np.float32)
-    return _TestOp(
-        jnp.asarray(matrices),
-        in_structure=jax.ShapeDtypeStruct((n_in,), jnp.float32),
+@pytest.fixture(scope='module')
+def mesh():
+    return jax.make_mesh((jax.device_count(),), ('obs',))
+
+
+def _make_blocks(
+    rng: np.random.Generator,
+    n_obs: int,
+    n_out: int,
+    n_in: int,
+    sharding=None,
+) -> _TestOp:
+    matrices = rng.standard_normal((n_obs, n_out, n_in)).astype(np.float64)
+    arr = (
+        jax.device_put(jnp.asarray(matrices), sharding)
+        if sharding is not None
+        else jnp.asarray(matrices)
     )
+    return _TestOp(arr, in_structure=jax.ShapeDtypeStruct((n_in,), jnp.float64))
 
 
-def _per_obs_matrices(op: _TestOp) -> list[Array]:
-    return [op.matrix[i] for i in range(op.matrix.shape[0])]
+def _per_obs(op: _TestOp) -> list[np.ndarray]:
+    m = np.array(jax.device_get(op.matrix))
+    return [m[i] for i in range(m.shape[0])]
 
 
 # ---------------------------------------------------------------------------
-# 1. Forward correctness
+# Structure shapes and sharding
 # ---------------------------------------------------------------------------
 
 
-def test_diagonal_mv(rng: np.random.Generator) -> None:
-    blocks = _stacked_test_op(rng, N_OBS, N_OUT, N_IN)
-    op = ScanBlockDiagonalOperator(blocks, N_OBS)
-    x_stacked = jnp.asarray(rng.standard_normal((N_OBS, N_IN)).astype(np.float32))
-    expected = jnp.stack([m @ x_stacked[i] for i, m in enumerate(_per_obs_matrices(blocks))])
-    assert_allclose(op.mv(x_stacked), expected, rtol=1e-5)
+def test_structure_shapes(rng: np.random.Generator) -> None:
+    blocks = _make_blocks(rng, N_OBS, N_OUT, N_IN)
+
+    op = ScanBlockDiagonalOperator.create(blocks)
+    assert op.in_structure.shape == (N_OBS, N_IN)
+    assert op.out_structure.shape == (N_OBS, N_OUT)
+
+    op = ScanBlockColumnOperator.create(blocks)
+    assert op.in_structure.shape == (N_IN,)
+    assert op.out_structure.shape == (N_OBS, N_OUT)
+
+    op = ScanBlockRowOperator.create(blocks)
+    assert op.in_structure.shape == (N_OBS, N_IN)
+    assert op.out_structure.shape == (N_OUT,)
+
+    op = ScanAdditionOperator.create(blocks)
+    assert op.in_structure.shape == (N_IN,)
+    assert op.out_structure.shape == (N_OUT,)
 
 
-def test_column_mv(rng: np.random.Generator) -> None:
-    blocks = _stacked_test_op(rng, N_OBS, N_OUT, N_IN)
-    op = ScanBlockColumnOperator(blocks, N_OBS)
-    x = jnp.asarray(rng.standard_normal((N_IN,)).astype(np.float32))
-    expected = jnp.stack([m @ x for m in _per_obs_matrices(blocks)])
+def test_structure_sharding_sharded(rng: np.random.Generator, mesh) -> None:
+    obs_sharding = NamedSharding(mesh, P('obs'))
+    blocks = _make_blocks(rng, N_OBS, N_OUT, N_IN, sharding=obs_sharding)
+
+    # Diagonal and Row: in_structure is obs-sharded along first dim
+    for cls in (ScanBlockDiagonalOperator, ScanBlockRowOperator):
+        op = cls.create(blocks)
+        s = op.in_structure.sharding
+        assert isinstance(s, NamedSharding)
+        assert s.spec[0] is not None
+
+    # Column and Addition: in_structure is replicated
+    for cls in (ScanBlockColumnOperator, ScanAdditionOperator):
+        op = cls.create(blocks)
+        s = op.in_structure.sharding
+        assert isinstance(s, NamedSharding)
+        assert all(a is None for a in s.spec)  # replicated: P() padded to P(None,...)
+
+
+# ---------------------------------------------------------------------------
+# Unsharded forward
+# ---------------------------------------------------------------------------
+
+
+def test_unsharded_diagonal_mv(rng: np.random.Generator) -> None:
+    blocks = _make_blocks(rng, N_OBS, N_OUT, N_IN)
+    op = ScanBlockDiagonalOperator.create(blocks)
+    x = jnp.asarray(rng.standard_normal((N_OBS, N_IN)).astype(np.float64))
+    expected = np.stack([m @ np.array(x[i]) for i, m in enumerate(_per_obs(blocks))])
     assert_allclose(op.mv(x), expected, rtol=1e-5)
 
 
-def test_row_mv(rng: np.random.Generator) -> None:
-    blocks = _stacked_test_op(rng, N_OBS, N_OUT, N_IN)
-    op = ScanBlockRowOperator(blocks, N_OBS)
-    x_stacked = jnp.asarray(rng.standard_normal((N_OBS, N_IN)).astype(np.float32))
-    expected = sum(m @ x_stacked[i] for i, m in enumerate(_per_obs_matrices(blocks)))
-    assert_allclose(op.mv(x_stacked), expected, rtol=1e-5)
+def test_unsharded_column_mv(rng: np.random.Generator) -> None:
+    blocks = _make_blocks(rng, N_OBS, N_OUT, N_IN)
+    op = ScanBlockColumnOperator.create(blocks)
+    x = jnp.asarray(rng.standard_normal((N_IN,)).astype(np.float64))
+    expected = np.stack([m @ np.array(x) for m in _per_obs(blocks)])
+    assert_allclose(op.mv(x), expected, rtol=1e-5)
 
 
-def test_sum_mv(rng: np.random.Generator) -> None:
-    blocks = _stacked_test_op(rng, N_OBS, N_OUT, N_IN)
-    op = ScanAdditionOperator(blocks, N_OBS)
-    x = jnp.asarray(rng.standard_normal((N_IN,)).astype(np.float32))
-    expected = sum(m @ x for m in _per_obs_matrices(blocks))
+def test_unsharded_row_mv(rng: np.random.Generator) -> None:
+    blocks = _make_blocks(rng, N_OBS, N_OUT, N_IN)
+    op = ScanBlockRowOperator.create(blocks)
+    x = jnp.asarray(rng.standard_normal((N_OBS, N_IN)).astype(np.float64))
+    expected = sum(m @ np.array(x[i]) for i, m in enumerate(_per_obs(blocks)))
+    assert_allclose(op.mv(x), expected, rtol=1e-5)
+
+
+def test_unsharded_addition_mv(rng: np.random.Generator) -> None:
+    blocks = _make_blocks(rng, N_OBS, N_OUT, N_IN)
+    op = ScanAdditionOperator.create(blocks)
+    x = jnp.asarray(rng.standard_normal((N_IN,)).astype(np.float64))
+    expected = sum(m @ np.array(x) for m in _per_obs(blocks))
     assert_allclose(op.mv(x), expected, rtol=1e-5)
 
 
 # ---------------------------------------------------------------------------
-# 2. Transpose correctness — class swap and numerical match
+# Unsharded transpose
 # ---------------------------------------------------------------------------
 
 
-def test_diagonal_transpose(rng: np.random.Generator) -> None:
-    blocks = _stacked_test_op(rng, N_OBS, N_OUT, N_IN)
-    op = ScanBlockDiagonalOperator(blocks, N_OBS)
-    op_T = op.T
+def test_unsharded_diagonal_transpose(rng: np.random.Generator) -> None:
+    blocks = _make_blocks(rng, N_OBS, N_OUT, N_IN)
+    op_T = ScanBlockDiagonalOperator.create(blocks).T
     assert isinstance(op_T, ScanBlockDiagonalOperator)
-    y_stacked = jnp.asarray(rng.standard_normal((N_OBS, N_OUT)).astype(np.float32))
-    expected = jnp.stack([m.T @ y_stacked[i] for i, m in enumerate(_per_obs_matrices(blocks))])
-    assert_allclose(op_T.mv(y_stacked), expected, rtol=1e-5)
+    y = jnp.asarray(rng.standard_normal((N_OBS, N_OUT)).astype(np.float64))
+    expected = np.stack([m.T @ np.array(y[i]) for i, m in enumerate(_per_obs(blocks))])
+    assert_allclose(op_T.mv(y), expected, rtol=1e-5)
 
 
-def test_column_transpose_is_row(rng: np.random.Generator) -> None:
-    blocks = _stacked_test_op(rng, N_OBS, N_OUT, N_IN)
-    op = ScanBlockColumnOperator(blocks, N_OBS)
-    op_T = op.T
+def test_unsharded_column_transpose_is_row(rng: np.random.Generator) -> None:
+    blocks = _make_blocks(rng, N_OBS, N_OUT, N_IN)
+    op_T = ScanBlockColumnOperator.create(blocks).T
     assert isinstance(op_T, ScanBlockRowOperator)
-    y_stacked = jnp.asarray(rng.standard_normal((N_OBS, N_OUT)).astype(np.float32))
-    expected = sum(m.T @ y_stacked[i] for i, m in enumerate(_per_obs_matrices(blocks)))
-    assert_allclose(op_T.mv(y_stacked), expected, rtol=1e-5)
+    y = jnp.asarray(rng.standard_normal((N_OBS, N_OUT)).astype(np.float64))
+    expected = sum(m.T @ np.array(y[i]) for i, m in enumerate(_per_obs(blocks)))
+    assert_allclose(op_T.mv(y), expected, rtol=1e-5)
 
 
-def test_row_transpose_is_column(rng: np.random.Generator) -> None:
-    blocks = _stacked_test_op(rng, N_OBS, N_OUT, N_IN)
-    op = ScanBlockRowOperator(blocks, N_OBS)
-    op_T = op.T
+def test_unsharded_row_transpose_is_column(rng: np.random.Generator) -> None:
+    blocks = _make_blocks(rng, N_OBS, N_OUT, N_IN)
+    op_T = ScanBlockRowOperator.create(blocks).T
     assert isinstance(op_T, ScanBlockColumnOperator)
-    y = jnp.asarray(rng.standard_normal((N_OUT,)).astype(np.float32))
-    expected = jnp.stack([m.T @ y for m in _per_obs_matrices(blocks)])
+    y = jnp.asarray(rng.standard_normal((N_OUT,)).astype(np.float64))
+    expected = np.stack([m.T @ np.array(y) for m in _per_obs(blocks)])
     assert_allclose(op_T.mv(y), expected, rtol=1e-5)
 
 
-def test_sum_transpose(rng: np.random.Generator) -> None:
-    blocks = _stacked_test_op(rng, N_OBS, N_OUT, N_IN)
-    op = ScanAdditionOperator(blocks, N_OBS)
-    op_T = op.T
+def test_unsharded_addition_transpose(rng: np.random.Generator) -> None:
+    blocks = _make_blocks(rng, N_OBS, N_OUT, N_IN)
+    op_T = ScanAdditionOperator.create(blocks).T
     assert isinstance(op_T, ScanAdditionOperator)
-    y = jnp.asarray(rng.standard_normal((N_OUT,)).astype(np.float32))
-    expected = sum(m.T @ y for m in _per_obs_matrices(blocks))
+    y = jnp.asarray(rng.standard_normal((N_OUT,)).astype(np.float64))
+    expected = sum(m.T @ np.array(y) for m in _per_obs(blocks))
     assert_allclose(op_T.mv(y), expected, rtol=1e-5)
 
 
 # ---------------------------------------------------------------------------
-# 3. Roundtrip op.T.T == op
+# Sharded forward
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.parametrize(
-    'cls',
-    [
+def test_sharded_diagonal_mv(rng: np.random.Generator, mesh) -> None:
+    obs_sharding = NamedSharding(mesh, P('obs'))
+    blocks = _make_blocks(rng, N_OBS, N_OUT, N_IN, sharding=obs_sharding)
+    op = ScanBlockDiagonalOperator.create(blocks)
+    x = jax.device_put(
+        jnp.asarray(rng.standard_normal((N_OBS, N_IN)).astype(np.float64)), obs_sharding
+    )
+    x_np = np.array(jax.device_get(x))
+    expected = np.stack([m @ x_np[i] for i, m in enumerate(_per_obs(blocks))])
+    assert_allclose(np.array(op.mv(x)), expected, rtol=1e-5)
+
+
+def test_sharded_column_mv(rng: np.random.Generator, mesh) -> None:
+    obs_sharding = NamedSharding(mesh, P('obs'))
+    no_sharding = NamedSharding(mesh, P())
+    blocks = _make_blocks(rng, N_OBS, N_OUT, N_IN, sharding=obs_sharding)
+    op = ScanBlockColumnOperator.create(blocks)
+    x = jax.device_put(jnp.asarray(rng.standard_normal((N_IN,)).astype(np.float64)), no_sharding)
+    expected = np.stack([m @ np.array(x) for m in _per_obs(blocks)])
+    assert_allclose(np.array(op.mv(x)), expected, rtol=1e-5)
+
+
+def test_sharded_row_mv(rng: np.random.Generator, mesh) -> None:
+    obs_sharding = NamedSharding(mesh, P('obs'))
+    blocks = _make_blocks(rng, N_OBS, N_OUT, N_IN, sharding=obs_sharding)
+    op = ScanBlockRowOperator.create(blocks)
+    x = jax.device_put(
+        jnp.asarray(rng.standard_normal((N_OBS, N_IN)).astype(np.float64)), obs_sharding
+    )
+    x_np = np.array(jax.device_get(x))
+    expected = sum(m @ x_np[i] for i, m in enumerate(_per_obs(blocks)))
+    assert_allclose(np.array(op.mv(x)), expected, rtol=1e-5)
+
+
+def test_sharded_addition_mv(rng: np.random.Generator, mesh) -> None:
+    obs_sharding = NamedSharding(mesh, P('obs'))
+    no_sharding = NamedSharding(mesh, P())
+    blocks = _make_blocks(rng, N_OBS, N_OUT, N_IN, sharding=obs_sharding)
+    op = ScanAdditionOperator.create(blocks)
+    x = jax.device_put(jnp.asarray(rng.standard_normal((N_IN,)).astype(np.float64)), no_sharding)
+    expected = sum(m @ np.array(x) for m in _per_obs(blocks))
+    assert_allclose(np.array(op.mv(x)), expected, rtol=1e-5)
+
+
+# ---------------------------------------------------------------------------
+# Sharded transpose
+# ---------------------------------------------------------------------------
+
+
+def test_sharded_diagonal_transpose(rng: np.random.Generator, mesh) -> None:
+    obs_sharding = NamedSharding(mesh, P('obs'))
+    blocks = _make_blocks(rng, N_OBS, N_OUT, N_IN, sharding=obs_sharding)
+    op_T = ScanBlockDiagonalOperator.create(blocks).T
+    assert isinstance(op_T, ScanBlockDiagonalOperator)
+    y = jax.device_put(
+        jnp.asarray(rng.standard_normal((N_OBS, N_OUT)).astype(np.float64)), obs_sharding
+    )
+    y_np = np.array(jax.device_get(y))
+    expected = np.stack([m.T @ y_np[i] for i, m in enumerate(_per_obs(blocks))])
+    assert_allclose(np.array(op_T.mv(y)), expected, rtol=1e-5)
+
+
+def test_sharded_column_transpose_is_row(rng: np.random.Generator, mesh) -> None:
+    obs_sharding = NamedSharding(mesh, P('obs'))
+    blocks = _make_blocks(rng, N_OBS, N_OUT, N_IN, sharding=obs_sharding)
+    op_T = ScanBlockColumnOperator.create(blocks).T
+    assert isinstance(op_T, ScanBlockRowOperator)
+    y = jax.device_put(
+        jnp.asarray(rng.standard_normal((N_OBS, N_OUT)).astype(np.float64)), obs_sharding
+    )
+    y_np = np.array(jax.device_get(y))
+    expected = sum(m.T @ y_np[i] for i, m in enumerate(_per_obs(blocks)))
+    assert_allclose(np.array(op_T.mv(y)), expected, rtol=1e-5)
+
+
+def test_sharded_row_transpose_is_column(rng: np.random.Generator, mesh) -> None:
+    obs_sharding = NamedSharding(mesh, P('obs'))
+    no_sharding = NamedSharding(mesh, P())
+    blocks = _make_blocks(rng, N_OBS, N_OUT, N_IN, sharding=obs_sharding)
+    op_T = ScanBlockRowOperator.create(blocks).T
+    assert isinstance(op_T, ScanBlockColumnOperator)
+    y = jax.device_put(jnp.asarray(rng.standard_normal((N_OUT,)).astype(np.float64)), no_sharding)
+    expected = np.stack([m.T @ np.array(y) for m in _per_obs(blocks)])
+    assert_allclose(np.array(op_T.mv(y)), expected, rtol=1e-5)
+
+
+def test_sharded_addition_transpose(rng: np.random.Generator, mesh) -> None:
+    obs_sharding = NamedSharding(mesh, P('obs'))
+    no_sharding = NamedSharding(mesh, P())
+    blocks = _make_blocks(rng, N_OBS, N_OUT, N_IN, sharding=obs_sharding)
+    op_T = ScanAdditionOperator.create(blocks).T
+    assert isinstance(op_T, ScanAdditionOperator)
+    y = jax.device_put(jnp.asarray(rng.standard_normal((N_OUT,)).astype(np.float64)), no_sharding)
+    expected = sum(m.T @ np.array(y) for m in _per_obs(blocks))
+    assert_allclose(np.array(op_T.mv(y)), expected, rtol=1e-5)
+
+
+# ---------------------------------------------------------------------------
+# Output sharding
+# ---------------------------------------------------------------------------
+
+
+def test_specs(rng: np.random.Generator, mesh) -> None:
+    obs_sharding = NamedSharding(mesh, P('obs'))
+    blocks = _make_blocks(rng, N_OBS, N_OUT, N_IN, sharding=obs_sharding)
+    obs_spec = P(mesh.axis_names)
+
+    for cls in (
         ScanBlockDiagonalOperator,
         ScanBlockColumnOperator,
         ScanBlockRowOperator,
         ScanAdditionOperator,
-    ],
-)
-def test_transpose_roundtrip(cls: type, rng: np.random.Generator) -> None:
-    blocks = _stacked_test_op(rng, N_OBS, N_OUT, N_IN)
-    op = cls(blocks, N_OBS)
-    op_TT = op.T.T
-    assert isinstance(op_TT, cls)
-    if cls is ScanBlockDiagonalOperator:
-        x = jnp.asarray(rng.standard_normal((N_OBS, N_IN)).astype(np.float32))
-    elif cls is ScanBlockColumnOperator or cls is ScanAdditionOperator:
-        x = jnp.asarray(rng.standard_normal((N_IN,)).astype(np.float32))
-    else:  # ScanBlockRow
-        x = jnp.asarray(rng.standard_normal((N_OBS, N_IN)).astype(np.float32))
-    assert_allclose(op_TT.mv(x), op.mv(x), rtol=1e-5)
+    ):
+        assert cls.create(blocks)._in_specs == obs_spec
+
+    assert ScanBlockDiagonalOperator.create(blocks)._out_specs == obs_spec
+    assert ScanBlockColumnOperator.create(blocks)._out_specs == obs_spec
+    assert ScanBlockRowOperator.create(blocks)._out_specs == P()
+    assert ScanAdditionOperator.create(blocks)._out_specs == P()
+
+
+def test_sharded_output_sharding(rng: np.random.Generator, mesh) -> None:
+    obs_sharding = NamedSharding(mesh, P('obs'))
+    no_sharding = NamedSharding(mesh, P())
+    blocks = _make_blocks(rng, N_OBS, N_OUT, N_IN, sharding=obs_sharding)
+
+    cases = [
+        (ScanBlockDiagonalOperator, jnp.ones((N_OBS, N_IN), jnp.float64), obs_sharding),
+        (ScanBlockColumnOperator, jnp.ones((N_IN,), jnp.float64), no_sharding),
+        (ScanBlockRowOperator, jnp.ones((N_OBS, N_IN), jnp.float64), obs_sharding),
+        (ScanAdditionOperator, jnp.ones((N_IN,), jnp.float64), no_sharding),
+    ]
+    for cls, x, x_sharding in cases:
+        op = cls.create(blocks)
+        y = op.mv(jax.device_put(x, x_sharding))
+        assert y.sharding == NamedSharding(mesh, op._out_specs)
 
 
 # ---------------------------------------------------------------------------
-# 4. as_matrix consistency
-# ---------------------------------------------------------------------------
-
-
-def test_diagonal_as_matrix(rng: np.random.Generator) -> None:
-    blocks = _stacked_test_op(rng, N_OBS, N_OUT, N_IN)
-    op = ScanBlockDiagonalOperator(blocks, N_OBS)
-    mats = _per_obs_matrices(blocks)
-    import jax.scipy.linalg as jsl
-
-    expected = jsl.block_diag(*mats)
-    assert_allclose(op.as_matrix(), expected, rtol=1e-5)
-
-
-def test_column_as_matrix(rng: np.random.Generator) -> None:
-    blocks = _stacked_test_op(rng, N_OBS, N_OUT, N_IN)
-    op = ScanBlockColumnOperator(blocks, N_OBS)
-    mats = _per_obs_matrices(blocks)
-    expected = jnp.vstack(mats)
-    assert_allclose(op.as_matrix(), expected, rtol=1e-5)
-
-
-def test_row_as_matrix(rng: np.random.Generator) -> None:
-    blocks = _stacked_test_op(rng, N_OBS, N_OUT, N_IN)
-    op = ScanBlockRowOperator(blocks, N_OBS)
-    mats = _per_obs_matrices(blocks)
-    expected = jnp.hstack(mats)
-    assert_allclose(op.as_matrix(), expected, rtol=1e-5)
-
-
-# ---------------------------------------------------------------------------
-# 5. Fusion rules
+# Fusion rules (unsharded)
 # ---------------------------------------------------------------------------
 
 
 def test_fusion_diag_diag(rng: np.random.Generator) -> None:
-    left_blocks = _stacked_test_op(rng, N_OBS, N_IN, N_IN)  # square
-    right_blocks = _stacked_test_op(rng, N_OBS, N_IN, N_IN)
-    left = ScanBlockDiagonalOperator(left_blocks, N_OBS)
-    right = ScanBlockDiagonalOperator(right_blocks, N_OBS)
-
-    composed = left @ right
-    reduced = composed.reduce()
+    left = ScanBlockDiagonalOperator.create(_make_blocks(rng, N_OBS, N_IN, N_IN))
+    right = ScanBlockDiagonalOperator.create(_make_blocks(rng, N_OBS, N_IN, N_IN))
+    reduced = (left @ right).reduce()
     assert isinstance(reduced, ScanBlockDiagonalOperator)
-
-    x = jnp.asarray(rng.standard_normal((N_OBS, N_IN)).astype(np.float32))
-    assert_allclose(reduced.mv(x), composed.mv(x), rtol=1e-5)
+    x = jnp.asarray(rng.standard_normal((N_OBS, N_IN)).astype(np.float64))
+    assert_allclose(reduced.mv(x), (left @ right).mv(x), rtol=1e-5)
 
 
 def test_fusion_diag_column(rng: np.random.Generator) -> None:
-    left_blocks = _stacked_test_op(rng, N_OBS, N_OUT, N_OUT)
-    right_blocks = _stacked_test_op(rng, N_OBS, N_OUT, N_IN)
-    left = ScanBlockDiagonalOperator(left_blocks, N_OBS)
-    right = ScanBlockColumnOperator(right_blocks, N_OBS)
-
-    composed = left @ right
-    reduced = composed.reduce()
+    left = ScanBlockDiagonalOperator.create(_make_blocks(rng, N_OBS, N_OUT, N_OUT))
+    right = ScanBlockColumnOperator.create(_make_blocks(rng, N_OBS, N_OUT, N_IN))
+    reduced = (left @ right).reduce()
     assert isinstance(reduced, ScanBlockColumnOperator)
-
-    x = jnp.asarray(rng.standard_normal((N_IN,)).astype(np.float32))
-    assert_allclose(reduced.mv(x), composed.mv(x), rtol=1e-5)
+    x = jnp.asarray(rng.standard_normal((N_IN,)).astype(np.float64))
+    assert_allclose(reduced.mv(x), (left @ right).mv(x), rtol=1e-5)
 
 
 def test_fusion_row_diag(rng: np.random.Generator) -> None:
-    left_blocks = _stacked_test_op(rng, N_OBS, N_OUT, N_IN)
-    right_blocks = _stacked_test_op(rng, N_OBS, N_IN, N_IN)
-    left = ScanBlockRowOperator(left_blocks, N_OBS)
-    right = ScanBlockDiagonalOperator(right_blocks, N_OBS)
-
-    composed = left @ right
-    reduced = composed.reduce()
+    left = ScanBlockRowOperator.create(_make_blocks(rng, N_OBS, N_OUT, N_IN))
+    right = ScanBlockDiagonalOperator.create(_make_blocks(rng, N_OBS, N_IN, N_IN))
+    reduced = (left @ right).reduce()
     assert isinstance(reduced, ScanBlockRowOperator)
-
-    x = jnp.asarray(rng.standard_normal((N_OBS, N_IN)).astype(np.float32))
-    assert_allclose(reduced.mv(x), composed.mv(x), rtol=1e-5)
+    x = jnp.asarray(rng.standard_normal((N_OBS, N_IN)).astype(np.float64))
+    assert_allclose(reduced.mv(x), (left @ right).mv(x), rtol=1e-5)
 
 
 def test_fusion_row_column(rng: np.random.Generator) -> None:
-    left_blocks = _stacked_test_op(rng, N_OBS, N_OUT, N_IN)
-    right_blocks = _stacked_test_op(rng, N_OBS, N_IN, N_IN)
-    left = ScanBlockRowOperator(left_blocks, N_OBS)
-    right = ScanBlockColumnOperator(right_blocks, N_OBS)
-
-    composed = left @ right
-    reduced = composed.reduce()
+    left = ScanBlockRowOperator.create(_make_blocks(rng, N_OBS, N_OUT, N_IN))
+    right = ScanBlockColumnOperator.create(_make_blocks(rng, N_OBS, N_IN, N_IN))
+    reduced = (left @ right).reduce()
     assert isinstance(reduced, ScanAdditionOperator)
-
-    x = jnp.asarray(rng.standard_normal((N_IN,)).astype(np.float32))
-    assert_allclose(reduced.mv(x), composed.mv(x), rtol=1e-5)
-
-
-# ---------------------------------------------------------------------------
-# 6. n_obs mismatch declines fusion
-# ---------------------------------------------------------------------------
+    x = jnp.asarray(rng.standard_normal((N_IN,)).astype(np.float64))
+    assert_allclose(reduced.mv(x), (left @ right).mv(x), rtol=1e-5)
 
 
-def test_mismatched_leading_dim_rejected_by_matmul(rng: np.random.Generator) -> None:
-    """Different leading-axis sizes give mismatched ``in_structure`` shapes, so
-    ``__matmul__`` rejects the composition before any fusion rule runs."""
-    blocks_a = _stacked_test_op(rng, 3, N_IN, N_IN)
-    blocks_b = _stacked_test_op(rng, 4, N_IN, N_IN)
-    left = ScanBlockDiagonalOperator(blocks_a, 3)
-    right = ScanBlockDiagonalOperator(blocks_b, 4)
-    with pytest.raises(ValueError, match='Incompatible'):
-        _ = left @ right
-
-
-# ---------------------------------------------------------------------------
-# 7. Multi-step chain fusion: T.T W T  (Diag @ Diag @ Diag → single Diag)
-# ---------------------------------------------------------------------------
-
-
-def test_chain_fusion_diag(rng: np.random.Generator) -> None:
-    a = _stacked_test_op(rng, N_OBS, N_IN, N_IN)
-    b = _stacked_test_op(rng, N_OBS, N_IN, N_IN)
-    c = _stacked_test_op(rng, N_OBS, N_IN, N_IN)
-    A = ScanBlockDiagonalOperator(a, N_OBS)
-    B = ScanBlockDiagonalOperator(b, N_OBS)
-    C = ScanBlockDiagonalOperator(c, N_OBS)
-    chain = A @ B @ C
-    reduced = chain.reduce()
-    assert isinstance(reduced, ScanBlockDiagonalOperator)
-
-    x = jnp.asarray(rng.standard_normal((N_OBS, N_IN)).astype(np.float32))
-    assert_allclose(reduced.mv(x), chain.mv(x), rtol=1e-5)
-
-
-# ---------------------------------------------------------------------------
-# 8. Row @ Diag @ Column reduces all the way to _ScanSumOperator
-# ---------------------------------------------------------------------------
-
-
-def test_chain_fusion_row_diag_column(rng: np.random.Generator) -> None:
-    """``H.T @ W @ H`` fuses to a single :class:`_ScanSumOperator` (= ``Σ H_i.T W_i H_i``)."""
-    H_blocks = _stacked_test_op(rng, N_OBS, N_OUT, N_IN)
-    W_blocks = _stacked_test_op(rng, N_OBS, N_OUT, N_OUT)
-
-    H = ScanBlockColumnOperator(H_blocks, N_OBS)
-    W = ScanBlockDiagonalOperator(W_blocks, N_OBS)
-    HT = H.T
-    assert isinstance(HT, ScanBlockRowOperator)
-
-    chain = HT @ W @ H
-    reduced = chain.reduce()
+def test_fusion_ht_w_h(rng: np.random.Generator) -> None:
+    H = ScanBlockColumnOperator.create(_make_blocks(rng, N_OBS, N_OUT, N_IN))
+    W = ScanBlockDiagonalOperator.create(_make_blocks(rng, N_OBS, N_OUT, N_OUT))
+    reduced = (H.T @ W @ H).reduce()
     assert isinstance(reduced, ScanAdditionOperator)
-
-    x = jnp.asarray(rng.standard_normal((N_IN,)).astype(np.float32))
-    assert_allclose(reduced.mv(x), chain.mv(x), rtol=1e-5)
-
-
-# ---------------------------------------------------------------------------
-# Sanity: CompositionOperator's __matmul__ structure check rejects mismatched shapes
-# ---------------------------------------------------------------------------
+    x = jnp.asarray(rng.standard_normal((N_IN,)).astype(np.float64))
+    assert_allclose(reduced.mv(x), (H.T @ W @ H).mv(x), rtol=1e-5)
 
 
-def test_composition_rejects_mismatched_shapes(rng: np.random.Generator) -> None:
-    a = _stacked_test_op(rng, N_OBS, N_OUT, N_IN)  # in n_in, out n_out
-    b = _stacked_test_op(rng, N_OBS, N_OUT, N_IN)  # same
-    A = ScanBlockDiagonalOperator(a, N_OBS)
-    B = ScanBlockDiagonalOperator(b, N_OBS)
-    # A.in = (n_obs, n_in), B.out = (n_obs, n_out): not compatible
-    with pytest.raises(ValueError, match='Incompatible'):
-        _ = A @ B
+def test_sharded_fusion_ht_w_h(rng: np.random.Generator, mesh) -> None:
+    obs_sharding = NamedSharding(mesh, P('obs'))
+    no_sharding = NamedSharding(mesh, P())
+    H = ScanBlockColumnOperator.create(_make_blocks(rng, N_OBS, N_OUT, N_IN, sharding=obs_sharding))
+    W = ScanBlockDiagonalOperator.create(
+        _make_blocks(rng, N_OBS, N_OUT, N_OUT, sharding=obs_sharding)
+    )
+    reduced = (H.T @ W @ H).reduce()
+    assert isinstance(reduced, ScanAdditionOperator)
+    x = jax.device_put(jnp.asarray(rng.standard_normal((N_IN,)).astype(np.float64)), no_sharding)
+    assert_allclose(np.array(reduced.mv(x)), np.array((H.T @ W @ H).mv(x)), rtol=1e-5)
 
 
 # ---------------------------------------------------------------------------
-# Smoke: reduce() on a Scan op delegates to inner blocks.reduce()
+# Lineax CG integration
 # ---------------------------------------------------------------------------
 
 
-def test_reduce_delegates_to_blocks(rng: np.random.Generator) -> None:
-    blocks = _stacked_test_op(rng, N_OBS, N_IN, N_IN)
-    op = ScanBlockDiagonalOperator(blocks, N_OBS)
-    reduced = op.reduce()
-    assert isinstance(reduced, ScanBlockDiagonalOperator)
-    x = jnp.asarray(rng.standard_normal((N_OBS, N_IN)).astype(np.float32))
-    assert_allclose(reduced.mv(x), op.mv(x), rtol=1e-5)
+def _make_spd_blocks(rng: np.random.Generator, n_obs: int, n: int, sharding=None) -> _TestOp:
+    """Each block is M @ M.T + I — guaranteed SPD."""
+    m = rng.standard_normal((n_obs, n, n)).astype(np.float64)
+    spd = m @ m.swapaxes(-1, -2) + np.eye(n)
+    arr = jax.device_put(jnp.asarray(spd), sharding) if sharding is not None else jnp.asarray(spd)
+    return _TestOp(arr, in_structure=jax.ShapeDtypeStruct((n,), jnp.float64))
 
 
-# ---------------------------------------------------------------------------
-# Smoke: a Scan op composed with itself reduces via the appropriate rule
-# (not just via the CompositionOperator wrapper)
-# ---------------------------------------------------------------------------
+def test_cg_scan_addition_unsharded(rng: np.random.Generator) -> None:
+    # A = H^T W H fused to ScanAdditionOperator — SPD when W is PD
+    H_blocks = _make_blocks(rng, N_OBS, N_OUT, N_IN)
+    W_blocks = _make_spd_blocks(rng, N_OBS, N_OUT)
+    H = ScanBlockColumnOperator.create(H_blocks)
+    W = ScanBlockDiagonalOperator.create(W_blocks)
+    A = (H.T @ W @ H).reduce()
+    assert isinstance(A, ScanAdditionOperator)
+
+    lx_A = as_lineax_operator(A, tags=OperatorTag.SYMMETRIC | OperatorTag.POSITIVE_SEMIDEFINITE)
+    b = jnp.asarray(rng.standard_normal((N_IN,)).astype(np.float64))
+    sol = lx.linear_solve(lx_A, b, solver=lx.CG(rtol=1e-4, atol=1e-4))
+    assert_allclose(A.mv(sol.value), b, rtol=1e-3, atol=1e-3)
 
 
-def test_self_composition_reduces(rng: np.random.Generator) -> None:
-    blocks = _stacked_test_op(rng, N_OBS, N_IN, N_IN)
-    op = ScanBlockDiagonalOperator(blocks, N_OBS)
-    composed = op @ op
-    assert isinstance(composed, CompositionOperator)
-    reduced = composed.reduce()
-    assert isinstance(reduced, ScanBlockDiagonalOperator)
+def test_cg_scan_diagonal_unsharded(rng: np.random.Generator) -> None:
+    # Block-diagonal SPD operator: each obs solved independently via CG
+    blocks = _make_spd_blocks(rng, N_OBS, N_IN)
+    A = ScanBlockDiagonalOperator.create(blocks)
+
+    lx_A = as_lineax_operator(A, tags=OperatorTag.SYMMETRIC | OperatorTag.POSITIVE_SEMIDEFINITE)
+    b = jnp.asarray(rng.standard_normal((N_OBS, N_IN)).astype(np.float64))
+    sol = lx.linear_solve(lx_A, b, solver=lx.CG(rtol=1e-4, atol=1e-4))
+    assert_allclose(A.mv(sol.value), b, rtol=1e-3, atol=1e-3)
+
+
+def test_cg_scan_addition_sharded(rng: np.random.Generator, mesh) -> None:
+    # Sharded H^T W H — in/out are replicated (P()), lineax CG sees regular arrays
+    obs_sharding = NamedSharding(mesh, P('obs'))
+    no_sharding = NamedSharding(mesh, P())
+    H_blocks = _make_blocks(rng, N_OBS, N_OUT, N_IN, sharding=obs_sharding)
+    W_blocks = _make_spd_blocks(rng, N_OBS, N_OUT, sharding=obs_sharding)
+    H = ScanBlockColumnOperator.create(H_blocks)
+    W = ScanBlockDiagonalOperator.create(W_blocks)
+    A = (H.T @ W @ H).reduce()
+    assert isinstance(A, ScanAdditionOperator)
+
+    lx_A = as_lineax_operator(A, tags=OperatorTag.SYMMETRIC | OperatorTag.POSITIVE_SEMIDEFINITE)
+    b = jax.device_put(jnp.asarray(rng.standard_normal((N_IN,)).astype(np.float64)), no_sharding)
+    sol = lx.linear_solve(lx_A, b, solver=lx.CG(rtol=1e-4, atol=1e-4))
+    assert_allclose(np.array(A.mv(sol.value)), np.array(b), rtol=1e-3, atol=1e-3)

--- a/tests/mapmaking/test_scan_blocks.py
+++ b/tests/mapmaking/test_scan_blocks.py
@@ -1,0 +1,378 @@
+import jax
+import jax.numpy as jnp
+import numpy as np
+import pytest
+from jaxtyping import Array, Inexact, PyTree
+from numpy.testing import assert_allclose
+
+from furax import AbstractLinearOperator
+from furax.core import CompositionOperator
+from furax.mapmaking._scan_blocks import (
+    ScanAdditionOperator,
+    ScanBlockColumnOperator,
+    ScanBlockDiagonalOperator,
+    ScanBlockRowOperator,
+)
+
+# ---------------------------------------------------------------------------
+# Test fixture: a minimal AbstractLinearOperator that supports stacking via a
+# leading batch axis on its ``matrix`` field.
+# ---------------------------------------------------------------------------
+
+
+class _TestOp(AbstractLinearOperator):
+    matrix: Inexact[Array, '...']
+
+    def __init__(
+        self,
+        matrix: Inexact[Array, '...'],
+        in_structure: PyTree[jax.ShapeDtypeStruct],
+    ) -> None:
+        object.__setattr__(self, 'matrix', matrix)
+        super().__init__(in_structure=in_structure)
+
+    def mv(self, x: PyTree[Inexact[Array, '...']]) -> PyTree[Inexact[Array, '...']]:
+        return jnp.einsum('...ij,...j->...i', self.matrix, x)
+
+    @property
+    def out_structure(self) -> PyTree[jax.ShapeDtypeStruct]:
+        # Per-slice metadata regardless of stacking.
+        return jax.ShapeDtypeStruct((self.matrix.shape[-2],), self.matrix.dtype)
+
+    def transpose(self) -> AbstractLinearOperator:
+        return _TestOp(
+            jnp.swapaxes(self.matrix, -1, -2),
+            in_structure=jax.ShapeDtypeStruct((self.matrix.shape[-2],), self.matrix.dtype),
+        )
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+N_OBS = 3
+N_IN = 4
+N_OUT = 5
+
+
+@pytest.fixture
+def rng() -> np.random.Generator:
+    return np.random.default_rng(seed=0)
+
+
+def _stacked_test_op(rng: np.random.Generator, n_obs: int, n_out: int, n_in: int) -> _TestOp:
+    matrices = rng.standard_normal((n_obs, n_out, n_in)).astype(np.float32)
+    return _TestOp(
+        jnp.asarray(matrices),
+        in_structure=jax.ShapeDtypeStruct((n_in,), jnp.float32),
+    )
+
+
+def _per_obs_matrices(op: _TestOp) -> list[Array]:
+    return [op.matrix[i] for i in range(op.matrix.shape[0])]
+
+
+# ---------------------------------------------------------------------------
+# 1. Forward correctness
+# ---------------------------------------------------------------------------
+
+
+def test_diagonal_mv(rng: np.random.Generator) -> None:
+    blocks = _stacked_test_op(rng, N_OBS, N_OUT, N_IN)
+    op = ScanBlockDiagonalOperator(blocks, N_OBS)
+    x_stacked = jnp.asarray(rng.standard_normal((N_OBS, N_IN)).astype(np.float32))
+    expected = jnp.stack([m @ x_stacked[i] for i, m in enumerate(_per_obs_matrices(blocks))])
+    assert_allclose(op.mv(x_stacked), expected, rtol=1e-5)
+
+
+def test_column_mv(rng: np.random.Generator) -> None:
+    blocks = _stacked_test_op(rng, N_OBS, N_OUT, N_IN)
+    op = ScanBlockColumnOperator(blocks, N_OBS)
+    x = jnp.asarray(rng.standard_normal((N_IN,)).astype(np.float32))
+    expected = jnp.stack([m @ x for m in _per_obs_matrices(blocks)])
+    assert_allclose(op.mv(x), expected, rtol=1e-5)
+
+
+def test_row_mv(rng: np.random.Generator) -> None:
+    blocks = _stacked_test_op(rng, N_OBS, N_OUT, N_IN)
+    op = ScanBlockRowOperator(blocks, N_OBS)
+    x_stacked = jnp.asarray(rng.standard_normal((N_OBS, N_IN)).astype(np.float32))
+    expected = sum(m @ x_stacked[i] for i, m in enumerate(_per_obs_matrices(blocks)))
+    assert_allclose(op.mv(x_stacked), expected, rtol=1e-5)
+
+
+def test_sum_mv(rng: np.random.Generator) -> None:
+    blocks = _stacked_test_op(rng, N_OBS, N_OUT, N_IN)
+    op = ScanAdditionOperator(blocks, N_OBS)
+    x = jnp.asarray(rng.standard_normal((N_IN,)).astype(np.float32))
+    expected = sum(m @ x for m in _per_obs_matrices(blocks))
+    assert_allclose(op.mv(x), expected, rtol=1e-5)
+
+
+# ---------------------------------------------------------------------------
+# 2. Transpose correctness — class swap and numerical match
+# ---------------------------------------------------------------------------
+
+
+def test_diagonal_transpose(rng: np.random.Generator) -> None:
+    blocks = _stacked_test_op(rng, N_OBS, N_OUT, N_IN)
+    op = ScanBlockDiagonalOperator(blocks, N_OBS)
+    op_T = op.T
+    assert isinstance(op_T, ScanBlockDiagonalOperator)
+    y_stacked = jnp.asarray(rng.standard_normal((N_OBS, N_OUT)).astype(np.float32))
+    expected = jnp.stack([m.T @ y_stacked[i] for i, m in enumerate(_per_obs_matrices(blocks))])
+    assert_allclose(op_T.mv(y_stacked), expected, rtol=1e-5)
+
+
+def test_column_transpose_is_row(rng: np.random.Generator) -> None:
+    blocks = _stacked_test_op(rng, N_OBS, N_OUT, N_IN)
+    op = ScanBlockColumnOperator(blocks, N_OBS)
+    op_T = op.T
+    assert isinstance(op_T, ScanBlockRowOperator)
+    y_stacked = jnp.asarray(rng.standard_normal((N_OBS, N_OUT)).astype(np.float32))
+    expected = sum(m.T @ y_stacked[i] for i, m in enumerate(_per_obs_matrices(blocks)))
+    assert_allclose(op_T.mv(y_stacked), expected, rtol=1e-5)
+
+
+def test_row_transpose_is_column(rng: np.random.Generator) -> None:
+    blocks = _stacked_test_op(rng, N_OBS, N_OUT, N_IN)
+    op = ScanBlockRowOperator(blocks, N_OBS)
+    op_T = op.T
+    assert isinstance(op_T, ScanBlockColumnOperator)
+    y = jnp.asarray(rng.standard_normal((N_OUT,)).astype(np.float32))
+    expected = jnp.stack([m.T @ y for m in _per_obs_matrices(blocks)])
+    assert_allclose(op_T.mv(y), expected, rtol=1e-5)
+
+
+def test_sum_transpose(rng: np.random.Generator) -> None:
+    blocks = _stacked_test_op(rng, N_OBS, N_OUT, N_IN)
+    op = ScanAdditionOperator(blocks, N_OBS)
+    op_T = op.T
+    assert isinstance(op_T, ScanAdditionOperator)
+    y = jnp.asarray(rng.standard_normal((N_OUT,)).astype(np.float32))
+    expected = sum(m.T @ y for m in _per_obs_matrices(blocks))
+    assert_allclose(op_T.mv(y), expected, rtol=1e-5)
+
+
+# ---------------------------------------------------------------------------
+# 3. Roundtrip op.T.T == op
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    'cls',
+    [
+        ScanBlockDiagonalOperator,
+        ScanBlockColumnOperator,
+        ScanBlockRowOperator,
+        ScanAdditionOperator,
+    ],
+)
+def test_transpose_roundtrip(cls: type, rng: np.random.Generator) -> None:
+    blocks = _stacked_test_op(rng, N_OBS, N_OUT, N_IN)
+    op = cls(blocks, N_OBS)
+    op_TT = op.T.T
+    assert isinstance(op_TT, cls)
+    if cls is ScanBlockDiagonalOperator:
+        x = jnp.asarray(rng.standard_normal((N_OBS, N_IN)).astype(np.float32))
+    elif cls is ScanBlockColumnOperator or cls is ScanAdditionOperator:
+        x = jnp.asarray(rng.standard_normal((N_IN,)).astype(np.float32))
+    else:  # ScanBlockRow
+        x = jnp.asarray(rng.standard_normal((N_OBS, N_IN)).astype(np.float32))
+    assert_allclose(op_TT.mv(x), op.mv(x), rtol=1e-5)
+
+
+# ---------------------------------------------------------------------------
+# 4. as_matrix consistency
+# ---------------------------------------------------------------------------
+
+
+def test_diagonal_as_matrix(rng: np.random.Generator) -> None:
+    blocks = _stacked_test_op(rng, N_OBS, N_OUT, N_IN)
+    op = ScanBlockDiagonalOperator(blocks, N_OBS)
+    mats = _per_obs_matrices(blocks)
+    import jax.scipy.linalg as jsl
+
+    expected = jsl.block_diag(*mats)
+    assert_allclose(op.as_matrix(), expected, rtol=1e-5)
+
+
+def test_column_as_matrix(rng: np.random.Generator) -> None:
+    blocks = _stacked_test_op(rng, N_OBS, N_OUT, N_IN)
+    op = ScanBlockColumnOperator(blocks, N_OBS)
+    mats = _per_obs_matrices(blocks)
+    expected = jnp.vstack(mats)
+    assert_allclose(op.as_matrix(), expected, rtol=1e-5)
+
+
+def test_row_as_matrix(rng: np.random.Generator) -> None:
+    blocks = _stacked_test_op(rng, N_OBS, N_OUT, N_IN)
+    op = ScanBlockRowOperator(blocks, N_OBS)
+    mats = _per_obs_matrices(blocks)
+    expected = jnp.hstack(mats)
+    assert_allclose(op.as_matrix(), expected, rtol=1e-5)
+
+
+# ---------------------------------------------------------------------------
+# 5. Fusion rules
+# ---------------------------------------------------------------------------
+
+
+def test_fusion_diag_diag(rng: np.random.Generator) -> None:
+    left_blocks = _stacked_test_op(rng, N_OBS, N_IN, N_IN)  # square
+    right_blocks = _stacked_test_op(rng, N_OBS, N_IN, N_IN)
+    left = ScanBlockDiagonalOperator(left_blocks, N_OBS)
+    right = ScanBlockDiagonalOperator(right_blocks, N_OBS)
+
+    composed = left @ right
+    reduced = composed.reduce()
+    assert isinstance(reduced, ScanBlockDiagonalOperator)
+
+    x = jnp.asarray(rng.standard_normal((N_OBS, N_IN)).astype(np.float32))
+    assert_allclose(reduced.mv(x), composed.mv(x), rtol=1e-5)
+
+
+def test_fusion_diag_column(rng: np.random.Generator) -> None:
+    left_blocks = _stacked_test_op(rng, N_OBS, N_OUT, N_OUT)
+    right_blocks = _stacked_test_op(rng, N_OBS, N_OUT, N_IN)
+    left = ScanBlockDiagonalOperator(left_blocks, N_OBS)
+    right = ScanBlockColumnOperator(right_blocks, N_OBS)
+
+    composed = left @ right
+    reduced = composed.reduce()
+    assert isinstance(reduced, ScanBlockColumnOperator)
+
+    x = jnp.asarray(rng.standard_normal((N_IN,)).astype(np.float32))
+    assert_allclose(reduced.mv(x), composed.mv(x), rtol=1e-5)
+
+
+def test_fusion_row_diag(rng: np.random.Generator) -> None:
+    left_blocks = _stacked_test_op(rng, N_OBS, N_OUT, N_IN)
+    right_blocks = _stacked_test_op(rng, N_OBS, N_IN, N_IN)
+    left = ScanBlockRowOperator(left_blocks, N_OBS)
+    right = ScanBlockDiagonalOperator(right_blocks, N_OBS)
+
+    composed = left @ right
+    reduced = composed.reduce()
+    assert isinstance(reduced, ScanBlockRowOperator)
+
+    x = jnp.asarray(rng.standard_normal((N_OBS, N_IN)).astype(np.float32))
+    assert_allclose(reduced.mv(x), composed.mv(x), rtol=1e-5)
+
+
+def test_fusion_row_column(rng: np.random.Generator) -> None:
+    left_blocks = _stacked_test_op(rng, N_OBS, N_OUT, N_IN)
+    right_blocks = _stacked_test_op(rng, N_OBS, N_IN, N_IN)
+    left = ScanBlockRowOperator(left_blocks, N_OBS)
+    right = ScanBlockColumnOperator(right_blocks, N_OBS)
+
+    composed = left @ right
+    reduced = composed.reduce()
+    assert isinstance(reduced, ScanAdditionOperator)
+
+    x = jnp.asarray(rng.standard_normal((N_IN,)).astype(np.float32))
+    assert_allclose(reduced.mv(x), composed.mv(x), rtol=1e-5)
+
+
+# ---------------------------------------------------------------------------
+# 6. n_obs mismatch declines fusion
+# ---------------------------------------------------------------------------
+
+
+def test_mismatched_leading_dim_rejected_by_matmul(rng: np.random.Generator) -> None:
+    """Different leading-axis sizes give mismatched ``in_structure`` shapes, so
+    ``__matmul__`` rejects the composition before any fusion rule runs."""
+    blocks_a = _stacked_test_op(rng, 3, N_IN, N_IN)
+    blocks_b = _stacked_test_op(rng, 4, N_IN, N_IN)
+    left = ScanBlockDiagonalOperator(blocks_a, 3)
+    right = ScanBlockDiagonalOperator(blocks_b, 4)
+    with pytest.raises(ValueError, match='Incompatible'):
+        _ = left @ right
+
+
+# ---------------------------------------------------------------------------
+# 7. Multi-step chain fusion: T.T W T  (Diag @ Diag @ Diag → single Diag)
+# ---------------------------------------------------------------------------
+
+
+def test_chain_fusion_diag(rng: np.random.Generator) -> None:
+    a = _stacked_test_op(rng, N_OBS, N_IN, N_IN)
+    b = _stacked_test_op(rng, N_OBS, N_IN, N_IN)
+    c = _stacked_test_op(rng, N_OBS, N_IN, N_IN)
+    A = ScanBlockDiagonalOperator(a, N_OBS)
+    B = ScanBlockDiagonalOperator(b, N_OBS)
+    C = ScanBlockDiagonalOperator(c, N_OBS)
+    chain = A @ B @ C
+    reduced = chain.reduce()
+    assert isinstance(reduced, ScanBlockDiagonalOperator)
+
+    x = jnp.asarray(rng.standard_normal((N_OBS, N_IN)).astype(np.float32))
+    assert_allclose(reduced.mv(x), chain.mv(x), rtol=1e-5)
+
+
+# ---------------------------------------------------------------------------
+# 8. Row @ Diag @ Column reduces all the way to _ScanSumOperator
+# ---------------------------------------------------------------------------
+
+
+def test_chain_fusion_row_diag_column(rng: np.random.Generator) -> None:
+    """``H.T @ W @ H`` fuses to a single :class:`_ScanSumOperator` (= ``Σ H_i.T W_i H_i``)."""
+    H_blocks = _stacked_test_op(rng, N_OBS, N_OUT, N_IN)
+    W_blocks = _stacked_test_op(rng, N_OBS, N_OUT, N_OUT)
+
+    H = ScanBlockColumnOperator(H_blocks, N_OBS)
+    W = ScanBlockDiagonalOperator(W_blocks, N_OBS)
+    HT = H.T
+    assert isinstance(HT, ScanBlockRowOperator)
+
+    chain = HT @ W @ H
+    reduced = chain.reduce()
+    assert isinstance(reduced, ScanAdditionOperator)
+
+    x = jnp.asarray(rng.standard_normal((N_IN,)).astype(np.float32))
+    assert_allclose(reduced.mv(x), chain.mv(x), rtol=1e-5)
+
+
+# ---------------------------------------------------------------------------
+# Sanity: CompositionOperator's __matmul__ structure check rejects mismatched shapes
+# ---------------------------------------------------------------------------
+
+
+def test_composition_rejects_mismatched_shapes(rng: np.random.Generator) -> None:
+    a = _stacked_test_op(rng, N_OBS, N_OUT, N_IN)  # in n_in, out n_out
+    b = _stacked_test_op(rng, N_OBS, N_OUT, N_IN)  # same
+    A = ScanBlockDiagonalOperator(a, N_OBS)
+    B = ScanBlockDiagonalOperator(b, N_OBS)
+    # A.in = (n_obs, n_in), B.out = (n_obs, n_out): not compatible
+    with pytest.raises(ValueError, match='Incompatible'):
+        _ = A @ B
+
+
+# ---------------------------------------------------------------------------
+# Smoke: reduce() on a Scan op delegates to inner blocks.reduce()
+# ---------------------------------------------------------------------------
+
+
+def test_reduce_delegates_to_blocks(rng: np.random.Generator) -> None:
+    blocks = _stacked_test_op(rng, N_OBS, N_IN, N_IN)
+    op = ScanBlockDiagonalOperator(blocks, N_OBS)
+    reduced = op.reduce()
+    assert isinstance(reduced, ScanBlockDiagonalOperator)
+    x = jnp.asarray(rng.standard_normal((N_OBS, N_IN)).astype(np.float32))
+    assert_allclose(reduced.mv(x), op.mv(x), rtol=1e-5)
+
+
+# ---------------------------------------------------------------------------
+# Smoke: a Scan op composed with itself reduces via the appropriate rule
+# (not just via the CompositionOperator wrapper)
+# ---------------------------------------------------------------------------
+
+
+def test_self_composition_reduces(rng: np.random.Generator) -> None:
+    blocks = _stacked_test_op(rng, N_OBS, N_IN, N_IN)
+    op = ScanBlockDiagonalOperator(blocks, N_OBS)
+    composed = op @ op
+    assert isinstance(composed, CompositionOperator)
+    reduced = composed.reduce()
+    assert isinstance(reduced, ScanBlockDiagonalOperator)

--- a/tests/mapmaking/test_scan_blocks.py
+++ b/tests/mapmaking/test_scan_blocks.py
@@ -60,9 +60,10 @@ def mesh():
     return jax.make_mesh((jax.device_count(),), ('obs',))
 
 
-@pytest.fixture(autouse=True)
+@pytest.fixture(scope='module', autouse=True)
 def set_mesh(mesh):
-    jax.set_mesh(mesh)
+    with jax.set_mesh(mesh):
+        yield
 
 
 def _make_blocks(sharding=None, *, n_in: int = N_IN) -> _TestOp:


### PR DESCRIPTION
Like #107 but using new block operators to fuse operations in scan loops.

Manual parallelism (shard_map) is needed because we want each process to use `scan` when looping through its observations (for memory reasons), and the inputs to `scan` must be fully replicated. In other words, each process should only see its own "local" slice of the data, which is what shard_map provides.

The new `ScanBlock{...}Operator` classes provide a convenient abstraction around the pattern where an operator pytree has been stacked along an axis (typically for observations) and needs to be applied to a stacked input vector using `scan`. Those operators do not embed sharding information in their input/output structures, and use sharding purely at runtime via `jax.reshard` and `jax.shard_map` inside `mv()`. This prevents structure equality checks (when composing operators) from failing in various places since not all the codebase is sharding-friendly/compatible.

Similarly, calls to shard_map use `check_vma=False` because we rely on `jax.linear_transpose` which traces the matvec function from the operator's input structure, constructed outside the shard and therefore lacking varying-axis (vma) annotations. This results in a mismatch between the traced function output and the cotangent type, which IS varying at call time.

`MapMakingConfig` and all its components have been made frozen dataclasses so that they are hashable and be passed as static arguments to jitted functions (namely `accumulate_rhs` in this case).