### PR TITLE
Support more eigenspectrum targeting options in 'lanczos_tr' 

### DIFF
--- a/src/furax/linalg/_lanczos.py
+++ b/src/furax/linalg/_lanczos.py
@@ -1,7 +1,7 @@
 """Lanczos eigenvalue solver for PyTree-aware linear operators."""
 
 from functools import reduce
-from typing import NamedTuple
+from typing import Literal, NamedTuple, TypeAlias, get_args
 
 import jax
 import jax.numpy as jnp
@@ -10,6 +10,8 @@ from jaxtyping import Float, Num, PyTree
 
 from furax import tree
 from furax.core import AbstractLinearOperator
+
+LanczosWhich: TypeAlias = Literal['LM', 'SM', 'LA', 'SA', 'BE']
 
 
 def _block_zeros_like(x: PyTree, k: int) -> PyTree:
@@ -353,7 +355,7 @@ def lanczos_tr(
     *,
     k: int = 20,
     m: int | None = None,
-    which: str = 'smallest',
+    which: LanczosWhich = 'LM',
     max_restarts: int = 300,
     tol: float = 1e-10,
 ) -> LanczosResult:
@@ -370,6 +372,19 @@ def lanczos_tr(
     Uses full reorthogonalization throughout.  No locking: all k pairs are
     recomputed at every restart regardless of convergence status.
 
+    Note:
+        ``residual_norms`` is the cheap bound, not the true residual.  Exactly
+        ``0`` means "converged below the detectable coupling", not zero error.
+
+    Note:
+        Lanczos converges fastest to *extremal* eigenvalues; interior ones
+        (near the middle of the spectrum) converge slowly.  This makes ``which``
+        targets that select interior pairs hard: ``'SM'`` for an indefinite
+        operator picks eigenvalues closest to zero, which are interior, and
+        restarts alone will not converge them unless ``m`` is a large fraction
+        of ``n`` (no shift-invert is implemented).  ``'LM'``, ``'LA'``, ``'SA'``
+        and the two ends of ``'BE'`` are extremal and converge with small ``m``.
+
     Args:
         A: A Hermitian linear operator.
         v0: Initial vector for the Krylov subspace.
@@ -377,9 +392,12 @@ def lanczos_tr(
         m: Size of the Krylov subspace.  Must be > k.
             Defaults to min(2*k, n).
         which: Which k eigenpairs to target.  One of:
-            - 'smallest' (default): k smallest eigenvalues.
-            - 'largest': k largest eigenvalues.
-            - 'best': k Ritz pairs with the smallest residual norms.
+            - 'LM' (default): k largest magnitude (|λ|).
+            - 'SM': k smallest magnitude (|λ|).
+            - 'LA': k largest algebraic.
+            - 'SA': k smallest algebraic.
+            - 'BE': half (k//2) from each end of the spectrum; for odd k the
+              extra pair comes from the high (largest algebraic) end.
         max_restarts: Maximum number of restart cycles.
         tol: Convergence tolerance on Lanczos residual bounds.
 
@@ -395,24 +413,30 @@ def lanczos_tr(
         >>> d = jnp.array([1., 2., 3., 4., 5.])
         >>> A = DiagonalOperator(d, in_structure=as_structure(d))
         >>> v0 = normal_like(as_structure(d), jax.random.PRNGKey(0))
-        >>> result = lanczos_tr(A, v0, k=2, which='smallest')
+        >>> result = lanczos_tr(A, v0, k=2, which='SA')
         >>> result.eigenvalues  # Should be approximately [1, 2]
         Array([1., 2.], dtype=float32)
     """
-    if which not in ('smallest', 'largest', 'best'):
-        raise ValueError(f"which must be 'smallest', 'largest', or 'best', got {which!r}")
+    if which not in get_args(LanczosWhich):
+        raise ValueError(f'which must be one of {get_args(LanczosWhich)}, got {which!r}')
     m = m or _default_m(A, k)
     if m <= k:
         raise ValueError(f'm ({m}) must be > k ({k})')
 
-    def _select_wanted(theta, beta_last, S):  # type: ignore[no-untyped-def]
-        if which == 'smallest':
-            sorted_idx = jnp.argsort(theta)
-        elif which == 'largest':
+    def _select_wanted(theta):  # type: ignore[no-untyped-def]
+        if which == 'LM':  # largest magnitude
+            sorted_idx = jnp.argsort(-jnp.abs(theta))
+        elif which == 'SM':  # smallest magnitude
+            sorted_idx = jnp.argsort(jnp.abs(theta))
+        elif which == 'LA':  # largest algebraic
             sorted_idx = jnp.argsort(-theta)
-        else:  # 'best'
-            ritz_res = jnp.abs(beta_last) * jnp.abs(S[-1, :])
-            sorted_idx = jnp.argsort(ritz_res)
+        elif which == 'SA':  # smallest algebraic
+            sorted_idx = jnp.argsort(theta)
+        else:  # 'BE': half from each end of the spectrum
+            sorted_idx = jnp.argsort(theta)
+            n_low = k // 2
+            n_high = k - n_low
+            return jnp.concatenate([sorted_idx[:n_low], sorted_idx[-n_high:]])
         return sorted_idx[:k]
 
     def _check_converged(beta_last, S, wanted_idx):  # type: ignore[no-untyped-def]
@@ -426,7 +450,7 @@ def lanczos_tr(
     # Initial m-step factorization
     alpha, beta, V, beta_last, v_last = lanczos_tridiag(A, v0, m)
     theta, S = jax.scipy.linalg.eigh_tridiagonal(alpha, beta, eigvals_only=False)
-    wanted_idx = _select_wanted(theta, beta_last, S)
+    wanted_idx = _select_wanted(theta)
     init_converged = _check_converged(beta_last, S, wanted_idx)
 
     def cond_fn(state):  # type: ignore[no-untyped-def]
@@ -445,7 +469,7 @@ def lanczos_tr(
         H = _build_bordered_tridiag(theta_k, h, alpha_ext, beta_ext, k, m)
         theta, S = jnp.linalg.eigh(H)  # H S = S diag(θ)
 
-        wanted_idx = _select_wanted(theta, beta_last, S)
+        wanted_idx = _select_wanted(theta)
         converged = _check_converged(beta_last, S, wanted_idx)
 
         return V, beta_last, v_last, iteration + 1, converged, theta, S, wanted_idx

--- a/src/furax/linalg/low_rank.py
+++ b/src/furax/linalg/low_rank.py
@@ -32,7 +32,7 @@ def low_rank(
     rank: int,
     key: PRNGKeyArray,
     *,
-    method: LowRankMethod = 'lanczos',
+    method: LowRankMethod = 'lanczos_tr',
     **kwargs: Any,
 ) -> LowRankTerms:
     """Compute a low-rank approximation of a Hermitian operator.
@@ -40,13 +40,21 @@ def low_rank(
     The approximation is of the form A ≈ U @ diag(S) @ U^T, where U contains
     the k eigenvectors and S contains the corresponding eigenvalues.
 
+    Two solvers are available via ``method``:
+
+    - 'lanczos': single-shot m-step Lanczos. Builds one Krylov subspace and returns the k
+      best-converged Ritz pairs by residual norm.
+      Extra kwargs: ``m``.
+    - 'lanczos_tr' (default): thick-restart Lanczos. Restarts until convergence and targets
+      specific eigenpairs via ``which`` ('LM', 'SM', 'LA', 'SA', 'BE'; default 'LM').
+      Extra kwargs: ``m``, ``which``, ``max_restarts``, ``tol``.
+
     Args:
         A: A Hermitian linear operator.
         rank: Number of eigenvalues/eigenvectors to compute.
         key: Random key for initialization of the eigenvalue solver.
-        method: Eigenvalue solver to use: 'lanczos' or 'lanczos_tr'.
-        **kwargs: Additional keyword arguments passed to the solver
-            (e.g., m, max_restarts, tol for lanczos_tr).
+        method: Eigenvalue solver to use (see above). Defaults to 'lanczos_tr'.
+        **kwargs: Additional keyword arguments passed to the selected solver.
 
     Returns:
         LowRankTerms containing eigenvalues and eigenvectors.
@@ -59,8 +67,8 @@ def low_rank(
         >>> d = jnp.array([1., 2., 3., 4., 5.])
         >>> A = DiagonalOperator(d, in_structure=as_structure(d))
         >>> terms = low_rank(A, rank=2, key=jax.random.PRNGKey(0), method='lanczos_tr')
-        >>> terms.eigenvalues  # Should be approximately [1, 2]
-        Array([1., 2.], dtype=float32)
+        >>> terms.eigenvalues  # Should be approximately [4, 5] (which='LM' by default)
+        Array([4., 5.], dtype=float32)
     """
     solvers = {'lanczos': lanczos_eigh, 'lanczos_tr': lanczos_tr}
     if method not in solvers:

--- a/tests/linalg/test_lanczos.py
+++ b/tests/linalg/test_lanczos.py
@@ -10,15 +10,17 @@ from furax.linalg._lanczos import lanczos_eigh, lanczos_tr, lanczos_tridiag
 from furax.tree import as_structure, normal_like
 
 
-def _random_pd_operator(n: int, key: jax.Array, dtype=None):
-    """Random positive definite operator of size n.
+def _random_hermitian_operator(n: int, key: jax.Array, dtype=None, *, pd=False):
+    """Random Hermitian operator of size n.
 
-    Pass a complex dtype for a Hermitian operator, or None for real SPD.
-    Returns (A, v0, eigenvalues) where eigenvalues are sorted ascending.
+    Returns (A, v0, eigenvalues) with eigenvalues sorted ascending.
     """
     key_mat, key_v0 = jax.random.split(key)
     B = jax.random.normal(key_mat, (n, n), dtype=dtype)
-    mat = B @ B.conj().T + n * jnp.eye(n, dtype=B.dtype)
+    if pd:
+        mat = B @ B.conj().T + n * jnp.eye(n, dtype=B.dtype)
+    else:
+        mat = (B + B.conj().T) / 2
     eigenvalues = jnp.linalg.eigvalsh(mat)
     v0 = jax.random.normal(key_v0, (n,), dtype=dtype)
     A = DenseBlockDiagonalOperator(mat, in_structure=as_structure(v0))
@@ -30,13 +32,13 @@ class TestLanczosTridiag:
 
     def test_lanczos_tridiag_orthonormal_vectors(self):
         """Lanczos basis is orthonormal for a random SPD operator with m < n."""
-        A, v0, _ = _random_pd_operator(30, jax.random.key(0))
+        A, v0, _ = _random_hermitian_operator(30, jax.random.key(0), pd=True)
         _, _, V, _, _ = lanczos_tridiag(A, v0, m=12)
         assert_allclose(V @ V.T, jnp.eye(12), atol=1e-10)
 
     def test_lanczos_tridiag_eigenvalue_relation(self):
         """Tridiagonal T has same eigenvalues as A when Krylov space is full (m == n)."""
-        A, v0, true_eigenvalues = _random_pd_operator(15, jax.random.key(1))
+        A, v0, true_eigenvalues = _random_hermitian_operator(15, jax.random.key(1), pd=True)
         alpha, beta, _, _, _ = lanczos_tridiag(A, v0, m=15)
         eigenvalues = jax.scipy.linalg.eigh_tridiagonal(alpha, beta, eigvals_only=True)
         assert_allclose(eigenvalues, true_eigenvalues, atol=1e-10)
@@ -47,7 +49,7 @@ class TestLanczosEigh:
 
     def test_lanczos_eigh_eigenvalues(self):
         """lanczos_eigh returns accurate eigenvalues when Krylov space is full (m == n)."""
-        A, v0, true_eigenvalues = _random_pd_operator(15, jax.random.key(0))
+        A, v0, true_eigenvalues = _random_hermitian_operator(15, jax.random.key(0), pd=True)
         result = lanczos_eigh(A, v0, k=5, m=15)
 
         min_dist = jnp.min(jnp.abs(result.eigenvalues[:, None] - true_eigenvalues[None, :]), axis=1)
@@ -72,7 +74,7 @@ class TestLanczosEigh:
 
     def test_lanczos_eigenvectors_orthonormal(self):
         """Ritz vectors are orthonormal for a random SPD operator with m < n."""
-        A, v0, _ = _random_pd_operator(30, jax.random.key(7))
+        A, v0, _ = _random_hermitian_operator(30, jax.random.key(7), pd=True)
         result = lanczos_eigh(A, v0, k=4, m=12)
 
         G = result.eigenvectors @ result.eigenvectors.T
@@ -82,32 +84,53 @@ class TestLanczosEigh:
 class TestLanczosThickRestart:
     """Tests for the thick-restart Lanczos method."""
 
-    def test_tr_smallest_eigenvalues(self):
-        """TR finds k smallest eigenvalues of a random SPD operator."""
-        A, v0, true_eigenvalues = _random_pd_operator(20, jax.random.key(0))
-        result = lanczos_tr(A, v0, k=2, m=6, which='smallest')
+    def test_tr_smallest_algebraic(self):
+        """TR with which='SA' finds k smallest (algebraic) eigenvalues."""
+        A, v0, true_eigenvalues = _random_hermitian_operator(20, jax.random.key(0))
+        result = lanczos_tr(A, v0, k=2, m=8, which='SA')
         assert_allclose(result.eigenvalues, true_eigenvalues[:2], atol=1e-10)
 
-    def test_tr_largest_eigenvalues(self):
-        """TR finds k largest eigenvalues of a random SPD operator."""
-        A, v0, true_eigenvalues = _random_pd_operator(20, jax.random.key(0))
-        result = lanczos_tr(A, v0, k=2, m=6, which='largest')
+    def test_tr_largest_algebraic(self):
+        """TR with which='LA' finds k largest (algebraic) eigenvalues."""
+        A, v0, true_eigenvalues = _random_hermitian_operator(20, jax.random.key(0))
+        result = lanczos_tr(A, v0, k=2, m=8, which='LA')
         assert_allclose(result.eigenvalues, true_eigenvalues[-2:], atol=1e-10)
 
-    def test_tr_best_converges(self):
-        """TR with which='best' converges to k valid eigenpairs."""
-        A, v0, true_eigenvalues = _random_pd_operator(20, jax.random.key(42))
-        tol = 1e-6
+    def test_tr_largest_magnitude(self):
+        """TR with which='LM' finds k largest |λ| (differs from LA for indefinite A)."""
+        A, v0, true_eigenvalues = _random_hermitian_operator(20, jax.random.key(0))
+        result = lanczos_tr(A, v0, k=2, m=8, which='LM')
+        expected = jnp.sort(true_eigenvalues[jnp.argsort(jnp.abs(true_eigenvalues))[-2:]])
+        assert_allclose(jnp.sort(result.eigenvalues), expected, atol=1e-10)
 
-        result = lanczos_tr(A, v0, k=3, m=8, tol=tol, which='best')
+    def test_tr_both_ends(self):
+        """TR with which='BE' returns half from each end of the spectrum."""
+        A, v0, true_eigenvalues = _random_hermitian_operator(20, jax.random.key(42))
+        result = lanczos_tr(A, v0, k=4, m=10, which='BE')
+        expected = jnp.concatenate([true_eigenvalues[:2], true_eigenvalues[-2:]])
+        assert_allclose(result.eigenvalues, expected, atol=1e-10)
 
-        assert jnp.all(result.residual_norms < tol)
-        min_dist = jnp.min(jnp.abs(result.eigenvalues[:, None] - true_eigenvalues[None, :]), axis=1)
-        assert_allclose(min_dist, jnp.zeros(3), atol=1e-10)
+    def test_tr_smallest_magnitude(self):
+        """TR with which='SM' targets smallest |λ|.
+
+        Smallest-magnitude eigenvalues are interior, which plain Lanczos resolves
+        slowly, so this uses a diagonal operator (Lanczos is near-exact on it).
+        """
+        d = jnp.array([-5.0, -1.0, 0.5, 3.0, 8.0, -7.0])
+        A = DiagonalOperator(d, in_structure=as_structure(d))
+        v0 = normal_like(as_structure(d), jax.random.key(0))
+        result = lanczos_tr(A, v0, k=2, m=5, which='SM', tol=1e-10)
+        assert_allclose(jnp.sort(result.eigenvalues), jnp.array([-1.0, 0.5]), atol=1e-10)
+
+    def test_tr_invalid_which(self):
+        """TR raises on an unknown which value."""
+        A, v0, _ = _random_hermitian_operator(5, jax.random.key(0), pd=True)
+        with pytest.raises(ValueError, match='which must be one of'):
+            lanczos_tr(A, v0, k=2, m=4, which='smallest')
 
     def test_tr_eigenvectors_orthonormal(self):
         """TR Ritz vectors are orthonormal for a random SPD operator with m < n."""
-        A, v0, _ = _random_pd_operator(30, jax.random.key(0))
+        A, v0, _ = _random_hermitian_operator(30, jax.random.key(0), pd=True)
         result = lanczos_tr(A, v0, k=3, m=8)
 
         G = result.eigenvectors @ result.eigenvectors.T
@@ -139,7 +162,7 @@ class TestLanczosThickRestart:
 
     def test_tr_requires_m_greater_than_k(self):
         """TR raises when m <= k."""
-        A, v0, _ = _random_pd_operator(5, jax.random.key(0))
+        A, v0, _ = _random_hermitian_operator(5, jax.random.key(0), pd=True)
 
         with pytest.raises(ValueError, match='m .* must be > k'):
             lanczos_tr(A, v0, k=5, m=5)
@@ -150,20 +173,22 @@ class TestLanczosComplexHermitian:
 
     def test_tridiag_orthonormal_basis(self):
         """Lanczos basis is orthonormal for a complex Hermitian operator."""
-        A, v0, _ = _random_pd_operator(20, jax.random.key(0), dtype=jnp.complex128)
+        A, v0, _ = _random_hermitian_operator(20, jax.random.key(0), dtype=jnp.complex128, pd=True)
         _, _, V, _, _ = lanczos_tridiag(A, v0, m=10)
         assert_allclose(V @ V.conj().T, jnp.eye(10), atol=1e-10)
 
     def test_tridiag_real_alpha_beta(self):
         """Tridiagonal coefficients are real for a complex Hermitian operator."""
-        A, v0, _ = _random_pd_operator(20, jax.random.key(1), dtype=jnp.complex128)
+        A, v0, _ = _random_hermitian_operator(20, jax.random.key(1), dtype=jnp.complex128, pd=True)
         alpha, beta, _, _, _ = lanczos_tridiag(A, v0, m=10)
         assert not jnp.iscomplexobj(alpha)
         assert not jnp.iscomplexobj(beta)
 
     def test_eigh_eigenvalues(self):
         """lanczos_eigh returns accurate eigenvalues for a complex Hermitian operator."""
-        A, v0, true_eigenvalues = _random_pd_operator(15, jax.random.key(2), dtype=jnp.complex128)
+        A, v0, true_eigenvalues = _random_hermitian_operator(
+            15, jax.random.key(2), dtype=jnp.complex128, pd=True
+        )
         result = lanczos_eigh(A, v0, k=5, m=15)
 
         min_dist = jnp.min(jnp.abs(result.eigenvalues[:, None] - true_eigenvalues[None, :]), axis=1)
@@ -171,7 +196,7 @@ class TestLanczosComplexHermitian:
 
     def test_eigh_eigenvectors_orthonormal(self):
         """Ritz vectors are orthonormal for a complex Hermitian operator."""
-        A, v0, _ = _random_pd_operator(20, jax.random.key(3), dtype=jnp.complex128)
+        A, v0, _ = _random_hermitian_operator(20, jax.random.key(3), dtype=jnp.complex128, pd=True)
         result = lanczos_eigh(A, v0, k=4, m=12)
 
         G = result.eigenvectors @ result.eigenvectors.conj().T
@@ -179,19 +204,23 @@ class TestLanczosComplexHermitian:
 
     def test_tr_smallest_eigenvalues(self):
         """TR finds k smallest eigenvalues of a complex Hermitian operator."""
-        A, v0, true_eigenvalues = _random_pd_operator(20, jax.random.key(4), dtype=jnp.complex128)
-        result = lanczos_tr(A, v0, k=2, m=6, which='smallest')
+        A, v0, true_eigenvalues = _random_hermitian_operator(
+            20, jax.random.key(4), dtype=jnp.complex128
+        )
+        result = lanczos_tr(A, v0, k=2, m=8, which='SA')
         assert_allclose(result.eigenvalues, true_eigenvalues[:2], atol=1e-10)
 
     def test_tr_largest_eigenvalues(self):
         """TR finds k largest eigenvalues of a complex Hermitian operator."""
-        A, v0, true_eigenvalues = _random_pd_operator(20, jax.random.key(5), dtype=jnp.complex128)
-        result = lanczos_tr(A, v0, k=2, m=6, which='largest')
+        A, v0, true_eigenvalues = _random_hermitian_operator(
+            20, jax.random.key(5), dtype=jnp.complex128
+        )
+        result = lanczos_tr(A, v0, k=2, m=8, which='LA')
         assert_allclose(result.eigenvalues, true_eigenvalues[-2:], atol=1e-10)
 
     def test_tr_eigenvectors_orthonormal(self):
         """TR Ritz vectors are orthonormal for a complex Hermitian operator."""
-        A, v0, _ = _random_pd_operator(20, jax.random.key(6), dtype=jnp.complex128)
+        A, v0, _ = _random_hermitian_operator(20, jax.random.key(6), dtype=jnp.complex128, pd=True)
         result = lanczos_tr(A, v0, k=3, m=8)
 
         G = result.eigenvectors @ result.eigenvectors.conj().T


### PR DESCRIPTION
Matches the options offered by scipy: https://docs.scipy.org/doc/scipy/reference/generated/scipy.sparse.linalg.eigsh.html (note that no shift-invert is implemented so interior eigenvalues, `which='SM'`, will struggle to converge).

Also default to TRLanczos method in `low_rank` since it is generally much more reliable.