### PR TITLE
Add `atomic` flag to QURotationOperator to prevent reduction

### DIFF
--- a/src/furax/mapmaking/acquisition.py
+++ b/src/furax/mapmaking/acquisition.py
@@ -74,14 +74,10 @@ def build_acquisition_operator(
         return 0.5 * rot.T @ pointing
 
     # In the general case, we include polarizer and HWP
-    assert hwp_angles is not None  # mypy assert
-
-    # Pad hwp_angles to rank 2 so that, when stacked across observations, the
-    # QURotation fusion rule can broadcast against the per-detector gamma angles.
     hwp = HWPOperator.create(
         shape=data_shape,
         dtype=dtype,
         stokes=landscape.stokes,
-        angles=hwp_angles[None, :],
+        angles=hwp_angles,
     )
     return polarizer @ rot @ hwp @ pointing

--- a/src/furax/mapmaking/acquisition.py
+++ b/src/furax/mapmaking/acquisition.py
@@ -54,12 +54,18 @@ def build_acquisition_operator(
         return polarizer @ pointing
 
     # If there is a HWP, we are in the boresight frame so we need another rotation
+    #
+    # Use `atomic=True` to prevent merging with the HWP's internal rotation:
+    # QURotationHWPRule commutes rot past the HWP, then QURotationRule would
+    # absorb rot.T(gamma, ndet×1) into rot(hwp_angles, ndet×nsamp), broadcasting
+    # the per-detector gamma across all samples unnecessarily.
     gamma = to_gamma_angles(detector_quaternions)[:, None]
     rot = QURotationOperator.create(
         data_shape,
         dtype,
         landscape.stokes,
         angles=gamma,
+        atomic=True,
     )
 
     # In the demodulated case, there is no polarizer

--- a/src/furax/obs/operators/_qu_rotations.py
+++ b/src/furax/obs/operators/_qu_rotations.py
@@ -16,6 +16,8 @@ which encodes successively (from right to left):
 - the rotation back to the original frame.
 """
 
+from dataclasses import field
+
 import jax
 import numpy as np
 from jax import Array
@@ -97,9 +99,12 @@ class QURotationOperator(AbstractLinearOperator):
 
     Attributes:
         angles: Rotation angles in radians.
+        atomic: If True, prevents this operator from being merged with adjacent
+            QU rotation operators during algebraic reduction.
     """
 
     angles: Float[Array, '...']
+    atomic: bool = field(kw_only=True, default=False, metadata={'static': True})
 
     @classmethod
     def create(
@@ -109,9 +114,10 @@ class QURotationOperator(AbstractLinearOperator):
         stokes: ValidStokesType = 'IQU',
         *,
         angles: Float[Array, '...'],
+        atomic: bool = False,
     ) -> AbstractLinearOperator:
         structure = Stokes.class_for(stokes).structure_for(shape, dtype)
-        return cls(angles=angles, in_structure=structure)
+        return cls(angles=angles, atomic=atomic, in_structure=structure)
 
     def mv(self, x: StokesPyTreeType) -> StokesPyTreeType:
         return rotate_qu(x, self.angles)  # type: ignore[no-any-return]
@@ -136,19 +142,20 @@ class QURotationRule(AbstractBinaryRule):
     def apply(
         self, left: AbstractLinearOperator, right: AbstractLinearOperator
     ) -> list[AbstractLinearOperator]:
-        if isinstance(left, QURotationOperator):
-            if isinstance(right, QURotationOperator):
+        if isinstance(left, QURotationOperator) and not left.atomic:
+            if isinstance(right, QURotationOperator) and not right.atomic:
                 angles = left.angles + right.angles
-            elif isinstance(right, QURotationTransposeOperator):
+            elif isinstance(right, QURotationTransposeOperator) and not right.operator.atomic:
                 angles = left.angles - right.operator.angles
             else:
                 raise NoReduction
-        else:
-            assert isinstance(left, QURotationTransposeOperator)  # mypy assert
-            if isinstance(right, QURotationOperator):
+        elif isinstance(left, QURotationTransposeOperator) and not left.operator.atomic:
+            if isinstance(right, QURotationOperator) and not right.atomic:
                 angles = right.angles - left.operator.angles
-            elif isinstance(right, QURotationTransposeOperator):
+            elif isinstance(right, QURotationTransposeOperator) and not right.operator.atomic:
                 angles = -left.operator.angles - right.operator.angles
             else:
                 raise NoReduction
+        else:
+            raise NoReduction
         return [QURotationOperator(angles=angles, in_structure=right.in_structure)]

--- a/tests/obs/operators/test_qu_rotations.py
+++ b/tests/obs/operators/test_qu_rotations.py
@@ -4,6 +4,7 @@ import pytest
 
 import furax as fx
 from furax import IdentityOperator
+from furax.core import CompositionOperator
 from furax.obs import QURotationOperator
 from furax.obs.stokes import Stokes, StokesI, StokesIQU, ValidStokesType
 
@@ -68,3 +69,38 @@ def test_rules(stokes: ValidStokesType, transpose_left, transpose_right, expecte
 
     assert isinstance(reduced_op, QURotationOperator)
     assert reduced_op.angles == expected_value
+
+
+@pytest.mark.parametrize(
+    'atomic_left, atomic_right',
+    [(True, False), (False, True), (True, True)],
+)
+@pytest.mark.parametrize(
+    'transpose_left, transpose_right',
+    [(False, False), (False, True), (True, False), (True, True)],
+)
+def test_atomic_prevents_reduction(
+    stokes: ValidStokesType,
+    atomic_left: bool,
+    atomic_right: bool,
+    transpose_left: bool,
+    transpose_right: bool,
+) -> None:
+    structure = Stokes.class_for(stokes).structure_for(())
+    left = QURotationOperator(1, atomic=atomic_left, in_structure=structure)
+    if transpose_left:
+        left = left.T
+    right = QURotationOperator(2, atomic=atomic_right, in_structure=structure)
+    if transpose_right:
+        right = right.T
+    reduced_op = (left @ right).reduce()
+
+    assert isinstance(reduced_op, CompositionOperator) and len(reduced_op.operands) == 2
+
+
+def test_atomic_identity_still_reduces(stokes: ValidStokesType) -> None:
+    structure = Stokes.class_for(stokes).structure_for(())
+    op = QURotationOperator(1.1, atomic=True, in_structure=structure)
+
+    assert isinstance((op @ op.T).reduce(), IdentityOperator)
+    assert isinstance((op.T @ op).reduce(), IdentityOperator)


### PR DESCRIPTION
There are cases where the reduction of two QU rotation operators may not be desirable, for instance if the sum/difference of their angles broadcasts to a larger shape: `(N, 1) x (1, M) -> (N, M)`.