### PR TITLE
Add non-ideal HWP operator with physical transfer-matrix model

### DIFF
--- a/src/furax/obs/operators/__init__.py
+++ b/src/furax/obs/operators/__init__.py
@@ -1,5 +1,5 @@
 from ._beam_operator import BeamOperator, BeamOperatorIQU
-from ._hwp import HWPOperator
+from ._hwp import HWPOperator, NonIdealHWPOperator, hwp_mueller_from_stack
 from ._polarizers import LinearPolarizerOperator
 from ._qu_rotations import QURotationOperator
 from ._seds import (
@@ -10,10 +10,20 @@ from ._seds import (
     NoiseDiagonalOperator,
     SynchrotronOperator,
 )
+from ._transfer_matrix import (
+    SO_HF_HWP_STACK,
+    SO_MF_HWP_STACK,
+    Layer,
+    Material,
+    Stack,
+    mueller_matrix,
+)
 
 __all__ = [
     # _hwp
     'HWPOperator',
+    'NonIdealHWPOperator',
+    'hwp_mueller_from_stack',
     # _polarizers
     'LinearPolarizerOperator',
     # _qu_rotations
@@ -28,4 +38,11 @@ __all__ = [
     # _beam_operator
     'BeamOperator',
     'BeamOperatorIQU',
+    # _transfer_matrix
+    'Layer',
+    'Material',
+    'Stack',
+    'SO_MF_HWP_STACK',
+    'SO_HF_HWP_STACK',
+    'mueller_matrix',
 ]

--- a/src/furax/obs/operators/_hwp.py
+++ b/src/furax/obs/operators/_hwp.py
@@ -1,21 +1,15 @@
 import numpy as np
 from jax import Array
+from jax import numpy as jnp
 from jax.typing import DTypeLike
 from jaxtyping import Float
 
 from furax import AbstractLinearOperator, diagonal
 from furax.core.rules import AbstractCompositionRule
 
-from ..stokes import (
-    Stokes,
-    StokesI,
-    StokesIQU,
-    StokesIQUV,
-    StokesQU,
-    StokesType,
-    ValidStokesType,
-)
+from ..stokes import Stokes, StokesType, ValidStokesType
 from ._qu_rotations import QURotationOperator, QURotationTransposeOperator
+from ._transfer_matrix import Stack, mueller_matrix
 
 
 @diagonal
@@ -23,12 +17,23 @@ class HWPOperator(AbstractLinearOperator):
     """Operator for an ideal half-wave plate (HWP).
 
     A HWP flips the sign of the U (and V) Stokes parameters while leaving
-    I and Q unchanged. This models the Mueller matrix diag(1, 1, -1, -1).
+    I and Q unchanged. This models the Mueller matrix `diag(1, 1, -1, -1)`.
 
-    The operator is diagonal and symmetric. For a rotating HWP at angle theta,
-    use ``HWPOperator.create(..., angles=theta)`` which computes R(-theta) @ HWP @ R(theta).
+    The operator is diagonal and symmetric.
 
-    Algebraic rule: R(theta) @ HWP = HWP @ R(-theta).
+    Algebraic rule: `R(theta) @ HWP = HWP @ R(-theta)`.
+
+    Examples:
+        A fixed HWP:
+
+        >>> import jax.numpy as jnp
+        >>> from furax.obs.operators import HWPOperator
+        >>> hwp = HWPOperator.create(shape=(5,), stokes='IQU')
+
+        A rotating HWP at angle theta, computed as R(-theta) @ HWP @ R(theta):
+
+        >>> theta = jnp.linspace(0, jnp.pi, 5)
+        >>> hwp = HWPOperator.create(shape=(5,), stokes='IQU', angles=theta)
     """
 
     @classmethod
@@ -40,6 +45,18 @@ class HWPOperator(AbstractLinearOperator):
         *,
         angles: Float[Array, '...'] | None = None,
     ) -> AbstractLinearOperator:
+        """Build an HWP operator.
+
+        Args:
+            shape: Shape of each Stokes component the operator acts on.
+            dtype: Floating-point dtype of the Stokes data.
+            stokes: Stokes components the operator acts on.
+            angles: HWP rotation angles in radians, broadcastable to ``shape``.
+                If None, the HWP is fixed (no rotation).
+
+        Returns:
+            A fixed HWP, or ``R(-angles) @ HWP @ R(angles)`` if `angles` is given.
+        """
         in_structure = Stokes.class_for(stokes).structure_for(shape, dtype)
         hwp = cls(in_structure=in_structure)
         if angles is None:
@@ -49,19 +66,145 @@ class HWPOperator(AbstractLinearOperator):
         return rotated_hwp
 
     def mv(self, x: StokesType) -> Stokes:
-        if isinstance(x, StokesI):
+        # Canonical component order is I, Q, U, V: once 'U' is present, it and
+        # every component after it (i.e. V) flip sign; I and Q are untouched.
+        idx = x.stokes.find('U')
+        if idx < 0:
             return x
-        if isinstance(x, StokesQU):
-            return StokesQU(x.q, -x.u)
-        if isinstance(x, StokesIQU):
-            return StokesIQU(x.i, x.q, -x.u)
-        if isinstance(x, StokesIQUV):
-            return StokesIQUV(x.i, x.q, -x.u, -x.v)
-        raise NotImplementedError
+        return x.from_array(x.data.at[idx:].multiply(-1.0))
+
+
+def hwp_mueller_from_stack(
+    stack: Stack,
+    frequency: Array,
+    angle_incidence: Array,
+) -> Float[Array, '3 3']:
+    """Compute the 3×3 IQU Mueller matrix for a physical HWP stack.
+
+    Uses the built-in transfer matrix method to compute the transmitted
+    Mueller matrix for a multilayer HWP stack at non-normal incidence.
+    JIT-friendly: ``frequency`` and ``angle_incidence`` are JAX-traced.
+
+    Args:
+        stack: A [`Stack`][furax.obs.operators.Stack] instance.
+        frequency: Frequency in Hz.
+        angle_incidence: Angle of incidence in radians.
+
+    Returns:
+        3×3 JAX array — the IQU block of the transmitted Mueller matrix.
+
+    Examples:
+        Build a per-detector batched Mueller matrix (shape ``(n_det, 3, 3)``) by
+        vmapping over angles:
+
+        >>> import jax
+        >>> muellers = jax.vmap(
+        ...     lambda a: hwp_mueller_from_stack(stack, freq, a)
+        ... )(focal_plane_angles)  # focal_plane_angles shape (n_det,)
+    """
+    return mueller_matrix(stack, frequency, angle_incidence)[:-1, :-1]
+
+
+class NonIdealHWPOperator(AbstractLinearOperator):
+    """HWP operator with full 3×3 IQU Mueller matrix, for non-normal incidence.
+
+    Unlike the ideal HWP (which simply flips U sign), this operator applies a
+    pre-computed frequency- and angle-dependent Mueller matrix. All IQU
+    components can mix.
+
+    Attributes:
+        mueller: The 3×3 IQU Mueller matrix, or a batched ``(*batch, 3, 3)`` array
+            where the batch dimensions form a leading prefix of each Stokes
+            component's shape. The typical batched case is ``(n_det, 3, 3)``
+            paired with Stokes components of shape ``(n_det, n_samples)``.
+
+    Examples:
+        Compute the Mueller matrix from a physical HWP stack, then build a
+        fixed operator:
+
+        >>> import jax.numpy as jnp
+        >>> from furax.obs.operators import (
+        ...     SO_MF_HWP_STACK, NonIdealHWPOperator, hwp_mueller_from_stack
+        ... )
+        >>> M = hwp_mueller_from_stack(SO_MF_HWP_STACK, frequency=150e9, angle_incidence=0.0)
+        >>> hwp = NonIdealHWPOperator.create(shape=(5,), stokes='IQU', mueller=M)
+
+        A rotating HWP at angle theta, computed as R(-theta) @ HWP @ R(theta):
+
+        >>> theta = jnp.linspace(0, jnp.pi, 5)
+        >>> hwp = NonIdealHWPOperator.create(shape=(5,), stokes='IQU', mueller=M, angles=theta)
+
+    Note:
+        For StokesIQUV input, V is passed through unchanged (not modelled).
+    """
+
+    mueller: Array
+
+    @classmethod
+    def create(
+        cls,
+        shape: tuple[int, ...],
+        dtype: DTypeLike = np.float64,
+        stokes: ValidStokesType = 'IQU',
+        *,
+        mueller: Array,
+        angles: Float[Array, '...'] | None = None,
+    ) -> AbstractLinearOperator:
+        """Build a non-ideal HWP operator.
+
+        Args:
+            shape: Shape of each Stokes component the operator acts on.
+            dtype: Floating-point dtype of the Stokes data.
+            stokes: Stokes components the operator acts on.
+            mueller: The 3×3 IQU Mueller matrix, or a batched ``(*batch, 3, 3)``
+                array; see the class docstring.
+            angles: HWP rotation angles in radians, broadcastable to ``shape``.
+                If None, the HWP is fixed (no rotation).
+
+        Returns:
+            A fixed HWP, or ``R(-angles) @ HWP @ R(angles)`` if `angles` is given.
+        """
+        in_structure = Stokes.class_for(stokes).structure_for(shape, dtype)
+        op = cls(mueller=mueller, in_structure=in_structure)
+        if angles is None:
+            return op
+        rot = QURotationOperator(angles=angles, in_structure=in_structure)
+        return rot.T @ op @ rot
+
+    _MUELLER_SLICE = {
+        'I': slice(0, 1),
+        'QU': slice(1, 3),
+        'IQU': slice(0, 3),
+        'IQUV': slice(0, 3),
+    }
+
+    def mv(self, x: StokesType) -> StokesType:
+        # Slice the Mueller matrix to keep only relevant components
+        sl = self._MUELLER_SLICE[x.stokes]
+        data = x.data[:3]  # drops V if x has it; no-op otherwise
+        M = self.mueller[..., sl, sl]
+
+        # M may have batch dims that are a leading prefix of data's trailing dims,
+        # e.g. M shape (n_det, k, k) with data shape (k, n_det, n_samples).
+        stk = jnp.moveaxis(data, 0, -1)  # (*batch, *extra, k)
+        extra_ndim = stk.ndim - M.ndim + 1
+        M_exp = M.reshape(M.shape[:-2] + (1,) * extra_ndim + M.shape[-2:])
+        out = (M_exp @ stk[..., None]).squeeze(-1)  # (*batch, *extra, k)
+        out = jnp.moveaxis(out, -1, 0)  # (k, *batch, *extra)
+
+        if x.stokes == 'IQUV':
+            return x.from_array(jnp.concatenate([out, x.data[3:]]))  # append V
+        return x.from_array(out)
+
+    def transpose(self) -> 'NonIdealHWPOperator':
+        return NonIdealHWPOperator(
+            mueller=jnp.swapaxes(self.mueller, -2, -1),
+            in_structure=self.in_structure,
+        )
 
 
 class QURotationHWPRule(AbstractCompositionRule):
-    """Binary rule for R(theta) @ HWP = HWP @ R(-theta)`."""
+    """Binary rule for R(theta) @ HWP = HWP @ R(-theta)."""
 
     left_operator_class = (QURotationOperator, QURotationTransposeOperator)
     right_operator_class = HWPOperator

--- a/src/furax/obs/operators/_transfer_matrix.py
+++ b/src/furax/obs/operators/_transfer_matrix.py
@@ -1,0 +1,427 @@
+"""Pure-JAX transfer matrix method for multilayer optical stacks.
+
+Reference:
+    Jones (1941), "A new calculus for the treatment of optical systems";
+    Goldstein (2003), "Polarized Light".
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import NamedTuple
+
+import jax.numpy as jnp
+import numpy as np
+from jax import Array
+from jaxtyping import Complex, Float
+
+_C = 2.998e8  # speed of light, m/s
+
+# Pauli-like basis for the Jones → Mueller formula:
+#   M[i,j] = Re( Tr(Σᵢ J Σⱼ J†) ) / 2
+_SIGMA = jnp.array(
+    [
+        [[1, 0], [0, 1]],  # I
+        [[1, 0], [0, -1]],  # Q
+        [[0, 1], [1, 0]],  # U
+        [[0, -1j], [1j, 0]],  # V
+    ],
+    dtype=jnp.complex128,
+)
+
+__all__ = [
+    'Material',
+    'Layer',
+    'Stack',
+    'SO_MF_HWP_STACK',
+    'SO_HF_HWP_STACK',
+    'mueller_matrix',
+]
+
+
+# ---------------------------------------------------------------------------
+# Physical types
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class Material:
+    """Optical properties of an isotropic or uniaxial material.
+
+    Attributes:
+        n_o: Ordinary refractive index.
+        n_e: Extraordinary refractive index (equal to ``n_o`` for isotropic).
+        loss_o: Ordinary loss tangent Im(ε)/Re(ε).
+        loss_e: Extraordinary loss tangent.
+    """
+
+    n_o: float
+    n_e: float
+    loss_o: float = 0.0
+    loss_e: float = 0.0
+
+    @classmethod
+    def isotropic(cls, n: float, loss: float = 0.0) -> Material:
+        return cls(n_o=n, n_e=n, loss_o=loss, loss_e=loss)
+
+
+class Layer(NamedTuple):
+    """A single layer of a multilayer optical stack.
+
+    Attributes:
+        thickness: Layer thickness in metres.
+        material: Optical properties of the layer.
+        crystal_angle: Extraordinary-axis orientation (radians from the x-axis)
+            for uniaxial layers; zero for isotropic layers.
+    """
+
+    thickness: float
+    material: Material
+    crystal_angle: float = 0.0
+
+
+@dataclass(frozen=True)
+class Stack:
+    """Multilayer optical stack.
+
+    Attributes:
+        layers: The stack's layers, ordered from the input medium to the exit medium.
+    """
+
+    layers: tuple[Layer, ...]
+
+    def __post_init__(self) -> None:
+        # Coerce list/other-sequence input to a tuple so the dataclass stays hashable.
+        object.__setattr__(self, 'layers', tuple(self.layers))
+
+
+# ---------------------------------------------------------------------------
+# Simons Observatory HWP stacks
+# ---------------------------------------------------------------------------
+
+_MM = 1e-3  # metres per millimetre
+_DEG = np.pi / 180  # radians per degree
+
+# Materials (shared between MF and HF)
+_SAPPHIRE = Material(n_o=3.05, n_e=3.38, loss_o=2.3e-4, loss_e=1.25e-4)
+_DUROID = Material.isotropic(n=1.41, loss=1.2e-3)
+_MULLITE = Material.isotropic(n=2.52, loss=0.0121)
+_EPOTECK = Material.isotropic(n=1.70, loss=0.0)
+
+
+def _so_hwp_stack(cap: float, bond: float, ar: float, ply: float, crystal_angle: float) -> Stack:
+    """Build a symmetric 9-layer SO HWP stack: cap/bond/AR/3x sapphire ply/AR/bond/cap."""
+    return Stack(
+        layers=(
+            Layer(cap, _DUROID),
+            Layer(bond, _EPOTECK),
+            Layer(ar, _MULLITE),
+            Layer(ply, _SAPPHIRE),
+            Layer(ply, _SAPPHIRE, crystal_angle),
+            Layer(ply, _SAPPHIRE),
+            Layer(ar, _MULLITE),
+            Layer(bond, _EPOTECK),
+            Layer(cap, _DUROID),
+        )
+    )
+
+
+SO_MF_HWP_STACK = _so_hwp_stack(
+    cap=0.394 * _MM,
+    bond=0.04 * _MM,
+    ar=0.212 * _MM,
+    ply=3.75 * _MM,
+    crystal_angle=54.0 * _DEG,
+)
+"""Simons Observatory MF (85–145 GHz) HWP stack."""
+
+SO_HF_HWP_STACK = _so_hwp_stack(
+    cap=0.183 * _MM,
+    bond=0.04 * _MM,
+    ar=0.097 * _MM,
+    ply=1.60 * _MM,
+    crystal_angle=57.0 * _DEG,
+)
+"""Simons Observatory HF (225–280 GHz) HWP stack."""
+
+
+# ---------------------------------------------------------------------------
+# Core computation: pure JAX functions
+# ---------------------------------------------------------------------------
+
+
+def _jones_to_mueller(J: Array) -> Float[Array, '4 4']:
+    """Convert a 2×2 Jones matrix to a 4×4 real Mueller matrix."""
+    # M[i,j] = Re( Tr(Σᵢ J Σⱼ J†) ) / 2
+    # = Re( Σᵢ[a,b] J[b,c] Σⱼ[c,d] conj(J)[a,d] ) / 2
+    return jnp.einsum('iab,bc,jcd,ad->ij', _SIGMA, J, _SIGMA, jnp.conj(J)).real / 2
+
+
+def _layer_transfer_matrix(
+    material: Material,
+    thickness: float,
+    frequency: Array,
+    nsin: Array,
+    chi: float,
+) -> Complex[Array, '4 4']:
+    """4×4 complex transfer matrix for a single anisotropic layer.
+
+    Args:
+        material: Optical properties of the layer.
+        thickness: Layer thickness in metres (static).
+        frequency: Frequency in Hz (JAX-traced).
+        nsin: Snell's-law invariant n₀ sin θ₀ (JAX-traced).
+        chi: Extraordinary-axis orientation in radians (static).
+    """
+    nO = float(material.n_o)
+    nEmat = float(material.n_e)
+
+    # Effective extraordinary index corrected for oblique incidence
+    nE = nEmat * jnp.sqrt(1 + (nEmat**-2 - nO**-2) * nsin**2 * np.cos(chi) ** 2)
+
+    thetaO = jnp.arcsin(nsin / nO)
+    thetaE = jnp.arcsin(nsin / nE)
+
+    # Complex refractive indices (loss included)
+    n_o_c = jnp.sqrt(jnp.array((1 - 1j * material.loss_o) * nO**2, dtype=jnp.complex128))
+    n_e_c = jnp.sqrt(jnp.array((1 - 1j * material.loss_e) * nE**2, dtype=jnp.complex128))
+
+    k0 = 2 * jnp.pi * frequency / _C
+
+    # ------------------------------------------------------------------
+    # Rotated dielectric tensor (3×3 complex)
+    # rot is constant at JIT time since chi is static
+    # ------------------------------------------------------------------
+    c_chi, s_chi = float(np.cos(chi)), float(np.sin(chi))
+    rot = jnp.array(
+        [[c_chi, -s_chi, 0.0], [s_chi, c_chi, 0.0], [0.0, 0.0, 1.0]],
+        dtype=jnp.complex128,
+    )
+    eps = jnp.diag(jnp.array([nE**2, nO**2, nO**2], dtype=jnp.complex128))
+    eps_rot = rot @ eps @ rot.conj().T  # rot.T = rot.conj().T for real chi
+    eps_rot_inv = jnp.linalg.inv(eps_rot)
+
+    # ------------------------------------------------------------------
+    # Field polarisation vectors for ordinary and extraordinary rays
+    # ------------------------------------------------------------------
+    # Ordinary displacement D
+    denom_Do = jnp.sqrt(jnp.cos(thetaO) ** 2 + jnp.sin(thetaO) ** 2 * s_chi**2)
+    D_o = (
+        jnp.array(
+            [
+                -s_chi * jnp.cos(thetaO),
+                c_chi * jnp.cos(thetaO),
+                s_chi * jnp.sin(thetaO),
+            ],
+            dtype=jnp.complex128,
+        )
+        / denom_Do
+    )
+
+    # Ordinary magnetic H
+    denom_Ho = jnp.sqrt(jnp.cos(thetaO) ** 2 * c_chi**2 + s_chi**2)
+    H_o = (
+        jnp.array(
+            [
+                -(jnp.cos(thetaO) ** 2) * c_chi,
+                -s_chi,
+                jnp.cos(thetaO) * jnp.sin(thetaO) * c_chi,
+            ],
+            dtype=jnp.complex128,
+        )
+        / denom_Ho
+    )
+
+    # Extraordinary displacement D
+    denom_De = jnp.sqrt(c_chi**2 * jnp.cos(thetaO) ** 2 + s_chi**2 * jnp.cos(thetaO - thetaE) ** 2)
+    D_e = (
+        jnp.array(
+            [
+                c_chi * jnp.cos(thetaO) * jnp.cos(thetaE),
+                s_chi * (jnp.sin(thetaO) * jnp.sin(thetaE) + jnp.cos(thetaO) * jnp.cos(thetaE)),
+                -c_chi * jnp.cos(thetaE) * jnp.sin(thetaO),
+            ],
+            dtype=jnp.complex128,
+        )
+        / denom_De
+    )
+
+    # Extraordinary magnetic H
+    denom_He = jnp.sqrt(jnp.cos(thetaO - thetaE) ** 2 * s_chi**2 + jnp.cos(thetaO) ** 2 * c_chi**2)
+    H_e = (
+        jnp.array(
+            [
+                -jnp.cos(thetaO - thetaE) * jnp.cos(thetaE) * s_chi,
+                jnp.cos(thetaO) * c_chi,
+                jnp.cos(thetaO - thetaE) * jnp.sin(thetaE) * s_chi,
+            ],
+            dtype=jnp.complex128,
+        )
+        / denom_He
+    )
+
+    # ------------------------------------------------------------------
+    # Phi: relates boundary tangential fields to wave amplitudes
+    # ------------------------------------------------------------------
+    Phi = jnp.array(
+        [
+            [D_o[0], D_e[0], D_o[0], D_e[0]],
+            [H_o[1] / nO, H_e[1] / nE, -H_o[1] / nO, -H_e[1] / nE],
+            [D_o[1], D_e[1], D_o[1], D_e[1]],
+            [-H_o[0] / nO, -H_e[0] / nE, H_o[0] / nO, H_e[0] / nE],
+        ],
+        dtype=jnp.complex128,
+    )
+
+    # Phase accumulated crossing the layer
+    delta_o = 1j * k0 * n_o_c * thickness * jnp.cos(thetaO)
+    delta_e = 1j * k0 * n_e_c * thickness * jnp.cos(thetaE)
+    P = jnp.diag(
+        jnp.array(
+            [jnp.exp(-delta_o), jnp.exp(-delta_e), jnp.exp(delta_o), jnp.exp(delta_e)],
+            dtype=jnp.complex128,
+        )
+    )
+
+    # Psi: D-field to E-field conversion via inverse dielectric tensor
+    Psi = jnp.array(
+        [
+            [eps_rot_inv[0, 0], 0, eps_rot_inv[0, 1], 0],
+            [0, 1, 0, 0],
+            [eps_rot_inv[1, 0], 0, eps_rot_inv[1, 1], 0],
+            [0, 0, 0, 1],
+        ],
+        dtype=jnp.complex128,
+    )
+
+    # Transfer matrix: Ψ Φ (Ψ Φ P)⁻¹
+    PsiPhi = Psi @ Phi
+    return PsiPhi @ jnp.linalg.inv(PsiPhi @ P)  # type: ignore[no-any-return]
+
+
+def _stack_transfer_matrix(
+    stack: Stack,
+    frequency: Array,
+    incidence_angle: Array,
+    rotation: float = 0.0,
+    input_index: float = 1.0,
+) -> Complex[Array, '4 4']:
+    """Product of all layer transfer matrices (left to right).
+
+    Args:
+        stack: Multilayer stack (static Python dataclass).
+        frequency: Frequency in Hz (JAX-traced).
+        incidence_angle: Angle of incidence in radians (JAX-traced).
+        rotation: Stack rotation about the optical axis in radians (static).
+        input_index: Refractive index of the input medium (static).
+    """
+    nsin = jnp.sin(incidence_angle) * input_index
+    total = jnp.eye(4, dtype=jnp.complex128)
+    for layer in stack.layers:
+        total = total @ _layer_transfer_matrix(
+            layer.material, layer.thickness, frequency, nsin, layer.crystal_angle + rotation
+        )
+    return total
+
+
+def _transfer_to_jones(
+    total: Array,
+    incidence_angle: Array,
+    input_index: float,
+    exit_index: float,
+) -> tuple[Complex[Array, '2 2'], Complex[Array, '2 2']]:
+    """Transmitted and reflected Jones matrices from the total transfer matrix.
+
+    Args:
+        total: Product of all layer transfer matrices (JAX-traced).
+        incidence_angle: Angle of incidence in radians (JAX-traced).
+        input_index: Refractive index of the input medium (static).
+        exit_index: Refractive index of the exit medium (static).
+
+    Returns:
+        Tuple of ``(transmitted, reflected)`` 2×2 complex Jones matrices.
+    """
+    nsin = jnp.sin(incidence_angle) * input_index
+    exit_angle = jnp.arcsin(nsin / exit_index)
+    m = total
+    n1, n3 = float(input_index), float(exit_index)
+    th1, th3 = incidence_angle, exit_angle
+
+    A = (m[0, 0] * jnp.cos(th3) + m[0, 1] * n3) / jnp.cos(th1)
+    B = (m[0, 2] + m[0, 3] * n3 * jnp.cos(th3)) / jnp.cos(th1)
+    C = (m[1, 0] * jnp.cos(th3) + m[1, 1] * n3) / n1
+    D = (m[1, 2] + m[1, 3] * n3 * jnp.cos(th3)) / n1
+    N = m[2, 0] * jnp.cos(th3) + m[2, 1] * n3
+    K = m[2, 2] + m[2, 3] * n3 * jnp.cos(th3)
+    Pv = (m[3, 0] * jnp.cos(th3) + m[3, 1] * n3) / (n1 * jnp.cos(th1))
+    S = (m[3, 2] + m[3, 3] * n3 * jnp.cos(th3)) / (n1 * jnp.cos(th1))
+
+    denom = (A + C) * (K + S) - (B + D) * (N + Pv)
+    J_tran = jnp.array([[K + S, -B - D], [-N - Pv, A + C]], dtype=jnp.complex128) * 2 / denom
+    J_refl = (
+        jnp.array(
+            [
+                [(C - A) * (K + S) - (D - B) * (N + Pv), 2 * (A * D - C * B)],
+                [2 * (N * S - Pv * K), (A + C) * (K - S) - (D + B) * (N - Pv)],
+            ],
+            dtype=jnp.complex128,
+        )
+        / denom
+    )
+    return J_tran, J_refl
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+def mueller_matrix(
+    stack: Stack,
+    frequency: Array,
+    incidence_angle: Array,
+    rotation: float = 0.0,
+    input_index: float = 1.0,
+    exit_index: float = 1.0,
+    *,
+    reflected: bool = False,
+) -> Float[Array, '4 4']:
+    """4×4 Mueller matrix for light through a multilayer optical stack.
+
+    JIT-friendly: ``frequency`` and ``incidence_angle`` are JAX-traced.
+    Use ``jax.vmap`` to batch over either quantity efficiently.
+
+    Args:
+        stack: Multilayer stack (static Python dataclass).
+        frequency: Frequency in Hz.
+        incidence_angle: Angle of incidence in radians.
+        rotation: Stack rotation about the optical axis in radians.
+        input_index: Refractive index of the input medium.
+        exit_index: Refractive index of the exit medium.
+        reflected: Return the reflected Mueller matrix instead of transmitted.
+
+    Returns:
+        4×4 real Mueller matrix.
+
+    Examples:
+        >>> import jax
+        >>> import jax.numpy as jnp
+        >>> from furax.obs.operators import mueller_matrix, Layer, Material, Stack
+        >>> sapphire = Material(n_o=3.05, n_e=3.38, loss_o=2.3e-4, loss_e=1.25e-4)
+        >>> stack = Stack(
+        ...     layers=[
+        ...         Layer(thickness=3.75e-3, material=sapphire),
+        ...         Layer(thickness=3.75e-3, material=sapphire, crystal_angle=jnp.deg2rad(54.0)),
+        ...         Layer(thickness=3.75e-3, material=sapphire),
+        ...     ]
+        ... )
+        >>> M = mueller_matrix(stack, frequency=150e9, incidence_angle=jnp.deg2rad(5.0))
+
+        Batched over detectors with different incident angles:
+
+        >>> angles = jnp.deg2rad(jnp.linspace(0, 10, 64))
+        >>> Ms = jax.vmap(lambda a: mueller_matrix(stack, 150e9, a))(angles)
+    """
+    total = _stack_transfer_matrix(stack, frequency, incidence_angle, rotation, input_index)
+    J_tran, J_refl = _transfer_to_jones(total, incidence_angle, input_index, exit_index)
+    return _jones_to_mueller(J_refl if reflected else J_tran)


### PR DESCRIPTION
Changes:

- Adds `NonIdealHWPOperator`: applies a full 3×3 IQU Mueller matrix (unlike the existing ideal `HWPOperator`, which just flips U/V sign), for modelling non-normal incidence and realistic HWP behavior.
- Adds `_transfer_matrix.py`: a pure-JAX Jones/Mueller transfer-matrix method to compute a physical HWP's Mueller matrix corresponding to a multilayer birefringent stack.
- Exposes pre-defined `SO_MF_HWP_STACK` / `SO_HF_HWP_STACK` constants for SO MF and HF sapphire HWP stacks.
- Rework `HWPOperator.mv` to operate directly on `Stokes`'s single stacked array instead of per-type branching.