### PR TITLE
Add identity noise option to disable noise weighting

### DIFF
--- a/src/furax/mapmaking/_model.py
+++ b/src/furax/mapmaking/_model.py
@@ -65,7 +65,7 @@ class ObservationModel:
             data.get('valid_scanning_masks'),
             structure=H.out_structure,
         )
-        noise_model, sample_rate = _noise_model(data, config)
+        noise_model, sample_rate = _noise_model(data, config, tod_structure=H.out_structure)
         W = _noise_operator(
             noise_model, H.out_structure, sample_rate, config.noise.correlation_length, inverse=True
         )
@@ -189,9 +189,17 @@ class SystemOperator(AbstractLinearOperator):
         return _system_scan(self.models, x, diag=self.diag)  # type: ignore[no-any-return]
 
 
-def _noise_model(data: Any, config: MapMakingConfig) -> tuple[PyTree[NoiseModel], Array]:
+def _noise_model(
+    data: Any, config: MapMakingConfig, tod_structure: Any = None
+) -> tuple[PyTree[NoiseModel], Array]:
     """Compute the noise model and sample rate for a single observation block."""
     fs = _sample_rate(data['timestamps'])
+    if config.noise.identity:
+        noise_model = jax.tree.map(
+            lambda s: WhiteNoiseModel(sigma=jnp.ones(s.shape[0], dtype=s.dtype)),
+            tod_structure,
+        )
+        return noise_model, fs
     if config.noise.fit_from_data:
         noise_model_class = WhiteNoiseModel if config.binned else AtmosphericNoiseModel
         fhwp = _hwp_frequency(data['timestamps'], data['hwp_angles'])

--- a/src/furax/mapmaking/_model.py
+++ b/src/furax/mapmaking/_model.py
@@ -139,11 +139,15 @@ def pad_model(models: ObservationModel, n_pad: int) -> ObservationModel:
 
 
 def _noise_model(
-    data: Any, config: MapMakingConfig, tod_structure: Any = None
+    data: Any,
+    config: MapMakingConfig,
+    tod_structure: jax.ShapeDtypeStruct | None = None,
 ) -> tuple[PyTree[NoiseModel], Array]:
     """Compute the noise model and sample rate for a single observation block."""
     fs = _sample_rate(data['timestamps'])
     if config.noise.identity:
