### PR TITLE
Improve reader fields handling

### DIFF
--- a/src/furax/interfaces/litebird_sim/observation.py
+++ b/src/furax/interfaces/litebird_sim/observation.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from collections.abc import Collection
 from pathlib import Path
 
 import jax.numpy as jnp
@@ -16,7 +17,7 @@ from furax.obs.landscapes import HealpixLandscape, ProjectionType, StokesLandsca
 class LBSObservation(AbstractSatelliteObservation[lbs.Observation]):
     @classmethod
     def from_file(
-        cls, filename: str | Path, requested_fields: list[str] | None = None
+        cls, filename: str | Path, requested_fields: Collection[str] | None = None
     ) -> LBSObservation:
         # check that file exists
         file = Path(filename)

--- a/src/furax/interfaces/sotodlib/observation.py
+++ b/src/furax/interfaces/sotodlib/observation.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from collections.abc import Collection
 from pathlib import Path
 from typing import Any, Literal
 
@@ -16,7 +17,7 @@ from sotodlib.coords.helpers import get_deflected_sightline
 from sotodlib.core import AxisManager
 from sotodlib.preprocess.preprocess_util import load_and_preprocess
 
-from furax.mapmaking import AbstractGroundObservation, AbstractLazyObservation
+from furax.mapmaking import AbstractGroundObservation, AbstractLazyObservation, ReaderField
 from furax.mapmaking.config import SotodlibConfig
 from furax.mapmaking.noise import AtmosphericNoiseModel, NoiseModel
 from furax.obs.landscapes import (
@@ -39,7 +40,7 @@ class SOTODLibObservation(AbstractGroundObservation[AxisManager]):
     def from_file(
         cls,
         filename: str | Path,
-        requested_fields: list[str] | None = None,
+        requested_fields: Collection[str] | None = None,
         sotodlib_config: SotodlibConfig | None = None,
     ) -> SOTODLibObservation:
         # check that file exists
@@ -55,30 +56,30 @@ class SOTODLibObservation(AbstractGroundObservation[AxisManager]):
             # minimum information needed to determine buffer shapes
             fields = ['dets', 'samp']
             # translate request to sotodlib subfield names
-            if 'metadata' in requested_fields:
+            if ReaderField.METADATA in requested_fields:
                 fields.append('obs_info')
-            if 'sample_data' in requested_fields:
+            if ReaderField.SAMPLE_DATA in requested_fields:
                 if config.demodulated:
                     fields.extend(['dsT', 'demodQ', 'demodU'])
                 else:
                     fields.append('signal')
-            if 'valid_sample_masks' in requested_fields:
+            if ReaderField.VALID_SAMPLE_MASKS in requested_fields:
                 fields.append('flags.glitch_flags')
-            if 'valid_scanning_masks' in requested_fields:
+            if ReaderField.VALID_SCANNING_MASKS in requested_fields:
                 fields.append('preprocess.turnaround_flags')
-            if 'timestamps' in requested_fields:
+            if ReaderField.TIMESTAMPS in requested_fields:
                 fields.append('timestamps')
-            if 'hwp_angles' in requested_fields:
+            if ReaderField.HWP_ANGLES in requested_fields:
                 fields.append('hwp_angle')
-            if 'boresight_quaternions' in requested_fields:
+            if ReaderField.BORESIGHT_QUATERNIONS in requested_fields:
                 fields.append('boresight')
                 if 'timestamps' not in fields:
                     fields.append('timestamps')
                 if config.wobble_correction:
                     fields.extend(['wobble_params', 'det_info', 'hwp_angle'])
-            if 'detector_quaternions' in requested_fields:
+            if ReaderField.DETECTOR_QUATERNIONS in requested_fields:
                 fields.append('focal_plane')
-            if 'noise_model_fits' in requested_fields:
+            if ReaderField.NOISE_MODEL_FITS in requested_fields:
                 if config.noise_source == 'mapmaking':
                     fields.append('preprocess.noiseQ_mapmaking')
                 else:
@@ -393,7 +394,7 @@ class LazySOTODLibObservation(AbstractLazyObservation[AxisManager]):
         super().__init__(filename)
         self._sotodlib_config = sotodlib_config
 
-    def get_data(self, requested_fields: list[str] | None = None) -> SOTODLibObservation:
+    def get_data(self, requested_fields: Collection[str] | None = None) -> SOTODLibObservation:
         return SOTODLibObservation.from_file(
             self.file, requested_fields, sotodlib_config=self._sotodlib_config
         )

--- a/src/furax/interfaces/toast/observation.py
+++ b/src/furax/interfaces/toast/observation.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import typing
+from collections.abc import Collection
 from functools import partial
 from pathlib import Path
 from typing import Any
@@ -16,7 +17,7 @@ from toast import qarray as qa
 from toast.observation import default_values as defaults
 from toast.ops.load_hdf5 import LoadHDF5
 
-from furax.mapmaking import AbstractGroundObservation, AbstractLazyObservation
+from furax.mapmaking import AbstractGroundObservation, AbstractLazyObservation, ReaderField
 from furax.mapmaking.noise import AtmosphericNoiseModel, NoiseModel
 from furax.obs.landscapes import (
     AstropyWCSLandscape,
@@ -82,7 +83,7 @@ class ToastObservation(AbstractGroundObservation[toast.Data]):
 
     @classmethod
     def from_file(
-        cls, filename: str | Path, requested_fields: list[str] | None = None
+        cls, filename: str | Path, requested_fields: Collection[str] | None = None
     ) -> ToastObservation:
         # check that file exists
         if not Path(filename).exists():
@@ -95,19 +96,19 @@ class ToastObservation(AbstractGroundObservation[toast.Data]):
         if requested_fields is not None:
             # translate request to sotodlib subfield names
             detdata = []
-            if 'sample_data' in requested_fields:
+            if ReaderField.SAMPLE_DATA in requested_fields:
                 detdata.append(defaults.det_data)
-            if 'valid_sample_masks' in requested_fields:
+            if ReaderField.VALID_SAMPLE_MASKS in requested_fields:
                 detdata.append(defaults.det_flags)
 
             shared = [defaults.times]  # Always need to load timestamps
-            if 'hwp_angles' in requested_fields:
+            if ReaderField.HWP_ANGLES in requested_fields:
                 shared.append(defaults.hwp_angle)
-            if 'boresight_quaternions' in requested_fields:
+            if ReaderField.BORESIGHT_QUATERNIONS in requested_fields:
                 shared.append(defaults.boresight_radec)
 
             intervals = ['']  # Toast loads all intervals if the list is empty
-            if 'valid_scanning_masks' in requested_fields:
+            if ReaderField.VALID_SCANNING_MASKS in requested_fields:
                 intervals.append(defaults.scanning_interval)
 
             loader.detdata = detdata

--- a/src/furax/mapmaking/__init__.py
+++ b/src/furax/mapmaking/__init__.py
@@ -5,6 +5,7 @@ from ._observation import (
     AbstractObservation,
     AbstractSatelliteObservation,
     HashedObservationMetadata,
+    ReaderField,
 )
 from ._reader import ObservationReader
 from .config import MapMakingConfig
@@ -22,6 +23,7 @@ __all__ = [
     'GapFillingOperator',
     'HashedObservationMetadata',
     'ObservationReader',
+    'ReaderField',
     'MapMakingConfig',
     'MapMakingResults',
     'MultiObservationMapMaker',

--- a/src/furax/mapmaking/_model.py
+++ b/src/furax/mapmaking/_model.py
@@ -10,6 +10,7 @@ from furax import AbstractLinearOperator, IdentityOperator, MaskOperator, tree
 from furax.core import BlockDiagonalOperator, CompositionOperator, IndexOperator
 from furax.obs.landscapes import StokesLandscape
 
+from ._observation import ReaderField
 from .acquisition import build_acquisition_operator
 from .config import MapMakingConfig, Methods, NoiseSource, WeightingMode
 from .noise import AtmosphericNoiseModel, NoiseModel, WhiteNoiseModel
@@ -47,9 +48,9 @@ class ObservationModel:
     ) -> Self:
         H = build_acquisition_operator(
             landscape,
-            data['boresight_quaternions'],
-            data['detector_quaternions'],
-            data.get('hwp_angles'),
+            data[ReaderField.BORESIGHT_QUATERNIONS],
+            data[ReaderField.DETECTOR_QUATERNIONS],
+            data.get(ReaderField.HWP_ANGLES),
             demodulated=config.demodulated,
             pointing_chunk_size=config.pointing.chunk_size,
             pointing_on_the_fly=config.pointing.on_the_fly,
@@ -58,7 +59,7 @@ class ObservationModel:
         )
         masker = _mask_projector(
             _sample_mask(data, config),
-            data.get('valid_scanning_masks'),
+            data.get(ReaderField.VALID_SCANNING_MASKS),
             structure=H.out_structure,
         )
         noise_model, sample_rate = _noise_model(data, config, tod_structure=H.out_structure)
@@ -72,6 +73,29 @@ class ObservationModel:
         if F_T := _template_deprojector(config, H.out_structure):
             W = W @ F_T
         return cls(H, W, masker, noise_model, sample_rate)
+
+    @staticmethod
+    def required_reader_fields(config: MapMakingConfig) -> set[str]:
+        """Reader fields needed to build an :class:`ObservationModel` via :meth:`create`."""
+        fields: set[str] = {
+            ReaderField.BORESIGHT_QUATERNIONS,
+            ReaderField.DETECTOR_QUATERNIONS,
+            ReaderField.VALID_SAMPLE_MASKS,
+            ReaderField.TIMESTAMPS,
+        }
+        if not config.demodulated:
+            # FIXME: this does not handle the case of a telescope without HWP
+            fields.add(ReaderField.HWP_ANGLES)
+        if config.scanning_mask:
+            fields.add(ReaderField.VALID_SCANNING_MASKS)
+        if config.weighting.mode != WeightingMode.IDENTITY:
+            if config.weighting.source == NoiseSource.FIT:
+                fields.update({ReaderField.SAMPLE_DATA, ReaderField.HWP_ANGLES})
+            else:
+                fields.add(ReaderField.NOISE_MODEL_FITS)
+        if config.gaps.fill and not config.binned:
+            fields.add(ReaderField.METADATA)
+        return fields
 
     @property
     def tod_structure(self) -> PyTree[jax.ShapeDtypeStruct]:
@@ -148,7 +172,7 @@ def _noise_model(
     tod_structure: jax.ShapeDtypeStruct | None = None,
 ) -> tuple[PyTree[NoiseModel], Array]:
     """Compute the noise model and sample rate for a single observation block."""
-    fs = _sample_rate(data['timestamps'])
+    fs = _sample_rate(data[ReaderField.TIMESTAMPS])
     if config.weighting.mode == WeightingMode.IDENTITY:
         if tod_structure is None:
             raise ValueError('tod_structure is required when config.weighting.mode is IDENTITY')
@@ -160,7 +184,7 @@ def _noise_model(
     if config.weighting.source == NoiseSource.FIT:
         fit_config = config.weighting.fitting
         noise_model_class = WhiteNoiseModel if config.binned else AtmosphericNoiseModel
-        fhwp = _hwp_frequency(data['timestamps'], data['hwp_angles'])
+        fhwp = _hwp_frequency(data[ReaderField.TIMESTAMPS], data[ReaderField.HWP_ANGLES])
 
         def _compute_Pxx_and_fit(tod):  # type: ignore[no-untyped-def]
             f, Pxx = jax.scipy.signal.welch(tod, fs=fs, nperseg=fit_config.nperseg)
@@ -172,9 +196,11 @@ def _noise_model(
                 config=fit_config,
             )
 
-        noise_model = jax.tree.map(_compute_Pxx_and_fit, data['sample_data'])
+        noise_model = jax.tree.map(_compute_Pxx_and_fit, data[ReaderField.SAMPLE_DATA])
     else:
-        noise_model = jax.tree.map(lambda x: AtmosphericNoiseModel(*x.T), data['noise_model_fits'])
+        noise_model = jax.tree.map(
+            lambda x: AtmosphericNoiseModel(*x.T), data[ReaderField.NOISE_MODEL_FITS]
+        )
         if config.binned:
             noise_model = jax.tree.map(
                 lambda m: m.to_white_noise_model(),
@@ -190,7 +216,7 @@ def _sample_mask(data: Any, config: MapMakingConfig) -> Array:
     For ATOP mapmaker, extra pixels may be masked depending on atop_tau.
     """
 
-    mask = data['valid_sample_masks']
+    mask = data[ReaderField.VALID_SAMPLE_MASKS]
 
     if config.method == Methods.ATOP:
         tau = config.atop_tau

--- a/src/furax/mapmaking/_observation.py
+++ b/src/furax/mapmaking/_observation.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
+from collections.abc import Collection
 from dataclasses import dataclass
+from enum import StrEnum
 from hashlib import sha1
 from pathlib import Path
 from typing import Any, ClassVar, Generic, Self, TypeVar
@@ -21,6 +23,25 @@ from furax.obs.stokes import ValidStokesType
 from .noise import NoiseModel
 
 T = TypeVar('T')
+
+
+class ReaderField(StrEnum):
+    """Canonical names of the data fields an observation reader can load.
+
+    Members are plain strings (``StrEnum``), so they interoperate with string keys in
+    field dictionaries and set membership tests. Using members instead of bare literals
+    makes typos a name-resolution error caught by linting/type-checking.
+    """
+
+    METADATA = 'metadata'
+    SAMPLE_DATA = 'sample_data'
+    VALID_SAMPLE_MASKS = 'valid_sample_masks'
+    VALID_SCANNING_MASKS = 'valid_scanning_masks'
+    TIMESTAMPS = 'timestamps'
+    HWP_ANGLES = 'hwp_angles'
+    DETECTOR_QUATERNIONS = 'detector_quaternions'
+    BORESIGHT_QUATERNIONS = 'boresight_quaternions'
+    NOISE_MODEL_FITS = 'noise_model_fits'
 
 
 @register_dataclass
@@ -64,21 +85,21 @@ class AbstractObservation(ABC, Generic[T]):
     ``Observation``, sotodlib's ``AxisManager``, litebird_sim's ``Observation``, etc.)
     """
 
-    AVAILABLE_READER_FIELDS: ClassVar[list[str]] = [
-        'metadata',
-        'sample_data',
-        'valid_sample_masks',
-        'timestamps',
-        'hwp_angles',
-        'detector_quaternions',
-        'boresight_quaternions',
-        'noise_model_fits',
-    ]
+    AVAILABLE_READER_FIELDS: ClassVar[frozenset[str]] = frozenset(
+        {
+            ReaderField.METADATA,
+            ReaderField.SAMPLE_DATA,
+            ReaderField.VALID_SAMPLE_MASKS,
+            ReaderField.TIMESTAMPS,
+            ReaderField.HWP_ANGLES,
+            ReaderField.DETECTOR_QUATERNIONS,
+            ReaderField.BORESIGHT_QUATERNIONS,
+            ReaderField.NOISE_MODEL_FITS,
+        }
+    )
     """Supported data field names for all observations"""
 
-    OPTIONAL_READER_FIELDS: ClassVar[list[str]] = [
-        'noise_model_fits',
-    ]
+    OPTIONAL_READER_FIELDS: ClassVar[frozenset[str]] = frozenset({ReaderField.NOISE_MODEL_FITS})
     """Optional data field names"""
 
     def __init__(self, data: T) -> None:
@@ -87,7 +108,7 @@ class AbstractObservation(ABC, Generic[T]):
     @classmethod
     @abstractmethod
     def from_file(
-        cls, filename: str | Path, requested_fields: list[str] | None = None
+        cls, filename: str | Path, requested_fields: Collection[str] | None = None
     ) -> AbstractObservation[T]:
         """Loads the observation from a binary file.
 
@@ -218,9 +239,12 @@ class AbstractSatelliteObservation(AbstractObservation[T]):
 class AbstractGroundObservation(AbstractObservation[T]):
     """Class for interfacing with ground-based observation data."""
 
-    AVAILABLE_READER_FIELDS: ClassVar[list[str]] = AbstractObservation.AVAILABLE_READER_FIELDS + [
-        'valid_scanning_masks',
-    ]
+    AVAILABLE_READER_FIELDS: ClassVar[frozenset[str]] = (
+        AbstractObservation.AVAILABLE_READER_FIELDS
+        | {
+            ReaderField.VALID_SCANNING_MASKS,
+        }
+    )
 
     @abstractmethod
     def get_scanning_intervals(self) -> NDArray[Any]:
@@ -345,7 +369,7 @@ class AbstractLazyObservation(ABC, Generic[T]):
         if not self.file.exists():
             raise FileNotFoundError(f'Observation file {self.file} does not exist')
 
-    def get_data(self, requested_fields: list[str] | None = None) -> AbstractObservation[T]:
+    def get_data(self, requested_fields: Collection[str] | None = None) -> AbstractObservation[T]:
         """Loads observation data from the underlying file.
 
         Args:

--- a/src/furax/mapmaking/_reader.py
+++ b/src/furax/mapmaking/_reader.py
@@ -1,4 +1,4 @@
-from collections.abc import Sequence
+from collections.abc import Collection, Sequence
 from typing import Any, Generic, Self, TypeVar
 
 import jax
@@ -17,6 +17,7 @@ from ._observation import (
     AbstractLazyObservation,
     AbstractObservation,
     HashedObservationMetadata,
+    ReaderField,
 )
 
 T = TypeVar('T')
@@ -65,7 +66,7 @@ class ObservationReader(AbstractReader, Generic[T]):
         observations: Sequence[AbstractLazyObservation[T]],
         *,
         read_indices: Sequence[int] | None = None,
-        requested_fields: Sequence[str] | None = None,
+        requested_fields: Collection[str] | None = None,
         demodulated: bool = False,
         stokes: ValidStokesType = 'IQU',
         dtype: DTypeLike = jnp.float64,
@@ -138,19 +139,20 @@ class ObservationReader(AbstractReader, Generic[T]):
     @staticmethod
     def _resolve_fields(
         observations: Sequence[AbstractLazyObservation[T]],
-        requested_fields: Sequence[str] | None,
-    ) -> list[str]:
+        requested_fields: Collection[str] | None,
+    ) -> set[str]:
         interface = observations[0].interface_class
         available = set(interface.AVAILABLE_READER_FIELDS)
         optional = set(interface.OPTIONAL_READER_FIELDS)
         if requested_fields is None:
-            return sorted(available - optional)
-        unsupported = set(requested_fields) - available
+            return available - optional
+        fields = set(requested_fields)
+        unsupported = fields - available
         if unsupported:
             raise ValueError(
                 f'Requested data fields {unsupported} are not supported by the interface.'
             )
-        return list(requested_fields)
+        return fields
 
     def _pad(
         self, data: PyTree[np.ndarray], padding: PyTree[tuple[int, ...]]
@@ -174,46 +176,50 @@ class ObservationReader(AbstractReader, Generic[T]):
 
         # Handle fields with non-zero padding
         data_field_names = self.common_keywords['data_field_names']
-        if 'timestamps' in data_field_names:
+        if ReaderField.TIMESTAMPS in data_field_names:
             # Extrapolate in the padded region for constant sample rate
-            pad_size = padding['timestamps'][0]
-            valid = data['timestamps'][: data['timestamps'].size - pad_size]
+            pad_size = padding[ReaderField.TIMESTAMPS][0]
+            valid = data[ReaderField.TIMESTAMPS][: data[ReaderField.TIMESTAMPS].size - pad_size]
             dt = (valid[-1] - valid[0]) / (valid.size - 1)  # Mean time spacing
-            data['timestamps'] = np.pad(
+            data[ReaderField.TIMESTAMPS] = np.pad(
                 valid, (0, pad_size), mode='linear_ramp', end_values=valid[-1] + dt * pad_size
             )
-        if 'hwp_angles' in data_field_names:
+        if ReaderField.HWP_ANGLES in data_field_names:
             # Extrapolate in the padded region for constant hwp rotation frequency
-            pad_size = padding['hwp_angles'][0]
-            valid = data['hwp_angles'][: data['hwp_angles'].size - pad_size]
+            pad_size = padding[ReaderField.HWP_ANGLES][0]
+            valid = data[ReaderField.HWP_ANGLES][: data[ReaderField.HWP_ANGLES].size - pad_size]
             dphi = (np.unwrap(valid)[-1] - valid[0]) / (valid.size - 1)  # Mean angle spacing
-            data['hwp_angles'] = np.pad(
+            data[ReaderField.HWP_ANGLES] = np.pad(
                 valid, (0, pad_size), mode='linear_ramp', end_values=valid[-1] + dphi * pad_size
             ) % (2 * np.pi)
-        if 'detector_quaternions' in data_field_names:
+        if ReaderField.DETECTOR_QUATERNIONS in data_field_names:
             # Pad with (1, 0, 0, 0), corresponding to xi=eta=gamma=0.
-            zero_padded = np.linalg.norm(data['detector_quaternions'], axis=-1) == 0.0
-            data['detector_quaternions'] = np.where(
+            quats = data[ReaderField.DETECTOR_QUATERNIONS]
+            zero_padded = np.linalg.norm(quats, axis=-1) == 0.0
+            data[ReaderField.DETECTOR_QUATERNIONS] = np.where(
                 zero_padded[:, None],
-                np.array([[1.0, 0.0, 0.0, 0.0]], dtype=data['detector_quaternions'].dtype),
-                data['detector_quaternions'],
+                np.array([[1.0, 0.0, 0.0, 0.0]], dtype=quats.dtype),
+                quats,
             )
-        if 'boresight_quaternions' in data_field_names:
+        if ReaderField.BORESIGHT_QUATERNIONS in data_field_names:
             # Pad with the last non-zero quaternion provided.
-            pad_size = padding['boresight_quaternions'][0]  # samples axis
-            last_quaternion = data['boresight_quaternions'][-pad_size - 1, :]
-            zero_padded = np.linalg.norm(data['boresight_quaternions'], axis=-1) == 0.0
-            data['boresight_quaternions'] = np.where(
-                zero_padded[:, None], last_quaternion[None, :], data['boresight_quaternions']
+            quats = data[ReaderField.BORESIGHT_QUATERNIONS]
+            pad_size = padding[ReaderField.BORESIGHT_QUATERNIONS][0]  # samples axis
+            last_quaternion = quats[-pad_size - 1, :]
+            zero_padded = np.linalg.norm(quats, axis=-1) == 0.0
+            data[ReaderField.BORESIGHT_QUATERNIONS] = np.where(
+                zero_padded[:, None], last_quaternion[None, :], quats
             )
-        if 'noise_model_fits' in data_field_names:
+        if ReaderField.NOISE_MODEL_FITS in data_field_names:
 
             def _pad_noise_fits(arr: np.ndarray) -> np.ndarray:
                 default = np.array([[0.0, 0.0, 1.0, 0.1]], dtype=arr.dtype)
                 zero_padded = arr[:, 0] == 0.0
                 return np.where(zero_padded[:, None], default, arr)
 
-            data['noise_model_fits'] = jax.tree.map(_pad_noise_fits, data['noise_model_fits'])
+            data[ReaderField.NOISE_MODEL_FITS] = jax.tree.map(
+                _pad_noise_fits, data[ReaderField.NOISE_MODEL_FITS]
+            )
 
         return data
 
@@ -234,15 +240,17 @@ class ObservationReader(AbstractReader, Generic[T]):
         )
 
         return {
-            'metadata': HashedObservationMetadata.structure_for(n_detectors),
-            'sample_data': sample_data_structure,
-            'valid_sample_masks': jax.ShapeDtypeStruct((n_detectors, n_samples), jnp.bool),
-            'valid_scanning_masks': jax.ShapeDtypeStruct((n_samples,), jnp.bool),
-            'timestamps': jax.ShapeDtypeStruct((n_samples,), dtype),
-            'hwp_angles': jax.ShapeDtypeStruct((n_samples,), dtype),
-            'detector_quaternions': jax.ShapeDtypeStruct((n_detectors, 4), dtype),
-            'boresight_quaternions': jax.ShapeDtypeStruct((n_samples, 4), dtype),
-            'noise_model_fits': (
+            ReaderField.METADATA: HashedObservationMetadata.structure_for(n_detectors),
+            ReaderField.SAMPLE_DATA: sample_data_structure,
+            ReaderField.VALID_SAMPLE_MASKS: jax.ShapeDtypeStruct(
+                (n_detectors, n_samples), jnp.bool
+            ),
+            ReaderField.VALID_SCANNING_MASKS: jax.ShapeDtypeStruct((n_samples,), jnp.bool),
+            ReaderField.TIMESTAMPS: jax.ShapeDtypeStruct((n_samples,), dtype),
+            ReaderField.HWP_ANGLES: jax.ShapeDtypeStruct((n_samples,), dtype),
+            ReaderField.DETECTOR_QUATERNIONS: jax.ShapeDtypeStruct((n_detectors, 4), dtype),
+            ReaderField.BORESIGHT_QUATERNIONS: jax.ShapeDtypeStruct((n_samples, 4), dtype),
+            ReaderField.NOISE_MODEL_FITS: (
                 Stokes.class_for(stokes).structure_for((n_detectors, 4), dtype)
                 if demodulated
                 else jax.ShapeDtypeStruct((n_detectors, 4), dtype)
@@ -281,21 +289,23 @@ class ObservationReader(AbstractReader, Generic[T]):
             return (timestamps - timestamps[0]).astype(target_dtype)
 
         return {
-            'metadata': lambda obs: HashedObservationMetadata.from_observation(obs),
-            'sample_data': get_sample_data,
-            'valid_sample_masks': lambda obs: obs.get_sample_mask(),
-            'valid_scanning_masks': lambda obs: obs.get_scanning_mask(),
-            'timestamps': get_timestamps,
-            'hwp_angles': lambda obs: obs.get_hwp_angles().astype(target_dtype),
-            'detector_quaternions': lambda obs: obs.get_detector_quaternions().astype(target_dtype),
-            'boresight_quaternions': lambda obs: obs.get_boresight_quaternions().astype(
+            ReaderField.METADATA: lambda obs: HashedObservationMetadata.from_observation(obs),
+            ReaderField.SAMPLE_DATA: get_sample_data,
+            ReaderField.VALID_SAMPLE_MASKS: lambda obs: obs.get_sample_mask(),
+            ReaderField.VALID_SCANNING_MASKS: lambda obs: obs.get_scanning_mask(),
+            ReaderField.TIMESTAMPS: get_timestamps,
+            ReaderField.HWP_ANGLES: lambda obs: obs.get_hwp_angles().astype(target_dtype),
+            ReaderField.DETECTOR_QUATERNIONS: lambda obs: obs.get_detector_quaternions().astype(
                 target_dtype
             ),
-            'noise_model_fits': get_noise_model_fits,
+            ReaderField.BORESIGHT_QUATERNIONS: lambda obs: obs.get_boresight_quaternions().astype(
+                target_dtype
+            ),
+            ReaderField.NOISE_MODEL_FITS: get_noise_model_fits,
         }
 
     def _read_structure_impure(
-        self, observation: AbstractLazyObservation[T], data_field_names: list[str]
+        self, observation: AbstractLazyObservation[T], data_field_names: Collection[str]
     ) -> PyTree[jax.ShapeDtypeStruct]:
         # request an empty list
         # this loads sufficient info to determine the structure
@@ -310,7 +320,7 @@ class ObservationReader(AbstractReader, Generic[T]):
         return {field: field_structure[field] for field in data_field_names}
 
     def _read_data_impure(
-        self, observation: AbstractLazyObservation[T], data_field_names: list[str]
+        self, observation: AbstractLazyObservation[T], data_field_names: Collection[str]
     ) -> PyTree[Array]:
         data = observation.get_data(data_field_names)
         field_reader = self._get_data_field_readers()

--- a/src/furax/mapmaking/mapmaker.py
+++ b/src/furax/mapmaking/mapmaker.py
@@ -1,6 +1,6 @@
 import pickle
 from abc import abstractmethod
-from collections.abc import Sequence
+from collections.abc import Collection, Sequence
 from dataclasses import asdict, dataclass
 from functools import cached_property
 from logging import Logger
@@ -49,7 +49,7 @@ from . import templates
 from ._geometry import minimum_enclosing_arc
 from ._logger import logger as furax_logger
 from ._model import ObservationModel, pad_model
-from ._observation import AbstractGroundObservation, AbstractLazyObservation
+from ._observation import AbstractGroundObservation, AbstractLazyObservation, ReaderField
 from ._reader import ObservationReader
 from ._scan_blocks import ScanBlockColumnOperator, ScanBlockDiagonalOperator
 from .config import (
@@ -135,7 +135,7 @@ class MultiObservationMapMaker(Generic[T]):
         _, _, n_pad = self.obs_distribution
         return np.pad(self.get_read_indices(), (0, n_pad), mode='edge')
 
-    def get_reader(self, required_fields: Sequence[str]) -> ObservationReader[T]:
+    def get_reader(self, required_fields: Collection[str]) -> ObservationReader[T]:
         """Build an ObservationReader for this process's local observations."""
         # Pass padded indices: process_allgather inside from_observations needs every
         # rank to send the same shape, so all ranks must report the same obs count.
@@ -250,25 +250,7 @@ class MultiObservationMapMaker(Generic[T]):
         ``n_owned`` entries along the leading axis (no padding). Padding to the
         uniform per-process count is applied by the caller before sharding.
         """
-        required_fields = [
-            'boresight_quaternions',
-            'detector_quaternions',
-            'valid_sample_masks',
-            'timestamps',
-        ]
-        if not self.config.demodulated:
-            # FIXME: this does not handle the case of a telescope without HWP
-            required_fields.append('hwp_angles')
-        if self.config.scanning_mask:
-            required_fields.append('valid_scanning_masks')
-        if self.config.weighting.mode != WeightingMode.IDENTITY:
-            if self.config.weighting.source == NoiseSource.FIT:
-                required_fields.extend(['sample_data', 'hwp_angles'])
-            else:
-                required_fields.append('noise_model_fits')
-        if self.config.gaps.fill and not self.config.binned:
-            required_fields.append('metadata')
-
+        required_fields = ObservationModel.required_reader_fields(self.config)
         reader = self.get_reader(required_fields)
 
         def build_one(_, i):  # type: ignore[no-untyped-def]
@@ -284,7 +266,7 @@ class MultiObservationMapMaker(Generic[T]):
 
     def accumulate_rhs(self, model: ObservationModel) -> StokesPyTreeType:
         """Accumulate the RHS vector across all observations."""
-        reader = self.get_reader(['metadata', 'sample_data'])
+        reader = self.get_reader([ReaderField.METADATA, ReaderField.SAMPLE_DATA])
         read_indices = self.distribute(self.get_padded_read_indices())
         config = self.config
         fill_gaps = config.gaps.fill and not config.binned
@@ -335,7 +317,7 @@ class MultiObservationMapMaker(Generic[T]):
         wcs_config = lc.wcs
         res = wcs_config.resolution * pixell.utils.arcmin
         proj = wcs_config.projection.name.lower()
-        pointing_fields = ['boresight_quaternions', 'detector_quaternions']
+        pointing_fields = [ReaderField.BORESIGHT_QUATERNIONS, ReaderField.DETECTOR_QUATERNIONS]
 
         n = len(self.observations)
         corners_rad = np.empty((2, 2, n))  # [bottom-left, top-right] corners per observation
@@ -408,7 +390,7 @@ def accumulate_rhs(
         def step(carry: StokesPyTreeType, args: Any) -> tuple[StokesPyTreeType, None]:
             obs, i = args
             data, _ = reader.read(i)
-            tod = data['sample_data']
+            tod = data[ReaderField.SAMPLE_DATA]
             if fill_gaps:
                 if correlation_length is None or gap_filling_params is None:
                     raise ValueError(
@@ -418,7 +400,7 @@ def accumulate_rhs(
                 gap_fill = GapFillingOperator(
                     N,
                     obs._get_indexer(),
-                    data['metadata'],
+                    data[ReaderField.METADATA],
                     obs.W,
                     rate=obs.sample_rate,
                     max_cg_steps=gap_filling_params.max_steps,


### PR DESCRIPTION
Refactor to improve handling of reader fields throughout the mapmaking code.

Changes:
- Introduce `ReaderField(StrEnum)` as single source of truth for reader field names, avoiding hardcoded string literals except for toast/sotodlib _internal_ names.
- `ObservationModel` gains `required_reader_fields()` staticmethod that lists the fields it needs when `create()` is called. Previously this was done in the mapmaker class.
- Various typing improvements.