### PR TITLE
Rebase observation timestamps to a zero origin before the float32 downcast

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -94,7 +94,7 @@ Python, JAX, linear operator framework, CMB mapmaking.
 
 ### Mapmaking conventions
 
-- `double_precision=False` → float32 on every float field, including geometry (timestamps, HWP angles, quaternions); the pipeline then runs under `jax_enable_x64=False`, where float64 arrays are illegal. (Float32 timestamps ~1.7e9 lose sub-second resolution — accepted.)
+- `double_precision=False` → float32 on every float field, including geometry (timestamps, HWP angles, quaternions); the pipeline then runs under `jax_enable_x64=False`, where float64 arrays are illegal. Timestamps are an exception in form only: the reader rebases them to a per-observation zero origin (in float64, before the downcast) so the absolute POSIX epoch does not exhaust the float32 range. The pipeline uses only time differences, so this is exact; absolute UTC is still read from the interface where needed (e.g. pointing).
 
 ## Designing operators from math
 

--- a/src/furax/mapmaking/_reader.py
+++ b/src/furax/mapmaking/_reader.py
@@ -85,7 +85,10 @@ class ObservationReader(AbstractReader, Generic[T]):
                 angles, quaternions). Use jnp.float32 to run a float32 mapmaking pipeline
                 (MapMakingConfig.double_precision=False). Casting the geometry is also
                 required there: under jax_enable_x64=False a float64 array is illegal, so
