### PR TITLE
Refactor noise weighting configuration

### DIFF
--- a/src/furax/mapmaking/_model.py
+++ b/src/furax/mapmaking/_model.py
@@ -11,7 +11,7 @@ from furax.core import BlockDiagonalOperator, CompositionOperator, IndexOperator
 from furax.obs.landscapes import StokesLandscape
 
 from .acquisition import build_acquisition_operator
-from .config import MapMakingConfig, Methods
+from .config import MapMakingConfig, Methods, NoiseSource, WeightingMode
 from .noise import AtmosphericNoiseModel, NoiseModel, WhiteNoiseModel
 from .templates import ATOPProjectionOperator
 
@@ -63,7 +63,11 @@ class ObservationModel:
         )
         noise_model, sample_rate = _noise_model(data, config, tod_structure=H.out_structure)
         W = _noise_operator(
-            noise_model, H.out_structure, sample_rate, config.noise.correlation_length, inverse=True
+            noise_model,
+            H.out_structure,
+            sample_rate,
+            config.weighting.correlation_length,
+            inverse=True,
         )
         if F_T := _template_deprojector(config, H.out_structure):
             W = W @ F_T
@@ -145,26 +149,27 @@ def _noise_model(
 ) -> tuple[PyTree[NoiseModel], Array]:
     """Compute the noise model and sample rate for a single observation block."""
     fs = _sample_rate(data['timestamps'])
-    if config.noise.identity:
+    if config.weighting.mode == WeightingMode.IDENTITY:
         if tod_structure is None:
-            raise ValueError('tod_structure is required when config.noise.identity is True')
+            raise ValueError('tod_structure is required when config.weighting.mode is IDENTITY')
         noise_model = jax.tree.map(
             lambda s: WhiteNoiseModel(sigma=jnp.ones(s.shape[0], dtype=s.dtype)),
             tod_structure,
         )
         return noise_model, fs
-    if config.noise.fit_from_data:
+    if config.weighting.source == NoiseSource.FIT:
+        fit_config = config.weighting.fitting
         noise_model_class = WhiteNoiseModel if config.binned else AtmosphericNoiseModel
         fhwp = _hwp_frequency(data['timestamps'], data['hwp_angles'])
 
         def _compute_Pxx_and_fit(tod):  # type: ignore[no-untyped-def]
-            f, Pxx = jax.scipy.signal.welch(tod, fs=fs, nperseg=config.noise.fitting.nperseg)
+            f, Pxx = jax.scipy.signal.welch(tod, fs=fs, nperseg=fit_config.nperseg)
             return noise_model_class.fit_psd_model(
                 f,
                 Pxx,
                 sample_rate=fs,
                 hwp_frequency=fhwp,
-                config=config.noise.fitting,
+                config=fit_config,
             )
 
         noise_model = jax.tree.map(_compute_Pxx_and_fit, data['sample_data'])

--- a/src/furax/mapmaking/config.py
+++ b/src/furax/mapmaking/config.py
@@ -25,6 +25,17 @@ class Methods(Enum):
     ATOP = 'ATOP'
 
 
+class WeightingMode(Enum):
+    IDENTITY = 'identity'  # identity inverse-noise, no weighting
+    DIAGONAL = 'diagonal'  # white (diagonal) weighting
+    TOEPLITZ = 'toeplitz'  # atmospheric 1/f, banded Toeplitz weighting
+
+
+class NoiseSource(Enum):
+    FIT = 'fit'  # fit the noise model from the TOD PSD
+    PRECOMPUTED = 'precomputed'  # read precomputed noise parameters from the data pipeline
+
+
 @dataclass
 class SolverConfig:
     rtol: float = 1e-6
@@ -69,33 +80,39 @@ class NoiseFitConfig:
 
 
 @dataclass
-class NoiseConfig:
-    """Configuration for noise modelling.
+class WeightingConfig:
+    """Configuration for the inverse-noise / weighting matrix used in mapmaking.
 
