### PR TITLE
Install `s2fft` from main repository

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,7 +46,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          uv pip install git+https://github.com/ArtemBasyrov/s2fft.git
+          uv pip install git+https://github.com/astro-informatics/s2fft.git
           uv pip install git+https://github.com/CMBSciPol/jax-healpy.git@implement-alm2map
           uv pip install .[dev,mapmaking,so,toast]
 


### PR DESCRIPTION
We don't need a fork since https://github.com/astro-informatics/s2fft/issues/379 is closed.