-                no field may stay float64.
+                no field may stay float64. Timestamps are rebased to a per-observation
+                zero origin (in float64, before the downcast) so the float32 cast does not
+                collapse the absolute POSIX epoch onto a single value; see the timestamps
+                reader in ``_get_data_field_readers``.
         """
         fields = cls._resolve_fields(observations, requested_fields)
         common_keywords = {'data_field_names': fields}
@@ -270,12 +273,19 @@ class ObservationReader(AbstractReader, Generic[T]):
                 fits = if_none_raise_error(obs.get_noise_model()).to_array()
             return jax.tree.map(lambda x: x.astype(target_dtype), fits)
 
+        def get_timestamps(obs: AbstractObservation[T]) -> Any:
+            # The pipeline uses only time differences, so anchor each observation at its
+            # own start. Subtracting in float64 keeps the samples resolved when cast to
+            # float32; the absolute epoch is read from the interface where needed.
+            timestamps = np.asarray(obs.get_timestamps(), dtype=np.float64)
+            return (timestamps - timestamps[0]).astype(target_dtype)
+
         return {
             'metadata': lambda obs: HashedObservationMetadata.from_observation(obs),
             'sample_data': get_sample_data,
             'valid_sample_masks': lambda obs: obs.get_sample_mask(),
             'valid_scanning_masks': lambda obs: obs.get_scanning_mask(),
-            'timestamps': lambda obs: obs.get_timestamps().astype(target_dtype),
+            'timestamps': get_timestamps,
             'hwp_angles': lambda obs: obs.get_hwp_angles().astype(target_dtype),
             'detector_quaternions': lambda obs: obs.get_detector_quaternions().astype(target_dtype),
             'boresight_quaternions': lambda obs: obs.get_boresight_quaternions().astype(

--- a/tests/mapmaking/test_double_precision.py
+++ b/tests/mapmaking/test_double_precision.py
@@ -25,6 +25,7 @@ from furax.mapmaking import (
     MultiObservationMapMaker,
     ObservationReader,
 )
+from furax.mapmaking._model import _sample_rate
 from furax.mapmaking.config import (
     HealpixConfig,
     LandscapeConfig,
@@ -35,7 +36,7 @@ from furax.mapmaking.config import (
     SolverConfig,
     WeightingConfig,
 )
-from tests.mapmaking.helpers import FakeLazyObservation
+from tests.mapmaking.helpers import FakeLazyObservation, FakeObservation
 
 # ----------------------------------------------------------------------------
 # In-process dtype plumbing tests
@@ -96,6 +97,48 @@ class TestObservationReaderDtype:
             dtype=jnp.float32,
         )
         assert reader.out_structure['valid_sample_masks'].dtype == jnp.bool
+
+
+class TestObservationReaderRebasesTimestamps:
+    """Reader rebases timestamps to a zero origin before the float32 cast.
+
+    ``FakeObservation`` timestamps carry an absolute POSIX epoch whose float32 ULP
+    is coarser than the (short) observation: without rebasing, every sample rounds
+    to the same value once cast to float32.
+    """
+
+    def test_reader_rebases_and_keeps_samples_resolved(self) -> None:
+        obs = FakeObservation()
+        reader = ObservationReader.from_observations(
+            [FakeLazyObservation()],
+            requested_fields=['timestamps'],
+            dtype=jnp.float32,
+        )
+        data, _ = reader.read(0)
+        timestamps = data['timestamps']
+
+        assert timestamps.dtype == jnp.float32
+        # Starts at zero, and the samples stay distinct: strictly increasing, all
+        # present, spanning the full (n_samples - 1) / sample_rate duration.
+        assert float(timestamps[0]) == 0.0
+        assert bool(jnp.all(jnp.diff(timestamps) > 0))
+        assert jnp.unique(timestamps).size == obs.n_samples
+        expected_span = (obs.n_samples - 1) / obs.sample_rate
+        assert float(jnp.ptp(timestamps)) == pytest.approx(expected_span, rel=1e-5)
+
+    def test_derived_sample_rate_is_finite(self) -> None:
+        # _sample_rate is (n_samples - 1) / ptp(timestamps): a collapsed axis (ptp=0)
+        # makes it diverge, so check it stays finite and recovers the true rate.
+        obs = FakeObservation()
+        reader = ObservationReader.from_observations(
+            [FakeLazyObservation()],
+            requested_fields=['timestamps'],
+            dtype=jnp.float32,
+        )
+        data, _ = reader.read(0)
+        fs = _sample_rate(data['timestamps'])
+        assert bool(jnp.isfinite(fs))
+        assert float(fs) == pytest.approx(obs.sample_rate, rel=1e-4)
 
 
 class TestMapMakerForwardsDtype:

--- a/tests/mapmaking/test_double_precision.py
+++ b/tests/mapmaking/test_double_precision.py
@@ -120,11 +120,11 @@ class TestObservationReaderRebasesTimestamps:
         assert timestamps.dtype == jnp.float32
         # Starts at zero, and the samples stay distinct: strictly increasing, all
         # present, spanning the full (n_samples - 1) / sample_rate duration.
-        assert float(timestamps[0]) == 0.0
-        assert bool(jnp.all(jnp.diff(timestamps) > 0))
+        assert timestamps[0] == 0.0
+        assert jnp.all(jnp.diff(timestamps) > 0)
         assert jnp.unique(timestamps).size == obs.n_samples
         expected_span = (obs.n_samples - 1) / obs.sample_rate
-        assert float(jnp.ptp(timestamps)) == pytest.approx(expected_span, rel=1e-5)
+        assert jnp.ptp(timestamps) == pytest.approx(expected_span, rel=1e-5)
 
     def test_derived_sample_rate_is_finite(self) -> None:
         # _sample_rate is (n_samples - 1) / ptp(timestamps): a collapsed axis (ptp=0)
@@ -137,8 +137,8 @@ class TestObservationReaderRebasesTimestamps:
         )
         data, _ = reader.read(0)
         fs = _sample_rate(data['timestamps'])
-        assert bool(jnp.isfinite(fs))
-        assert float(fs) == pytest.approx(obs.sample_rate, rel=1e-4)
+        assert jnp.isfinite(fs)
+        assert fs == pytest.approx(obs.sample_rate, rel=1e-4)
 
 
 class TestMapMakerForwardsDtype:


### PR DESCRIPTION
## Summary

Under `double_precision=False` (the float32 mapmaking pipeline, run with `jax_enable_x64=False`), `ObservationReader` downcasts every geometry field to float32 on read, including timestamps. Timestamps are absolute POSIX seconds, an offset large enough (order 1e9) that float32 cannot resolve an individual observation sitting on top of it: the ULP at that magnitude is on the order of 100 s, far coarser than the sample spacing and, for a short enough observation, coarser than the whole observation span. The downcast therefore quantizes the timestamps onto a coarse grid, silently corrupting quantities derived from them. This PR rebases each observation's timestamps to a per-observation zero origin, in float64, before the downcast, so the float32 only ever has to represent the (small) elapsed time within the observation.

## The bug

The reader's downcast `timestamps` field feeds the per-observation noise model in `_model.py`, which derives rates from time differences and then divides by them:

- `_sample_rate = (N - 1) / jnp.ptp(timestamps)` and `_hwp_frequency = … / jnp.ptp(timestamps)`. `ptp` is `max - min`, so it collapses to `0` whenever the observation span is smaller than the float32 ULP at the epoch: every sample rounds to the same value and the rate diverges to `inf`.
- The noise model then builds its FFT frequency grid as `jnp.fft.rfftfreq(n, d=1 / sample_rate) = rfftfreq(n, d=0)`, which yields NaN/inf, and those values propagate into `AᵀN⁻¹d` and poison the output map.

Even when the span is large enough that `ptp` stays non-zero, the absolute epoch still costs most of the float32 mantissa, so the per-sample timestamps degrade to a coarse staircase. The run otherwise completes and reports the correct float32 dtype, so the corruption is silent.

## The fix

`ObservationReader._get_data_field_readers` reads timestamps via a dedicated `get_timestamps` function that pins the interface array to float64, subtracts the start time, and only then casts to the target dtype: `timestamps = np.asarray(obs.get_timestamps(), dtype=np.float64); (timestamps - timestamps[0]).astype(target_dtype)`. The explicit float64 cast makes the rebasing exact regardless of the dtype the interface returns (it is host/numpy, inside the `io_callback`, so float64 is legal even with `jax_enable_x64=False`). The pipeline consumes only time *differences*, so subtracting a per-observation constant changes no result; it only restores the resolution the float32 cast was destroying. After rebasing, the device-side timestamps span `[0, observation_duration]`, whose float32 ULP is far finer than the sample spacing for any realistic observation length — no collapse, at any epoch.

## Why it is safe

The reader's downcast `timestamps` field is consumed only through time differences (`_sample_rate`, `_hwp_frequency`), so rebasing it to a per-observation origin is invariant and simply restores precision. The one place that genuinely needs absolute UTC is the az/el→celestial pointing in the sotodlib interface (`get_boresight_quaternions`, via `so3g.proj.CelestialSightLine.az_el`) and the analogous litebird `slerp(start_time, …)`; both read the raw `self.data.timestamps` / `self.data.start_time` directly inside the interface and produce quaternions independently of the reader's downcast field, so this change cannot affect them. The interface contract of `get_timestamps()` (absolute UTC) is left unchanged; only the reader's device-side field is rebased. Nothing in the pipeline compares timestamps across observations (maps are accumulated in sky-pixel space), so rebasing each observation to its own origin is self-consistent.

## Scope

This PR rebases the reader's device-side `timestamps` field, which feeds the noise-model path described above. The host-side `AbstractObservation.get_elapsed_times()` (used by the polynomial scan-block templates) is a separate code path that does not go through the reader and is left unchanged here.

## Tests

Added `TestObservationReaderRebasesTimestamps` in `tests/mapmaking/test_double_precision.py`, using the shared `FakeObservation` / `FakeLazyObservation` (whose timestamps carry an absolute POSIX epoch). With `dtype=jnp.float32` it reads the reader's actual output (via `reader.read(0)`) and asserts it is reoriented to a zero origin, is strictly increasing with all samples distinct, spans the true `(N - 1) / sample_rate` duration, and yields a finite `_sample_rate` equal to the true rate. These assertions fail on `main` (`timestamps[0]` is the raw epoch, `_sample_rate == inf`) and pass with this fix. The full `tests/mapmaking` and `tests/io` suites pass unchanged, including the sotodlib real-data mapmaker tests that exercise the absolute-time pointing path.

## Notes

The device-side `timestamps` field is now a per-observation elapsed-time axis rather than absolute UTC. Every device consumer is difference-based, so this is correct; any future code that needs absolute time on device must add the start time back (nothing requires this today). `AGENTS.md` is updated to document the rebasing in the mapmaking dtype conventions.

## Files changed

- `src/furax/mapmaking/_reader.py`: rebase timestamps to a zero origin (in float64) before the float32 cast; document it in the `from_observations` dtype docstring.
- `tests/mapmaking/test_double_precision.py`: add `TestObservationReaderRebasesTimestamps`.
- `AGENTS.md`: document the timestamp rebasing in the mapmaking dtype conventions.