-    ``fit_from_data`` controls where the noise model comes from:
+    ``mode`` selects the structure of the inverse-noise matrix:
 
-    - ``True`` (default): fit a noise model directly from the TOD power spectral density.
-    - ``False``: load precomputed noise parameters from the data pipeline.
+    - ``IDENTITY``: identity matrix (no weighting).
+    - ``DIAGONAL``: diagonal white-noise weighting (default).
+    - ``TOEPLITZ``: banded Toeplitz weighting for atmospheric (1/f) noise.
+
+    ``source`` selects where the noise model comes from: ``FIT`` (default) fits it from the
+    TOD power spectral density using ``fitting``; ``PRECOMPUTED`` reads noise parameters from
+    the data pipeline (``fitting`` is then ignored).
 
     ``correlation_length`` sets the Toeplitz bandwidth (in samples) of the inverse-noise
-    operator.  It is only used by the atmospheric (1/f) noise model and is ignored when
-    ``white`` is True.
+    operator.  It is only used in ``TOEPLITZ`` mode and is ignored otherwise.
     """
 
-    white: bool = True
-    """Use a white (diagonal) noise model.  Set to False for the atmospheric (1/f) model."""
+    mode: WeightingMode = WeightingMode.DIAGONAL
+    """Inverse-noise weighting matrix structure."""
 
-    identity: bool = False
-    """Use an identity inverse-noise matrix (no noise weighting)."""
-
-    fit_from_data: bool = True
-    """Fit the noise model from the TOD PSD (True) or load it from the data pipeline (False)."""
+    source: NoiseSource = NoiseSource.FIT
+    """Where the noise model comes from: fit from the TOD PSD or read precomputed parameters."""
 
     correlation_length: int = 1_000
-    """Toeplitz bandwidth in samples.  Only relevant for the atmospheric (1/f) noise model."""
+    """Toeplitz bandwidth in samples.  Only relevant in ``TOEPLITZ`` mode."""
 
     fitting: NoiseFitConfig = field(default_factory=NoiseFitConfig)
-    """Options controlling PSD estimation and model fitting."""
+    """Options for fitting the noise PSD to the data.  Ignored when ``source`` is PRECOMPUTED."""
+
+    @property
+    def diagonal_matrix(self) -> bool:
+        """True when the inverse-noise matrix is diagonal (identity or white)."""
+        return self.mode != WeightingMode.TOEPLITZ
 
 
 @dataclass
@@ -352,7 +369,7 @@ class MapMakingConfig:
     cond_cut: float = 1e-2
     double_precision: bool = True
     pointing: PointingConfig = field(default_factory=PointingConfig)
-    noise: NoiseConfig = field(default_factory=NoiseConfig)
+    weighting: WeightingConfig = field(default_factory=WeightingConfig)
     debug: bool = True
     solver: SolverConfig = field(default_factory=SolverConfig)
     gaps: GapsConfig = field(default_factory=GapsConfig)
@@ -385,14 +402,14 @@ class MapMakingConfig:
         if method == Methods.BINNED:
             return cls(
                 method=Methods.BINNED,
-                noise=NoiseConfig(white=True),
+                weighting=WeightingConfig(),
                 templates=None,
             )
         elif method == Methods.MAXL:
             return cls(
                 method=Methods.MAXL,
-                noise=NoiseConfig(
-                    white=False,
+                weighting=WeightingConfig(
+                    mode=WeightingMode.TOEPLITZ,
                     correlation_length=1_000,
                 ),
                 solver=SolverConfig(
@@ -405,7 +422,7 @@ class MapMakingConfig:
         elif method == Methods.TWOSTEP:
             return cls(
                 method=Methods.TWOSTEP,
-                noise=NoiseConfig(white=True),
+                weighting=WeightingConfig(),
                 solver=SolverConfig(
                     rtol=1e-6,
                     atol=0,
@@ -418,7 +435,7 @@ class MapMakingConfig:
         elif method == Methods.ATOP:
             return cls(
                 method=Methods.ATOP,
-                noise=NoiseConfig(white=True),
+                weighting=WeightingConfig(),
                 solver=SolverConfig(
                     rtol=1e-6,
                     atol=0,
@@ -462,7 +479,7 @@ class MapMakingConfig:
 
     @property
     def binned(self) -> bool:
-        return self.noise.white
+        return self.weighting.diagonal_matrix
 
     @property
     def demodulated(self) -> bool:

--- a/src/furax/mapmaking/mapmaker.py
+++ b/src/furax/mapmaking/mapmaker.py
@@ -52,7 +52,15 @@ from ._model import ObservationModel, pad_model
 from ._observation import AbstractGroundObservation, AbstractLazyObservation
 from ._reader import ObservationReader
 from ._scan_blocks import ScanBlockColumnOperator, ScanBlockDiagonalOperator
-from .config import GapFillingConfig, LandscapeConfig, MapMakingConfig, Methods, WCSConfig
+from .config import (
+    GapFillingConfig,
+    LandscapeConfig,
+    MapMakingConfig,
+    Methods,
+    NoiseSource,
+    WCSConfig,
+    WeightingMode,
+)
 from .gap_filling import GapFillingOperator
 from .noise import AtmosphericNoiseModel, NoiseModel, WhiteNoiseModel
 from .preconditioner import BJPreconditioner
@@ -83,7 +91,7 @@ class MultiObservationMapMaker(Generic[T]):
         """Validate and adjust config for method-specific compatibility."""
         if self.config.method == Methods.ATOP:
             if not self.config.binned:
-                raise ValueError('ATOP requires a white noise model (noise.white=True).')
+                raise ValueError('ATOP requires diagonal weighting (weighting.mode=DIAGONAL).')
             if 'I' in (stokes := self.config.landscape.stokes):
                 if stokes != 'IQU':
                     raise ValueError(
@@ -251,8 +259,8 @@ class MultiObservationMapMaker(Generic[T]):
             required_fields.append('hwp_angles')
         if self.config.scanning_mask:
             required_fields.append('valid_scanning_masks')
-        if not self.config.noise.identity:
-            if self.config.noise.fit_from_data:
+        if self.config.weighting.mode != WeightingMode.IDENTITY:
+            if self.config.weighting.source == NoiseSource.FIT:
                 required_fields.extend(['sample_data', 'hwp_angles'])
             else:
                 required_fields.append('noise_model_fits')
@@ -283,7 +291,7 @@ class MultiObservationMapMaker(Generic[T]):
             read_indices,
             reader,
             fill_gaps=fill_gaps,
-            correlation_length=config.noise.correlation_length if fill_gaps else None,
+            correlation_length=config.weighting.correlation_length if fill_gaps else None,
             gap_filling_params=config.gaps.fill_options if fill_gaps else None,
         )
 
@@ -738,12 +746,12 @@ class MapMaker:
         """
         config = self.config
 
