### PR TITLE
Split binary rules into composition/addition flavours

### DIFF
--- a/src/furax/core/_axes.py
+++ b/src/furax/core/_axes.py
@@ -8,7 +8,7 @@ from jax import numpy as jnp
 from jaxtyping import Inexact, PyTree
 
 from ._base import AbstractLinearOperator, IdentityOperator, TransposeOperator
-from .rules import AbstractBinaryRule, NoReduction
+from .rules import AbstractCompositionRule, NoReduction
 
 __all__ = [
     'MoveAxisOperator',
@@ -68,7 +68,7 @@ class MoveAxisOperator(AbstractLinearOperator):
     inverse = transpose
 
 
-class MoveAxisInverseRule(AbstractBinaryRule):
+class MoveAxisInverseRule(AbstractCompositionRule):
     """Binary rule for move_axis.T @ move_axis = I`.
 
     Note:
@@ -237,7 +237,7 @@ class ReshapeTransposeOperator(TransposeOperator):
         )
 
 
-class ReshapeInverseRule(AbstractBinaryRule):
+class ReshapeInverseRule(AbstractCompositionRule):
     """Binary rule for reshape.T @ reshape = I and reshape @ reshape.T = I`.
 
     Note:

--- a/src/furax/core/_base.py
+++ b/src/furax/core/_base.py
@@ -408,13 +408,12 @@ class AdditionOperator(AbstractLinearOperator):
         return functools.reduce(jnp.add, (operand.as_matrix() for operand in self.operand_leaves))
 
     def reduce(self) -> AbstractLinearOperator:
-        operands = self._tree_map(lambda operand: operand.reduce())
-        operand_leaves = jax.tree.leaves(
-            operands, is_leaf=lambda leaf: isinstance(leaf, AbstractLinearOperator)
-        )
-        if len(operand_leaves) == 1:
-            leaf: AbstractLinearOperator = operand_leaves[0]
-            return leaf
+        from .rules import AdditiveReductionRule
+
+        operands = [operand.reduce() for operand in self.operand_leaves]
+        operands = AdditiveReductionRule().apply(operands)
+        if len(operands) == 1:
+            return operands[0]
         return AdditionOperator(operands)
 
     @property

--- a/src/furax/core/_blocks.py
+++ b/src/furax/core/_blocks.py
@@ -12,7 +12,7 @@ from jaxtyping import Inexact, PyTree
 
 from ..tree import add
 from ._base import AbstractLinearOperator, AdditionOperator, IdentityOperator
-from .rules import AbstractBinaryRule
+from .rules import AbstractCompositionRule
 
 
 class AbstractBlockOperator(AbstractLinearOperator, ABC):
@@ -244,7 +244,7 @@ class BlockColumnOperator(AbstractBlockOperator):
         return jnp.vstack([op.as_matrix() for op in self.block_leaves])
 
 
-class AbstractBlockDiagonalRule(AbstractBinaryRule):
+class AbstractBlockDiagonalRule(AbstractCompositionRule):
     reduced_class: type[AbstractBlockOperator] | type[AdditionOperator]
 
     def apply(

--- a/src/furax/core/_indices.py
+++ b/src/furax/core/_indices.py
@@ -8,7 +8,7 @@ from jaxtyping import Bool, Inexact, Integer, PyTree
 
 from ._base import AbstractLinearOperator, IdentityOperator, TransposeOperator
 from ._diagonal import DiagonalOperator
-from .rules import AbstractBinaryRule, NoReduction
+from .rules import AbstractCompositionRule, NoReduction
 
 __all__ = ['IndexOperator']
 
@@ -156,7 +156,7 @@ class IndexOperator(AbstractLinearOperator):
         return axes
 
 
-class IndexTransposeRule(AbstractBinaryRule):
+class IndexTransposeRule(AbstractCompositionRule):
     """Binary rule for `index @ index.T = I`."""
 
     left_operator_class = IndexOperator
@@ -171,7 +171,7 @@ class IndexTransposeRule(AbstractBinaryRule):
         return []
 
 
-class TransposeIndexRule(AbstractBinaryRule):
+class TransposeIndexRule(AbstractCompositionRule):
     """Binary rule for `index.T @ index = I`."""
 
     left_operator_class = TransposeOperator

--- a/src/furax/core/_linear.py
+++ b/src/furax/core/_linear.py
@@ -2,7 +2,7 @@ from jax import Array
 from jaxtyping import Bool, PyTree
 
 from ._base import AbstractLinearOperator, TransposeOperator
-from .rules import AbstractBinaryRule
+from .rules import AbstractCompositionRule
 
 
 class PackOperator(AbstractLinearOperator):
@@ -20,7 +20,7 @@ class PackOperator(AbstractLinearOperator):
         return x[self.mask]
 
 
-class PackUnpackRule(AbstractBinaryRule):
+class PackUnpackRule(AbstractCompositionRule):
     """Binary rule for `pack @ pack.T = I`."""
 
     left_operator_class = PackOperator

--- a/src/furax/core/_mask.py
+++ b/src/furax/core/_mask.py
@@ -3,7 +3,7 @@ import jax.numpy as jnp
 from jaxtyping import Array, Bool, Inexact, PyTree, UInt8
 
 from ._base import AbstractLinearOperator, symmetric
-from .rules import AbstractBinaryRule
+from .rules import AbstractCompositionRule
 
 
 @symmetric
@@ -86,7 +86,7 @@ def _check_and_pack(
     return jnp.packbits(boolean_mask, axis=-1)
 
 
-class InverseBinaryRule(AbstractBinaryRule):
+class InverseBinaryRule(AbstractCompositionRule):
     """Binary rule for composition of MaskOperator's."""
 
     left_operator_class = MaskOperator

--- a/src/furax/core/_trees.py
+++ b/src/furax/core/_trees.py
@@ -9,7 +9,7 @@ from jaxtyping import Inexact, PyTree
 
 from ..tree import _dense_to_tree, _get_outer_treedef, _tree_to_dense, matmat, matvec
 from ._base import AbstractLinearOperator
-from .rules import AbstractBinaryRule
+from .rules import AbstractCompositionRule
 
 
 class TreeOperator(AbstractLinearOperator):
@@ -91,7 +91,7 @@ class TreeOperator(AbstractLinearOperator):
         return TreeOperator(tree, in_structure=self.out_structure)
 
 
-class TreeMultiplicationRule(AbstractBinaryRule):
+class TreeMultiplicationRule(AbstractCompositionRule):
     """Binary rule for `tree_left @ tree_right."""
 
     left_operator_class = TreeOperator

--- a/src/furax/core/rules.py
+++ b/src/furax/core/rules.py
@@ -76,7 +76,7 @@ class AlgebraicReductionRule(AbstractNaryRule):
         while index < len(operands) - 1:
             left, right = operands[index], operands[index + 1]
 
-            for rule in BINARY_RULE_REGISTRY:
+            for rule in COMPOSITION_RULE_REGISTRY:
                 try:
                     rule.check(left, right)
                     new_ops = rule.apply(left, right)
@@ -148,8 +148,49 @@ class IdentityRule(AbstractNaryRule):
         return [_ for _ in operands if not isinstance(_, IdentityOperator)]
 
 
+class AdditiveReductionRule(AbstractNaryRule):
+    """Pairwise reduction of the operands of an ``AdditionOperator``."""
+
+    def apply(self, operands: list[AbstractLinearOperator]) -> list[AbstractLinearOperator]:
+        # Addition is commutative and associative, so the operands are reduced by repeatedly
+        # fusing any pair for which an `AbstractAdditionRule` applies (trying both orders),
+        # until a fixed point is reached. Operands left unfused are returned as-is.
+        operands = list(operands)
+        changed = True
+        while changed and len(operands) > 1:
+            changed = False
+            for a in range(len(operands)):
+                for b in range(a + 1, len(operands)):
+                    fused = self._fuse(operands[a], operands[b])
+                    if fused is not None:
+                        operands = operands[:a] + fused + operands[a + 1 : b] + operands[b + 1 :]
+                        changed = True
+                        break
+                if changed:
+                    break
+        return operands
+
+    @staticmethod
+    def _fuse(
+        left: AbstractLinearOperator, right: AbstractLinearOperator
+    ) -> list[AbstractLinearOperator] | None:
+        for rule in ADDITION_RULE_REGISTRY:
+            for first, second in ((left, right), (right, left)):
+                try:
+                    rule.check(first, second)
+                    return rule.apply(first, second)
+                except NoReduction:
+                    continue
+        return None
+
+
 class AbstractBinaryRule(AbstractRule, ABC):
-    """A binary algebraic rule to reduce `op1 @ op2`."""
+    """A binary algebraic rule to reduce two operators.
+
+    Subclasses implement different flavours of reduction, e.g. `op1 @ op2` or `op1 + op2`.
+    """
+
+    registry: 'RuleRegistry[AbstractBinaryRule]'  # set by the flavour subclass
 
     operator_class: (
         type[AbstractLinearOperator] | tuple[type[AbstractLinearOperator], ...] | None
@@ -169,7 +210,7 @@ class AbstractBinaryRule(AbstractRule, ABC):
     def __init_subclass__(cls) -> None:
         if cls.__name__.startswith('Abstract'):
             return
-        BINARY_RULE_REGISTRY.register(cls())
+        cls.registry.register(cls())
         if (
             cls.operator_class is None
             and cls.left_operator_class is None
@@ -183,7 +224,8 @@ class AbstractBinaryRule(AbstractRule, ABC):
                     'specified in the binary rule.'
                 )
 
-    def check(self, left: AbstractLinearOperator, right: AbstractLinearOperator) -> None:
+    def _check_operands(self, left: AbstractLinearOperator, right: AbstractLinearOperator) -> None:
+        """Shared operand-class matching: raises :class:`NoReduction` if the rule does not apply."""
         if self.operator_class is not None:
             if not isinstance(left, self.operator_class) and not isinstance(
                 right, self.operator_class
@@ -197,22 +239,38 @@ class AbstractBinaryRule(AbstractRule, ABC):
             right, self.right_operator_class
         ):
             raise NoReduction
-        if self.left_operator_class is TransposeOperator and left.operator is not right:  # type: ignore[attr-defined]
-            raise NoReduction
-        if self.right_operator_class is TransposeOperator and right.operator is not left:  # type: ignore[attr-defined]
-            raise NoReduction
+
+    @abstractmethod
+    def check(self, left: AbstractLinearOperator, right: AbstractLinearOperator) -> None:
+        """Raises :class:`NoReduction` if the rule does not apply to ``(left, right)``."""
 
     @abstractmethod
     def apply(
         self, left: AbstractLinearOperator, right: AbstractLinearOperator
     ) -> list[AbstractLinearOperator]:
-        """Applies the algebraic rule to reduce the composition left @ right."""
+        """Applies the algebraic rule to reduce the binary combination of left and right."""
 
 
-BINARY_RULE_REGISTRY = RuleRegistry[AbstractBinaryRule]()
+# Registries of binary reduction rules
+COMPOSITION_RULE_REGISTRY = RuleRegistry[AbstractBinaryRule]()
+ADDITION_RULE_REGISTRY = RuleRegistry[AbstractBinaryRule]()
 
 
-class InverseBinaryRule(AbstractBinaryRule):
+class AbstractCompositionRule(AbstractBinaryRule):
+    """A binary rule to reduce a composition ``op1 @ op2``."""
+
+    registry = COMPOSITION_RULE_REGISTRY
+
+    def check(self, left: AbstractLinearOperator, right: AbstractLinearOperator) -> None:
+        self._check_operands(left, right)
+        # In addition to checking operands, handle the case of TransposeOperator
+        if self.left_operator_class is TransposeOperator and left.operator is not right:  # type: ignore[attr-defined]
+            raise NoReduction
+        if self.right_operator_class is TransposeOperator and right.operator is not left:  # type: ignore[attr-defined]
+            raise NoReduction
+
+
+class InverseBinaryRule(AbstractCompositionRule):
     """Binary rule for `op.I @ op = I` and `op.I @ op = I`."""
 
     operator_class = AbstractLazyInverseOperator
@@ -231,3 +289,12 @@ class InverseBinaryRule(AbstractBinaryRule):
         self, left: AbstractLinearOperator, right: AbstractLinearOperator
     ) -> list[AbstractLinearOperator]:
         return []
+
+
+class AbstractAdditionRule(AbstractBinaryRule):
+    """A binary rule to reduce a sum ``op1 + op2``."""
+
+    registry = ADDITION_RULE_REGISTRY
+
+    def check(self, left: AbstractLinearOperator, right: AbstractLinearOperator) -> None:
+        self._check_operands(left, right)

--- a/src/furax/core/rules.py
+++ b/src/furax/core/rules.py
@@ -298,3 +298,17 @@ class AbstractAdditionRule(AbstractBinaryRule):
 
     def check(self, left: AbstractLinearOperator, right: AbstractLinearOperator) -> None:
         self._check_operands(left, right)
+
+
+class HomothetyAdditionRule(AbstractAdditionRule):
+    """Additive rule ``H(a) + H(b) = H(a + b)`` (the additive analog of :class:`HomothetyRule`)."""
+
+    left_operator_class = HomothetyOperator
+    right_operator_class = HomothetyOperator
+
+    def apply(
+        self, left: AbstractLinearOperator, right: AbstractLinearOperator
+    ) -> list[AbstractLinearOperator]:
+        assert isinstance(left, HomothetyOperator)  # mypy
+        assert isinstance(right, HomothetyOperator)  # mypy
+        return [HomothetyOperator(left.value + right.value, in_structure=left.in_structure)]

--- a/src/furax/mapmaking/_scan_blocks.py
+++ b/src/furax/mapmaking/_scan_blocks.py
@@ -8,7 +8,7 @@ from jax.sharding import PartitionSpec as P
 from jaxtyping import Inexact, PyTree
 
 from furax import AbstractLinearOperator, tree
-from furax.core.rules import AbstractBinaryRule
+from furax.core.rules import AbstractCompositionRule
 
 # jax.eval_shape inside a jax.set_mesh context annotates outputs with sharding information,
 # which breaks operator compatibility checks. Wrapping inner transpose/reduction calls with
@@ -250,7 +250,7 @@ class ScanAdditionOperator(AbstractScanBlockOperator):
         return ScanAdditionOperator(operator_T, in_structure=self.out_structure)
 
 
-class AbstractScanFusionRule(AbstractBinaryRule):
+class AbstractScanFusionRule(AbstractCompositionRule):
     reduced_class: type[AbstractScanBlockOperator]
 
     def apply(

--- a/src/furax/math/sht.py
+++ b/src/furax/math/sht.py
@@ -23,7 +23,7 @@ import jax_healpy as jhp
 from jaxtyping import Array, Inexact, PyTree
 
 from furax import AbstractLinearOperator, IdentityOperator
-from furax.core.rules import AbstractBinaryRule, NoReduction
+from furax.core.rules import AbstractCompositionRule, NoReduction
 
 
 class Map2Alm(AbstractLinearOperator):
@@ -198,7 +198,7 @@ class Alm2Map(AbstractLinearOperator):
         )
 
 
-class SHTRule(AbstractBinaryRule):
+class SHTRule(AbstractCompositionRule):
     """Algebraic rule reducing ``Map2Alm @ Alm2Map`` to an identity.
 
     The composition *analysis after synthesis* (``Map2Alm @ Alm2Map``) is

--- a/src/furax/obs/operators/_beam_operator.py
+++ b/src/furax/obs/operators/_beam_operator.py
@@ -21,7 +21,7 @@ from jaxtyping import Array, Float, Inexact, PyTree
 
 import furax.tree as fxtree
 from furax import AbstractLinearOperator, symmetric
-from furax.core.rules import AbstractBinaryRule, NoReduction
+from furax.core.rules import AbstractCompositionRule, NoReduction
 from furax.math.sht import Alm2Map, Map2Alm
 
 
@@ -179,7 +179,7 @@ class BeamOperatorIQU(AbstractLinearOperator):
         return BeamOperatorIQU(lmax=self.lmax, beam_fl=inv_beam, in_structure=self.in_structure)
 
 
-class BeamRule(AbstractBinaryRule):
+class BeamRule(AbstractCompositionRule):
     """Algebraic rule reducing ``BeamOperator @ BeamOperator`` to a single operator.
 
     When two :class:`BeamOperator` instances with the same ``lmax`` are composed,
@@ -224,7 +224,7 @@ class BeamRule(AbstractBinaryRule):
         ]
 
 
-class BeamIQURule(AbstractBinaryRule):
+class BeamIQURule(AbstractCompositionRule):
     """Algebraic rule reducing ``BeamOperatorIQU @ BeamOperatorIQU`` to a single operator.
 
     When two :class:`BeamOperatorIQU` instances with the same ``lmax`` are

--- a/src/furax/obs/operators/_hwp.py
+++ b/src/furax/obs/operators/_hwp.py
@@ -4,7 +4,7 @@ from jax.typing import DTypeLike
 from jaxtyping import Float
 
 from furax import AbstractLinearOperator, diagonal
-from furax.core.rules import AbstractBinaryRule
+from furax.core.rules import AbstractCompositionRule
 
 from ..stokes import (
     Stokes,
@@ -60,7 +60,7 @@ class HWPOperator(AbstractLinearOperator):
         raise NotImplementedError
 
 
-class QURotationHWPRule(AbstractBinaryRule):
+class QURotationHWPRule(AbstractCompositionRule):
     """Binary rule for R(theta) @ HWP = HWP @ R(-theta)`."""
 
     left_operator_class = (QURotationOperator, QURotationTransposeOperator)

--- a/src/furax/obs/operators/_polarizers.py
+++ b/src/furax/obs/operators/_polarizers.py
@@ -3,7 +3,7 @@ from jax.typing import DTypeLike
 from jaxtyping import Array, Float
 
 from furax import AbstractLinearOperator
-from furax.core.rules import AbstractBinaryRule
+from furax.core.rules import AbstractCompositionRule
 
 from ..stokes import (
     Stokes,
@@ -53,7 +53,7 @@ class LinearPolarizerOperator(AbstractLinearOperator):
         return 0.5 * (x.i + x.q)
 
 
-class LinearPolarizerHWPRule(AbstractBinaryRule):
+class LinearPolarizerHWPRule(AbstractCompositionRule):
     """Binary rule for LinPol @ HWP = LinPol`."""
 
     left_operator_class = LinearPolarizerOperator

--- a/src/furax/obs/operators/_qu_rotations.py
+++ b/src/furax/obs/operators/_qu_rotations.py
@@ -27,7 +27,7 @@ from jaxtyping import Float
 
 from furax import AbstractLinearOperator, orthogonal
 from furax.core import AbstractLazyInverseOrthogonalOperator
-from furax.core.rules import AbstractBinaryRule, NoReduction
+from furax.core.rules import AbstractCompositionRule, NoReduction
 
 from ..stokes import (
     Stokes,
@@ -133,7 +133,7 @@ class QURotationTransposeOperator(AbstractLazyInverseOrthogonalOperator):
         return rotate_qu(x, -self.operator.angles)  # type: ignore[no-any-return]
 
 
-class QURotationRule(AbstractBinaryRule):
+class QURotationRule(AbstractCompositionRule):
     """Adds or subtracts QU rotation angles."""
 
     left_operator_class = (QURotationOperator, QURotationTransposeOperator)

--- a/tests/core/test_rules.py
+++ b/tests/core/test_rules.py
@@ -7,7 +7,11 @@ import pytest
 from jaxtyping import PyTree
 
 from furax import AbstractLinearOperator, HomothetyOperator, IdentityOperator, orthogonal, square
-from furax.core._base import AbstractLazyInverseOrthogonalOperator, CompositionOperator
+from furax.core._base import (
+    AbstractLazyInverseOrthogonalOperator,
+    AdditionOperator,
+    CompositionOperator,
+)
 
 
 class Op(AbstractLinearOperator):
@@ -119,6 +123,28 @@ def test_homothety_addition_multiple() -> None:
     reduced_op = (ops[0] + ops[1] + ops[2]).reduce()
     assert isinstance(reduced_op, HomothetyOperator)
     assert reduced_op.value == 6
+
+
+def test_addition_partial_fusion() -> None:
+    # the two homotheties fuse across the intervening op; the op is returned unchanged.
+    h1 = HomothetyOperator(2.0, in_structure=_scalar_struct)
+    op = Op1(in_structure=_scalar_struct)
+    h2 = HomothetyOperator(6.0, in_structure=_scalar_struct)
+    reduced_op = (h1 + op + h2).reduce()
+    assert isinstance(reduced_op, AdditionOperator)
+    leaves = reduced_op.operand_leaves
+    assert len(leaves) == 2
+    (hom,) = [o for o in leaves if isinstance(o, HomothetyOperator)]
+    assert hom.value == 8
+    assert any(o is op for o in leaves)
+
+
+def test_addition_no_fusion() -> None:
+    h = HomothetyOperator(2.0, in_structure=_scalar_struct)
+    op = Op1(in_structure=_scalar_struct)
+    reduced_op = (h + op).reduce()
+    assert isinstance(reduced_op, AdditionOperator)
+    assert len(reduced_op.operand_leaves) == 2
 
 
 def test_homothety2() -> None:

--- a/tests/core/test_rules.py
+++ b/tests/core/test_rules.py
@@ -103,6 +103,24 @@ def test_homothety1() -> None:
     assert composed_op.value == 12
 
 
+def test_homothety_addition() -> None:
+    op1 = HomothetyOperator(2.0, in_structure=jax.ShapeDtypeStruct((2,), np.float32))
+    op2 = HomothetyOperator(6.0, in_structure=jax.ShapeDtypeStruct((2,), np.float32))
+    reduced_op = (op1 + op2).reduce()
+    assert isinstance(reduced_op, HomothetyOperator)
+    assert reduced_op.value == 8
+
+
+def test_homothety_addition_multiple() -> None:
+    ops = [
+        HomothetyOperator(v, in_structure=jax.ShapeDtypeStruct((2,), np.float32))
+        for v in (1.0, 2.0, 3.0)
+    ]
+    reduced_op = (ops[0] + ops[1] + ops[2]).reduce()
+    assert isinstance(reduced_op, HomothetyOperator)
+    assert reduced_op.value == 6
+
+
 def test_homothety2() -> None:
     op1 = HomothetyOperator(2.0, in_structure=jax.ShapeDtypeStruct((2,), np.float32))
     op2 = HomothetyOperator(6.0, in_structure=jax.ShapeDtypeStruct((2,), np.float32))


### PR DESCRIPTION
Generalise the operator-algebra rule machinery so sums (op1 + op2) can be reduced, not just compositions (op1 @ op2).

To demonstrate, I also added a new `HomothetyAdditionRule` to reduce `H(a) + H(b) = H(a + b)`. This is the only behaviour change.

Summary:
- `AbstractBinaryRule` becomes a neutral base: operand-class registration via a `registry` class attribute.
- Two flavours
  - `AbstractCompositionRule` with `COMPOSITION_RULE_REGISTRY` replacing the previous `BINARY_RULE_REGISTRY`
  - `AbstractAdditionRule` with `ADDITION_RULE_REGISTRY`
- `AdditionOperator.reduce()` now runs a new N-ary `AdditiveReductionRule` mirroring how `CompositionOperator.reduce()` calls `AlgebraicReductionRule`.