+        if tod_structure is None:
+            raise ValueError('tod_structure is required when config.noise.identity is True')
         noise_model = jax.tree.map(
             lambda s: WhiteNoiseModel(sigma=jnp.ones(s.shape[0], dtype=s.dtype)),
             tod_structure,

--- a/src/furax/mapmaking/config.py
+++ b/src/furax/mapmaking/config.py
@@ -85,6 +85,9 @@ class NoiseConfig:
     white: bool = True
     """Use a white (diagonal) noise model.  Set to False for the atmospheric (1/f) model."""
 
+    identity: bool = False
+    """Use an identity inverse-noise matrix (no noise weighting)."""
+
     fit_from_data: bool = True
     """Fit the noise model from the TOD PSD (True) or load it from the data pipeline (False)."""
 

--- a/src/furax/mapmaking/mapmaker.py
+++ b/src/furax/mapmaking/mapmaker.py
@@ -221,10 +221,11 @@ class MultiObservationMapMaker(Generic[T]):
             required_fields.append('hwp_angles')
         if self.config.scanning_mask:
             required_fields.append('valid_scanning_masks')
-        if self.config.noise.fit_from_data:
-            required_fields.extend(['sample_data', 'hwp_angles'])
-        else:
-            required_fields.append('noise_model_fits')
+        if not self.config.noise.identity:
+            if self.config.noise.fit_from_data:
+                required_fields.extend(['sample_data', 'hwp_angles'])
+            else:
+                required_fields.append('noise_model_fits')
         if self.config.gaps.fill and not self.config.binned:
             required_fields.append('metadata')
         reader = self.get_reader(required_fields)
@@ -534,6 +535,10 @@ class MapMaker:
         but otherwise fits a model to the data.
         """
         config = self.config
+
+        if config.noise.identity:
+            return WhiteNoiseModel(sigma=jnp.ones(observation.n_detectors, dtype=config.dtype))
+
         Model = WhiteNoiseModel if config.binned else AtmosphericNoiseModel
 
         if not config.noise.fit_from_data:
@@ -762,7 +767,7 @@ class BinnedMapMaker(MapMaker):
             output['wcs'] = landscape.to_wcs()
         elif isinstance(landscape, AstropyWCSLandscape):
             output['wcs'] = landscape.wcs
-        if config.noise.fit_from_data:
+        if config.noise.fit_from_data and not config.noise.identity:
             output['noise_fit'] = noise_model.to_array()  # type: ignore[assignment]
         if config.debug:
             proj_map = (masker.T @ acquisition)(res)
@@ -821,10 +826,14 @@ class MLMapmaker(MapMaker):
         logger_info('Created noise and inverse noise covariance operators')
 
         # Approximate system matrix with diagonal noise covariance and full map pixels
-        if not isinstance(inv_noise, SymmetricBandToeplitzOperator):
+        if config.noise.identity:
+            diag_inv_noise = inv_noise
+        elif isinstance(inv_noise, SymmetricBandToeplitzOperator):
+            diag_inv_noise = DiagonalOperator(
+                inv_noise.band_values[..., [0]], in_structure=data_struct
+            )
+        else:
             raise NotImplementedError
-
-        diag_inv_noise = DiagonalOperator(inv_noise.band_values[..., [0]], in_structure=data_struct)
         diag_system = BJPreconditioner.create(acquisition.T @ diag_inv_noise @ masker @ acquisition)
         logger_info('Created approximate system matrix')
 
@@ -954,7 +963,7 @@ class MLMapmaker(MapMaker):
             output['wcs'] = landscape.to_wcs()
         elif isinstance(landscape, AstropyWCSLandscape):
             output['wcs'] = landscape.wcs
-        if config.noise.fit_from_data:
+        if config.noise.fit_from_data and not config.noise.identity:
             output['noise_fit'] = noise_model.to_array()
         if config.use_templates:
             for key in tmpl_ampl.keys():
@@ -1074,7 +1083,7 @@ class TwoStepMapmaker(MapMaker):
             output['wcs'] = landscape.to_wcs()
         elif isinstance(landscape, AstropyWCSLandscape):
             output['wcs'] = landscape.wcs
-        if config.noise.fit_from_data:
+        if config.noise.fit_from_data and not config.noise.identity:
             output['noise_fit'] = noise_model.to_array()
         if config.debug:
             proj_map = (mp @ acquisition)(result_map)
@@ -1194,7 +1203,7 @@ class ATOPMapMaker(MapMaker):
         output = {'map': final_map, 'weights': blocks}
         if isinstance(landscape, AstropyWCSLandscape):
             output['wcs'] = landscape.wcs
-        if config.noise.fit_from_data:
+        if config.noise.fit_from_data and not config.noise.identity:
             output['noise_fit'] = noise_model.to_array()
         if config.debug:
             proj_map = (mp @ acquisition)(result_map)

--- a/src/furax/mapmaking/noise.py
+++ b/src/furax/mapmaking/noise.py
@@ -48,6 +48,9 @@ class NoiseModel(ABC):
         self, in_structure: PyTree[jax.ShapeDtypeStruct], **kwargs: Any
     ) -> AbstractLinearOperator: ...
 
+    @abstractmethod
+    def to_white_noise_model(self) -> 'WhiteNoiseModel': ...
+
     def to_operator_fourier(
         self,
         in_structure: PyTree[jax.ShapeDtypeStruct],

--- a/src/furax/mapmaking/noise.py
+++ b/src/furax/mapmaking/noise.py
@@ -108,6 +108,9 @@ class WhiteNoiseModel(NoiseModel):
         inv_var = jnp.where(self.sigma > 0, 1.0 / (self.sigma**2), 0.0)
         return DiagonalOperator(inv_var[:, None], in_structure=in_structure)
 
+    def to_white_noise_model(self) -> 'WhiteNoiseModel':
+        return self
+
     @classmethod
     def fit_psd_model(
         cls,

--- a/tests/mapmaking/test_mapmaker.py
+++ b/tests/mapmaking/test_mapmaker.py
@@ -161,6 +161,34 @@ class TestMultiObsMapMaker:
         assert results.icov.shape == (n_stokes, n_stokes, *maker.landscape.shape)
 
 
+@pytest.mark.parametrize('landscape_type', LANDSCAPE_TYPES)
+@pytest.mark.parametrize('stokes', STOKES_TYPES)
+@pytest.mark.parametrize('name,demodulated', PARAMS)
+class TestIdentityNoise:
+    """Test that identity noise mode works end-to-end."""
+
+    def test_identity_noise_builds_model(self, name, demodulated, stokes, landscape_type):
+        observations = _observations(name, demodulated)
+        config = _config(landscape_type, stokes, demodulated, identity_noise=True)
+        maker = MultiObservationMapMaker(observations, config=config)
+        model = maker.build_model()
+        noise_leaves = jax.tree.leaves(
+            model.noise_model, is_leaf=lambda x: isinstance(x, WhiteNoiseModel)
+        )
+        for nm in noise_leaves:
+            assert isinstance(nm, WhiteNoiseModel)
+            assert jnp.allclose(nm.sigma, 1.0)
+
+    def test_identity_noise_full_mapmaker(self, name, demodulated, stokes, landscape_type):
+        observations = _observations(name, demodulated)
+        config = _config(landscape_type, stokes, demodulated, identity_noise=True)
+        maker = MultiObservationMapMaker(observations, config=config)
+        results = maker.run()
+        n_stokes = len(stokes)
+        assert results.icov.shape == (n_stokes, n_stokes, *maker.landscape.shape)
+        assert results.solver_stats is not None
+
+
 ATOP_PARAMS = [
     pytest.param(
         'sotodlib',
@@ -240,6 +268,7 @@ def _config(
     interpolation: Literal['nearest', 'bilinear'] = 'nearest',
     method: Methods = Methods.BINNED,
     atop_tau: int = 0,
+    identity_noise: bool = False,
 ) -> MapMakingConfig:
     if landscape_type == 'healpix':
         lc = LandscapeConfig(stokes=stokes, healpix=HealpixConfig(nside=16))
@@ -256,7 +285,11 @@ def _config(
         method=method,
         pointing=PointingConfig(on_the_fly=True, interpolation=interpolation),
         landscape=lc,
-        noise=NoiseConfig(fit_from_data=fit_noise_model, fitting=NoiseFitConfig(nperseg=512)),
+        noise=NoiseConfig(
+            identity=identity_noise,
+            fit_from_data=fit_noise_model,
+            fitting=NoiseFitConfig(nperseg=512),
+        ),
         sotodlib=SotodlibConfig(demodulated=True) if demodulated else None,
         atop_tau=atop_tau,
     )

--- a/tests/mapmaking/test_mapmaker.py
+++ b/tests/mapmaking/test_mapmaker.py
@@ -163,48 +163,42 @@ class TestMultiObsMapMaker:
         assert results.icov.shape == (n_stokes, n_stokes, *maker.landscape.shape)
 
 
-@pytest.mark.parametrize('landscape_type', LANDSCAPE_TYPES)
-@pytest.mark.parametrize('stokes', STOKES_TYPES)
 @pytest.mark.parametrize('name,demodulated', PARAMS)
-class TestIdentityNoise:
-    """Test that identity noise mode works end-to-end."""
-
-    def test_identity_noise_builds_model(self, name, demodulated, stokes, landscape_type):
+class TestNoiseModelSelection:
+    def test_white_noise_models_binned_or_demodulated(self, name, demodulated):
+        stokes = 'IQU'
         observations = _observations(name, demodulated)
-        config = _config(landscape_type, stokes, demodulated, identity_noise=True)
+        config = _config('healpix', stokes, demodulated=demodulated)
         maker = MultiObservationMapMaker(observations, config=config)
-        model = maker.build_model()
+        noise_model = maker.build_model().noise_model
+        if demodulated:
+            assert isinstance(noise_model, Stokes.class_for(stokes))
+            assert all(
+                isinstance(getattr(noise_model, stoke.lower()), WhiteNoiseModel) for stoke in stokes
+            )
+        else:
+            assert isinstance(noise_model, WhiteNoiseModel)
+
+    def test_identity_builds_unit_white_noise(self, name, demodulated):
+        observations = _observations(name, demodulated)
+        config = _config('healpix', 'IQU', demodulated, identity_noise=True)
+        maker = MultiObservationMapMaker(observations, config=config)
         noise_leaves = jax.tree.leaves(
-            model.noise_model, is_leaf=lambda x: isinstance(x, WhiteNoiseModel)
+            maker.build_model().noise_model, is_leaf=lambda x: isinstance(x, WhiteNoiseModel)
         )
+        assert noise_leaves
         for nm in noise_leaves:
             assert isinstance(nm, WhiteNoiseModel)
             assert jnp.allclose(nm.sigma, 1.0)
 
-    def test_identity_noise_full_mapmaker(self, name, demodulated, stokes, landscape_type):
+    @pytest.mark.parametrize('method', [Methods.BINNED, Methods.MAXL])
+    def test_identity_full_mapmaker(self, name, demodulated, method):
         observations = _observations(name, demodulated)
-        config = _config(landscape_type, stokes, demodulated, identity_noise=True)
+        config = _config('healpix', 'IQU', demodulated, method=method, identity_noise=True)
         maker = MultiObservationMapMaker(observations, config=config)
         results = maker.run()
-        n_stokes = len(stokes)
-        assert results.icov.shape == (n_stokes, n_stokes, *maker.landscape.shape)
+        assert results.icov.shape == (3, 3, *maker.landscape.shape)
         assert results.solver_stats is not None
-
-
-@pytest.mark.parametrize('name,demodulated', PARAMS)
-def test_white_noise_models_binned_or_demodulated(name, demodulated):
-    stokes = 'IQU'
-    observations = _observations(name, demodulated)
-    config = _config('healpix', stokes, demodulated=demodulated)
-    maker = MultiObservationMapMaker(observations, config=config)
-    noise_model = maker.build_model().noise_model
-    if demodulated:
-        assert isinstance(noise_model, Stokes.class_for(stokes))
-        assert all(
-            isinstance(getattr(noise_model, stoke.lower()), WhiteNoiseModel) for stoke in stokes
-        )
-    else:
-        assert isinstance(noise_model, WhiteNoiseModel)
 
 
 ATOP_PARAMS = [

--- a/tests/mapmaking/test_model.py
+++ b/tests/mapmaking/test_model.py
@@ -1,9 +1,11 @@
+import jax
 import jax.numpy as jnp
 import pytest
-from numpy.testing import assert_array_equal
+from numpy.testing import assert_allclose, assert_array_equal
 
-from furax.mapmaking._model import _sample_mask
-from furax.mapmaking.config import MapMakingConfig, Methods
+from furax.mapmaking._model import _noise_model, _noise_operator, _sample_mask
+from furax.mapmaking.config import MapMakingConfig, Methods, NoiseConfig
+from furax.mapmaking.noise import WhiteNoiseModel
 
 
 class TestSampleMask:
@@ -23,3 +25,44 @@ class TestSampleMask:
         result = _sample_mask({'valid_sample_masks': mask}, config)
 
         assert_array_equal(result[0, 2 * tau :], jnp.zeros(n_samp - 2 * tau, dtype=jnp.bool_))
+
+
+class TestIdentityNoise:
+    @pytest.fixture
+    def tod_structure(self):
+        return jax.ShapeDtypeStruct((4, 200), jnp.float64)
+
+    @pytest.fixture
+    def identity_config(self):
+        return MapMakingConfig(noise=NoiseConfig(identity=True))
+
+    def test_noise_model_creates_unit_white_noise(self, identity_config, tod_structure):
+        data = {'timestamps': jnp.linspace(0, 1, 200)}
+        noise_model, fs = _noise_model(data, identity_config, tod_structure=tod_structure)
+        assert isinstance(noise_model, WhiteNoiseModel)
+        assert_allclose(noise_model.sigma, jnp.ones(4))
+
+    def test_noise_operator_acts_as_identity(self, identity_config, tod_structure):
+        data = {'timestamps': jnp.linspace(0, 1, 200)}
+        noise_model, fs = _noise_model(data, identity_config, tod_structure=tod_structure)
+        inv_op = _noise_operator(noise_model, tod_structure, fs, 100, inverse=True)
+        fwd_op = _noise_operator(noise_model, tod_structure, fs, 100, inverse=False)
+        x = jax.random.normal(jax.random.key(1), (4, 200))
+        assert_allclose(inv_op(x), x, rtol=1e-12)
+        assert_allclose(fwd_op(x), x, rtol=1e-12)
+
+    def test_identity_skips_noise_data_fields(self, identity_config, tod_structure):
+        data = {'timestamps': jnp.linspace(0, 1, 200)}
+        noise_model, _ = _noise_model(data, identity_config, tod_structure=tod_structure)
+        assert isinstance(noise_model, WhiteNoiseModel)
+
+    def test_identity_config_yaml_round_trip(self):
+        config = MapMakingConfig(noise=NoiseConfig(identity=True))
+        yaml_str = config._to_yaml()
+        assert 'identity: true' in yaml_str
+        loaded = MapMakingConfig.load_dict({'noise': {'identity': True}})
+        assert loaded.noise.identity is True
+
+    def test_identity_false_by_default(self):
+        config = NoiseConfig()
+        assert config.identity is False

--- a/tests/mapmaking/test_model.py
+++ b/tests/mapmaking/test_model.py
@@ -38,9 +38,10 @@ class TestIdentityNoise:
 
     def test_noise_model_creates_unit_white_noise(self, identity_config, tod_structure):
         data = {'timestamps': jnp.linspace(0, 1, 200)}
-        noise_model, fs = _noise_model(data, identity_config, tod_structure=tod_structure)
+        noise_model, _ = _noise_model(data, identity_config, tod_structure=tod_structure)
         assert isinstance(noise_model, WhiteNoiseModel)
         assert_allclose(noise_model.sigma, jnp.ones(4))
+        assert noise_model.sigma.dtype == tod_structure.dtype
 
     def test_noise_operator_acts_as_identity(self, identity_config, tod_structure):
         data = {'timestamps': jnp.linspace(0, 1, 200)}
@@ -51,10 +52,10 @@ class TestIdentityNoise:
         assert_allclose(inv_op(x), x, rtol=1e-12)
         assert_allclose(fwd_op(x), x, rtol=1e-12)
 
-    def test_identity_skips_noise_data_fields(self, identity_config, tod_structure):
+    def test_identity_requires_tod_structure(self, identity_config):
         data = {'timestamps': jnp.linspace(0, 1, 200)}
-        noise_model, _ = _noise_model(data, identity_config, tod_structure=tod_structure)
-        assert isinstance(noise_model, WhiteNoiseModel)
+        with pytest.raises(ValueError, match='tod_structure is required'):
+            _noise_model(data, identity_config, tod_structure=None)
 
     def test_identity_config_yaml_round_trip(self):
         config = MapMakingConfig(noise=NoiseConfig(identity=True))

--- a/tests/mapmaking/test_noise.py
+++ b/tests/mapmaking/test_noise.py
@@ -72,6 +72,17 @@ class TestWhiteNoiseModel:
         x = jnp.ones((2, 50))
         assert_allclose(model.inverse_operator(struct)(model.operator(struct)(x)), x, rtol=1e-5)
 
+    def test_to_white_noise_model_returns_self(self):
+        model = WhiteNoiseModel(sigma=jnp.array([1.0, 2.0]))
+        assert model.to_white_noise_model() is model
+
+    def test_identity_noise_operators_act_as_identity(self):
+        model = WhiteNoiseModel(sigma=jnp.ones(3))
+        struct = jax.ShapeDtypeStruct((3, 100), jnp.float64)
+        x = jax.random.normal(jax.random.key(0), (3, 100))
+        assert_allclose(model.operator(struct)(x), x, rtol=1e-12)
+        assert_allclose(model.inverse_operator(struct)(x), x, rtol=1e-12)
+
 
 # ---------------------------------------------------------------------------
 # AtmosphericNoiseModel

--- a/tests/mapmaking/test_noise.py
+++ b/tests/mapmaking/test_noise.py
@@ -76,13 +76,6 @@ class TestWhiteNoiseModel:
         model = WhiteNoiseModel(sigma=jnp.array([1.0, 2.0]))
         assert model.to_white_noise_model() is model
 
-    def test_identity_noise_operators_act_as_identity(self):
-        model = WhiteNoiseModel(sigma=jnp.ones(3))
-        struct = jax.ShapeDtypeStruct((3, 100), jnp.float64)
-        x = jax.random.normal(jax.random.key(0), (3, 100))
-        assert_allclose(model.operator(struct)(x), x, rtol=1e-12)
-        assert_allclose(model.inverse_operator(struct)(x), x, rtol=1e-12)
-
 
 # ---------------------------------------------------------------------------
 # AtmosphericNoiseModel


### PR DESCRIPTION
## Motivation

There is currently no way to turn off noise weighting in the mapmaking pipeline. In some scenarios — such as debugging, unit testing, or running on simulated data with uniform noise — the inverse noise matrix should simply be the identity (N⁻¹ = I). Previously, the only workaround was to manually construct a `WhiteNoiseModel` with unit sigma outside the pipeline, which required bypassing the standard configuration flow.

## Changes

This PR adds an `identity` flag to `NoiseConfig` that, when set to `True`, replaces the inverse noise covariance with the identity matrix. The flag is respected across both mapmaker APIs (`MapMaker` single-observation and `MultiObservationMapMaker` multi-observation) and is fully serializable via YAML.

### Implementation details

- **`config.py`**: Added `identity: bool = False` to `NoiseConfig`. Defaults to `False`, preserving existing behavior. Serializes as `noise.identity: true` in YAML.
- **`noise.py`**: Added `WhiteNoiseModel.to_white_noise_model()` returning `self`, which was missing and is required by `ObservationModel.white_noise_W()` when the noise model is a `WhiteNoiseModel`.
- **`_model.py`**: `_noise_model()` short-circuits when `identity=True`, creating a `WhiteNoiseModel(sigma=ones)` from the TOD structure without fitting or loading any noise data.
- **`mapmaker.py`**: Four targeted changes — (1) `build_model()` skips requesting noise data fields when identity, (2) `get_or_fit_noise_model()` returns a unit-sigma model immediately, (3) `MLMapmaker` bypasses the `SymmetricBandToeplitzOperator` type check that would otherwise reject the diagonal operator, (4) all four mapmaker classes skip writing the `noise_fit` output since there is no meaningful fit to report.

### Usage

In a YAML config file:

```yaml
noise:
  identity: true
```

Or in code:

```python
config = MapMakingConfig(noise=NoiseConfig(identity=True))
```

## Tests

- **`test_noise.py`** — `WhiteNoiseModel.to_white_noise_model()` returns self; sigma=1 model operators act as identity on random input.
- **`test_model.py`** — `_noise_model` creates unit-sigma `WhiteNoiseModel` when identity; forward and inverse operators are identity; works without noise data fields; YAML round-trip preserves the flag; default is `False`.
- **`test_mapmaker.py`** — End-to-end integration: `build_model()` produces all-ones noise models and `run()` completes successfully with identity noise (parametrized over interface, Stokes type, and landscape type).

All existing tests pass without modification.