-        if config.noise.identity:
+        if config.weighting.mode == WeightingMode.IDENTITY:
             return WhiteNoiseModel(sigma=jnp.ones(observation.n_detectors, dtype=config.dtype))
 
         Model = WhiteNoiseModel if config.binned else AtmosphericNoiseModel
 
-        if not config.noise.fit_from_data:
+        if config.weighting.source == NoiseSource.PRECOMPUTED:
             # Load the noise model from data if available
             noise_model = observation.get_noise_model()
             if noise_model:
@@ -757,7 +765,9 @@ class MapMaker:
         # Otherwise, fit the noise model from data
         self.logger.info('Fitting noise model from data')
         f, Pxx = jax.scipy.signal.welch(
-            observation.get_tods(), fs=observation.sample_rate, nperseg=config.noise.fitting.nperseg
+            observation.get_tods(),
+            fs=observation.sample_rate,
+            nperseg=config.weighting.fitting.nperseg,
         )
         hwp_frequency = observation.get_hwp_frequency()
         return Model.fit_psd_model(
@@ -765,7 +775,7 @@ class MapMaker:
             Pxx,
             sample_rate=jnp.array(observation.sample_rate),
             hwp_frequency=hwp_frequency,
-            config=config.noise.fitting,
+            config=config.weighting.fitting,
         )
 
     def get_pixel_selector(
@@ -969,7 +979,10 @@ class BinnedMapMaker(MapMaker):
             output['wcs'] = landscape.to_wcs()
         elif isinstance(landscape, AstropyWCSLandscape):
             output['wcs'] = landscape.wcs
-        if config.noise.fit_from_data and not config.noise.identity:
+        if (
+            config.weighting.source == NoiseSource.FIT
+            and config.weighting.mode != WeightingMode.IDENTITY
+        ):
             output['noise_fit'] = noise_model.to_array()  # type: ignore[assignment]
         if config.debug:
             proj_map = (masker.T @ acquisition)(res)
@@ -1018,17 +1031,17 @@ class MLMapmaker(MapMaker):
         inv_noise = noise_model.inverse_operator(
             data_struct,
             sample_rate=observation.sample_rate,
-            correlation_length=config.noise.correlation_length,
+            correlation_length=config.weighting.correlation_length,
         )
         noise = noise_model.operator(
             data_struct,
             sample_rate=observation.sample_rate,
-            correlation_length=config.noise.correlation_length,
+            correlation_length=config.weighting.correlation_length,
         )
         logger_info('Created noise and inverse noise covariance operators')
 
         # Approximate system matrix with diagonal noise covariance and full map pixels
-        if config.noise.identity:
+        if config.weighting.mode == WeightingMode.IDENTITY:
             diag_inv_noise = inv_noise
         elif isinstance(inv_noise, SymmetricBandToeplitzOperator):
             diag_inv_noise = DiagonalOperator(
@@ -1165,7 +1178,10 @@ class MLMapmaker(MapMaker):
             output['wcs'] = landscape.to_wcs()
         elif isinstance(landscape, AstropyWCSLandscape):
             output['wcs'] = landscape.wcs
-        if config.noise.fit_from_data and not config.noise.identity:
+        if (
+            config.weighting.source == NoiseSource.FIT
+            and config.weighting.mode != WeightingMode.IDENTITY
+        ):
             output['noise_fit'] = noise_model.to_array()
         if config.use_templates:
             for key in tmpl_ampl.keys():
@@ -1285,7 +1301,10 @@ class TwoStepMapmaker(MapMaker):
             output['wcs'] = landscape.to_wcs()
         elif isinstance(landscape, AstropyWCSLandscape):
             output['wcs'] = landscape.wcs
-        if config.noise.fit_from_data and not config.noise.identity:
+        if (
+            config.weighting.source == NoiseSource.FIT
+            and config.weighting.mode != WeightingMode.IDENTITY
+        ):
             output['noise_fit'] = noise_model.to_array()
         if config.debug:
             proj_map = (mp @ acquisition)(result_map)
@@ -1405,7 +1424,10 @@ class ATOPMapMaker(MapMaker):
         output = {'map': final_map, 'weights': blocks}
         if isinstance(landscape, AstropyWCSLandscape):
             output['wcs'] = landscape.wcs
-        if config.noise.fit_from_data and not config.noise.identity:
+        if (
+            config.weighting.source == NoiseSource.FIT
+            and config.weighting.mode != WeightingMode.IDENTITY
+        ):
             output['noise_fit'] = noise_model.to_array()
         if config.debug:
             proj_map = (mp @ acquisition)(result_map)

--- a/tests/mapmaking/test_mapmaker.py
+++ b/tests/mapmaking/test_mapmaker.py
@@ -16,12 +16,13 @@ from furax.mapmaking.config import (
     HealpixConfig,
     LandscapeConfig,
     Methods,
-    NoiseConfig,
     NoiseFitConfig,
     PointingConfig,
     SkyPatch,
     SotodlibConfig,
     WCSConfig,
+    WeightingConfig,
+    WeightingMode,
 )
 from furax.mapmaking.mapmaker import get_obs_distribution_to_process
 from furax.mapmaking.noise import WhiteNoiseModel
@@ -296,9 +297,8 @@ def _config(
         method=method,
         pointing=PointingConfig(on_the_fly=True, interpolation=interpolation),
         landscape=lc,
-        noise=NoiseConfig(
-            identity=identity_noise,
-            fit_from_data=True,
+        weighting=WeightingConfig(
+            mode=WeightingMode.IDENTITY if identity_noise else WeightingMode.DIAGONAL,
             fitting=NoiseFitConfig(nperseg=512),
         ),
         sotodlib=SotodlibConfig(demodulated=True) if demodulated else None,

--- a/tests/mapmaking/test_model.py
+++ b/tests/mapmaking/test_model.py
@@ -4,7 +4,7 @@ import pytest
 from numpy.testing import assert_allclose, assert_array_equal
 
 from furax.mapmaking._model import _noise_model, _noise_operator, _sample_mask
-from furax.mapmaking.config import MapMakingConfig, Methods, NoiseConfig
+from furax.mapmaking.config import MapMakingConfig, Methods, WeightingConfig, WeightingMode
 from furax.mapmaking.noise import WhiteNoiseModel
 
 
@@ -34,7 +34,7 @@ class TestIdentityNoise:
 
     @pytest.fixture
     def identity_config(self):
-        return MapMakingConfig(noise=NoiseConfig(identity=True))
+        return MapMakingConfig(weighting=WeightingConfig(mode=WeightingMode.IDENTITY))
 
     def test_noise_model_creates_unit_white_noise(self, identity_config, tod_structure):
         data = {'timestamps': jnp.linspace(0, 1, 200)}
@@ -58,12 +58,12 @@ class TestIdentityNoise:
             _noise_model(data, identity_config, tod_structure=None)
 
     def test_identity_config_yaml_round_trip(self):
-        config = MapMakingConfig(noise=NoiseConfig(identity=True))
+        config = MapMakingConfig(weighting=WeightingConfig(mode=WeightingMode.IDENTITY))
         yaml_str = config._to_yaml()
-        assert 'identity: true' in yaml_str
-        loaded = MapMakingConfig.load_dict({'noise': {'identity': True}})
-        assert loaded.noise.identity is True
+        assert 'mode: identity' in yaml_str
+        loaded = MapMakingConfig.load_dict({'weighting': {'mode': 'identity'}})
+        assert loaded.weighting.mode is WeightingMode.IDENTITY
 
-    def test_identity_false_by_default(self):
-        config = NoiseConfig()
-        assert config.identity is False
+    def test_diagonal_by_default(self):
+        config = WeightingConfig()
+        assert config.mode is WeightingMode.DIAGONAL


### PR DESCRIPTION
`NoiseConfig` described the inverse-noise/weighting matrix, not the noise model per se. I find it clearer to rename it to `WeightingConfig` and the associated configuration fields `noise -> weighting`.

In addition, I replaced the coupled booleans `white/identity` with a `WeightingMode` enum (identity/diagonal/toeplitz), and the `fit_from_data` boolean with a `NoiseSource` enum (fit/precomputed). I preferred that rather than making the fitting options optional because I expect us to use the defaults in most cases and I don't want to have to write `fitting: ...` in the YAML file if not necessary.

Example YAML migration
```yaml
# before
noise:
  white: false
  fit_from_data: false

# after
weighting:
  mode: toeplitz
  source: precomputed
```