### PR TITLE
Only check shape and dtype for structure compatibility

### DIFF
--- a/src/furax/core/_base.py
+++ b/src/furax/core/_base.py
@@ -26,6 +26,23 @@ from furax.tree import zeros_like
 from .utils import register_dataclass_with_keys
 
 
+def structure_equal(a: PyTree[jax.ShapeDtypeStruct], b: PyTree[jax.ShapeDtypeStruct]) -> bool:
+    """Compare operator structures by tree shape, array shape and dtype, ignoring sharding.
+
+    Sharding is a runtime data-layout concern, not part of an operator's logical structure.
+    """
+    a_leaves, a_treedef = jax.tree.flatten(a)
+    b_leaves, b_treedef = jax.tree.flatten(b)
+    # equal treedefs guarantee equal leaf counts, so the zip below is aligned
+    return (
+        a_treedef == b_treedef  # type: ignore[operator]
+        and all(
+            x.shape == y.shape and x.dtype == y.dtype
+            for x, y in zip(a_leaves, b_leaves, strict=True)
+        )
+    )
+
+
 class OperatorTag(IntFlag):
     """Flags representing properties of linear operators."""
 
@@ -124,7 +141,7 @@ class AbstractLinearOperator(ABC):
     def __matmul__(self, other: Any) -> 'AbstractLinearOperator':
         if not isinstance(other, AbstractLinearOperator):
             return NotImplemented
-        if self.in_structure != other.out_structure:
+        if not structure_equal(self.in_structure, other.out_structure):
             msg = (
                 f'Incompatible linear operator structures: '
                 f'self.in_structure={self.in_structure}, '
@@ -142,9 +159,9 @@ class AbstractLinearOperator(ABC):
     def __add__(self, other: Any) -> 'AbstractLinearOperator':
         if not isinstance(other, AbstractLinearOperator):
             return NotImplemented
-        if self.in_structure != other.in_structure:
+        if not structure_equal(self.in_structure, other.in_structure):
             raise ValueError('Incompatible linear operator input structures')
-        if self.out_structure != other.out_structure:
+        if not structure_equal(self.out_structure, other.out_structure):
             raise ValueError('Incompatible linear operator output structures')
         if isinstance(other, AdditionOperator):
             return NotImplemented
@@ -154,9 +171,9 @@ class AbstractLinearOperator(ABC):
     def __sub__(self, other: Any) -> 'AbstractLinearOperator':
         if not isinstance(other, AbstractLinearOperator):
             return NotImplemented
-        if self.in_structure != other.in_structure:
+        if not structure_equal(self.in_structure, other.in_structure):
             raise ValueError('Incompatible linear operator input structures')
-        if self.out_structure != other.out_structure:
+        if not structure_equal(self.out_structure, other.out_structure):
             raise ValueError('Incompatible linear operator output structures')
 
         result: AbstractLinearOperator = self + (-other)
@@ -378,9 +395,9 @@ class AdditionOperator(AbstractLinearOperator):
     def __add__(self, other: AbstractLinearOperator) -> 'AdditionOperator':
         if not isinstance(other, AbstractLinearOperator):
             return NotImplemented
-        if self.in_structure != other.in_structure:
+        if not structure_equal(self.in_structure, other.in_structure):
             raise ValueError('Incompatible linear operator input structures')
-        if self.out_structure != other.out_structure:
+        if not structure_equal(self.out_structure, other.out_structure):
             raise ValueError('Incompatible linear operator output structures')
         if isinstance(other, AdditionOperator):
             operands = other.operand_leaves
@@ -391,9 +408,9 @@ class AdditionOperator(AbstractLinearOperator):
     def __radd__(self, other: AbstractLinearOperator) -> 'AdditionOperator':
         if not isinstance(other, AbstractLinearOperator):
             return NotImplemented
-        if self.in_structure != other.in_structure:
+        if not structure_equal(self.in_structure, other.in_structure):
             raise ValueError('Incompatible linear operator input structures')
-        if self.out_structure != other.out_structure:
+        if not structure_equal(self.out_structure, other.out_structure):
             raise ValueError('Incompatible linear operator output structures')
         return AdditionOperator([other] + self.operand_leaves)
 
@@ -444,8 +461,8 @@ class CompositionOperator(AbstractLinearOperator):
     # Tag propagation properties
     @property
     def is_square(self) -> bool:
-        result: bool = super().is_square or (
-            self.operands[0].out_structure == self.operands[-1].in_structure
+        result: bool = super().is_square or structure_equal(
+            self.operands[0].out_structure, self.operands[-1].in_structure
         )
         return result
 
@@ -464,7 +481,7 @@ class CompositionOperator(AbstractLinearOperator):
     def __matmul__(self, other: AbstractLinearOperator) -> 'CompositionOperator':
         if not isinstance(other, AbstractLinearOperator):
             return NotImplemented
-        if self.in_structure != other.out_structure:
+        if not structure_equal(self.in_structure, other.out_structure):
             msg = (
                 f'Incompatible linear operator structures: '
                 f'self.in_structure={self.in_structure}, '
@@ -480,7 +497,7 @@ class CompositionOperator(AbstractLinearOperator):
     def __rmatmul__(self, other: AbstractLinearOperator) -> 'CompositionOperator':
         if not isinstance(other, AbstractLinearOperator):
             return NotImplemented
-        if self.out_structure != other.in_structure:
+        if not structure_equal(self.out_structure, other.in_structure):
             msg = (
                 f'Incompatible linear operator structures: '
                 f'self.out_structure={self.out_structure}, '
@@ -568,7 +585,7 @@ class InverseOperator(AbstractLazyInverseOperator):
 
     def __post_init__(self) -> None:
         super().__post_init__()
-        if self.operator.in_structure != self.operator.out_structure:
+        if not structure_equal(self.operator.in_structure, self.operator.out_structure):
             raise ValueError('Only square operators can be inverted.')
         object.__setattr__(self, 'operator', self.operator.reduce())
 

--- a/src/furax/core/_blocks.py
+++ b/src/furax/core/_blocks.py
@@ -11,7 +11,12 @@ from jax.tree_util import PyTreeDef
 from jaxtyping import Inexact, PyTree
 
 from ..tree import add
-from ._base import AbstractLinearOperator, AdditionOperator, IdentityOperator
+from ._base import (
+    AbstractLinearOperator,
+    AdditionOperator,
+    IdentityOperator,
+    structure_equal,
+)
 from .rules import AbstractCompositionRule
 
 
@@ -80,7 +85,7 @@ class BlockRowOperator(AbstractBlockOperator):
         invalid_structures = [
             structure
             for operator in operators[1:]
-            if (structure := operator.out_structure) != ref_structure
+            if not structure_equal((structure := operator.out_structure), ref_structure)
         ]
         if len(invalid_structures) > 0:
             structures_as_str = '\n - '.join(str(structure) for structure in invalid_structures)
@@ -162,7 +167,9 @@ class BlockDiagonalOperator(AbstractBlockOperator):
 
     def inverse(self) -> AbstractLinearOperator:
         # if some of the blocks are not square, let's defer to the default inverse method
-        if not jax.tree.all(self._tree_map(lambda op: op.in_structure == op.out_structure)):
+        if not jax.tree.all(
+            self._tree_map(lambda op: structure_equal(op.in_structure, op.out_structure))
+        ):
             return super().inverse()
         return BlockDiagonalOperator(self._tree_map(lambda op: op.I))
 
@@ -224,7 +231,7 @@ class BlockColumnOperator(AbstractBlockOperator):
         invalid_structures = [
             structure
             for operator in operators[1:]
-            if (structure := operator.in_structure) != ref_structure
+            if not structure_equal((structure := operator.in_structure), ref_structure)
         ]
         if len(invalid_structures) > 0:
             structures_as_str = '\n - '.join(str(structure) for structure in invalid_structures)

--- a/src/furax/mapmaking/_scan_blocks.py
+++ b/src/furax/mapmaking/_scan_blocks.py
@@ -5,7 +5,7 @@ from typing import ClassVar, Self
 import jax
 import jax.numpy as jnp
 from jax import Array
-from jax.sharding import AbstractMesh, NamedSharding
+from jax.sharding import AbstractMesh
 from jax.sharding import PartitionSpec as P
 from jaxtyping import Inexact, PyTree
 
@@ -18,11 +18,6 @@ from furax.core import (
     IdentityOperator,
 )
 from furax.core.rules import AbstractAdditionRule, AbstractCompositionRule, NoReduction
-
-# jax.eval_shape inside a jax.set_mesh context annotates outputs with sharding information,
-# which breaks operator compatibility checks. Wrapping inner transpose/reduction calls with
-# use_abstract_mesh(_EMPTY_MESH) clears the active mesh so those structs stay sharding-free.
-_EMPTY_MESH = jax.sharding.AbstractMesh((), ())
 
 
 def _get_mesh() -> AbstractMesh:
@@ -62,22 +57,11 @@ def _check_scanned(scanned: AbstractLinearOperator, n_lead: int) -> None:
             )
 
 
-def _augment_structure(
+def _prepend_axis(
     structure: PyTree[jax.ShapeDtypeStruct],
-    *,
-    axis_size: int | None = None,
+    axis_size: int,
 ) -> PyTree[jax.ShapeDtypeStruct]:
-    mesh = jax.sharding.get_abstract_mesh()
-    axis_name = mesh.axis_names[0] if not mesh.empty and axis_size is not None else None
-
-    def transform(s: jax.ShapeDtypeStruct) -> jax.ShapeDtypeStruct:
-        shape = (axis_size, *s.shape) if axis_size is not None else s.shape
-        if axis_name is None:
-            return jax.ShapeDtypeStruct(shape, s.dtype)
-        spec = P(axis_name, *([None] * len(s.shape)))
-        return jax.ShapeDtypeStruct(shape, s.dtype, sharding=NamedSharding(mesh, spec))
-
-    return jax.tree.map(transform, structure)
+    return jax.tree.map(lambda s: jax.ShapeDtypeStruct((axis_size, *s.shape), s.dtype), structure)
 
 
 class AbstractScanBlockOperator(AbstractLinearOperator, ABC):
@@ -100,7 +84,7 @@ class AbstractScanBlockOperator(AbstractLinearOperator, ABC):
 
     The "block" denomination refers to how each slice appears in the global operator matrix:
     subclasses arrange the N per-slice operators as blocks of a larger matrix (diagonal, column, or
-    row layout). The `_augment_in` / `_augment_out` class flags say whether the block prepends the
+    row layout). The `_prepend_in` / `_prepend_out` class flags say whether the block prepends the
     observation axis to its input / output structure.
 
     An active mesh context is required when calling `mv`; use `jax.set_mesh` beforehand.
@@ -111,8 +95,8 @@ class AbstractScanBlockOperator(AbstractLinearOperator, ABC):
     post: AbstractLinearOperator
     n_lead: int = field(kw_only=True, metadata={'static': True})
 
-    _augment_in: ClassVar[bool]
-    _augment_out: ClassVar[bool]
+    _prepend_in: ClassVar[bool]
+    _prepend_out: ClassVar[bool]
 
     @classmethod
     def create(cls, operator: AbstractLinearOperator, *, n_lead: int | None = None) -> Self:
@@ -140,8 +124,8 @@ class AbstractScanBlockOperator(AbstractLinearOperator, ABC):
     ) -> Self:
         _check_scanned(scanned, n_lead)
         per_obs_in = pre.in_structure
-        if cls._augment_in:
-            in_structure = _augment_structure(per_obs_in, axis_size=n_lead)
+        if cls._prepend_in:
+            in_structure = _prepend_axis(per_obs_in, axis_size=n_lead)
         else:
             in_structure = per_obs_in
         return cls(scanned, pre, post, n_lead=n_lead, in_structure=in_structure)
@@ -149,21 +133,19 @@ class AbstractScanBlockOperator(AbstractLinearOperator, ABC):
     @property
     def out_structure(self) -> PyTree[jax.ShapeDtypeStruct]:
         per_obs_out = self.post.out_structure
-        if self._augment_out:
-            return _augment_structure(per_obs_out, axis_size=self.n_lead)
+        if self._prepend_out:
+            return _prepend_axis(per_obs_out, axis_size=self.n_lead)
         return per_obs_out
 
     @property
     def operator(self) -> AbstractLinearOperator:
         """Effective per-observation operator `post @ scanned @ pre` (for introspection)."""
-        with jax.sharding.use_abstract_mesh(_EMPTY_MESH):
-            return (self.post @ self.scanned @ self.pre).reduce()
+        return (self.post @ self.scanned @ self.pre).reduce()
 
     def reduce(self) -> AbstractLinearOperator:
-        with jax.sharding.use_abstract_mesh(_EMPTY_MESH):
-            scanned = self.scanned.reduce()
-            pre = self.pre.reduce()
-            post = self.post.reduce()
+        scanned = self.scanned.reduce()
+        pre = self.pre.reduce()
+        post = self.post.reduce()
         return type(self)._build(scanned, pre, post, n_lead=self.n_lead)
 
 
@@ -180,8 +162,8 @@ class ScanBlockDiagonalOperator(AbstractScanBlockOperator):
         ...     weighted = W(samples)                           # (N, *in) -> (N, *out)
     """
 
-    _augment_in = True
-    _augment_out = True
+    _prepend_in = True
+    _prepend_out = True
 
     def mv(self, x: PyTree[Inexact[Array, '...']]) -> PyTree[Inexact[Array, '...']]:
         axis = _get_mesh().axis_names[0]
@@ -198,8 +180,7 @@ class ScanBlockDiagonalOperator(AbstractScanBlockOperator):
         return kernel(self.scanned, self.pre, self.post, x)
 
     def transpose(self) -> AbstractLinearOperator:
-        with jax.sharding.use_abstract_mesh(_EMPTY_MESH):
-            scanned_t, pre_t, post_t = self.scanned.T, self.post.T, self.pre.T
+        scanned_t, pre_t, post_t = self.scanned.T, self.post.T, self.pre.T
         return ScanBlockDiagonalOperator._build(scanned_t, pre_t, post_t, n_lead=self.n_lead)
 
 
@@ -216,8 +197,8 @@ class ScanBlockColumnOperator(AbstractScanBlockOperator):
         ...     tod = H(pixel_map)                               # (*in,) -> (N, *out)
     """
 
-    _augment_in = False
-    _augment_out = True
+    _prepend_in = False
+    _prepend_out = True
 
     def mv(self, x: PyTree[Inexact[Array, '...']]) -> PyTree[Inexact[Array, '...']]:
         axis = _get_mesh().axis_names[0]
@@ -233,8 +214,7 @@ class ScanBlockColumnOperator(AbstractScanBlockOperator):
         return kernel(self.scanned, self.pre, self.post, x)
 
     def transpose(self) -> AbstractLinearOperator:
-        with jax.sharding.use_abstract_mesh(_EMPTY_MESH):
-            scanned_t, pre_t, post_t = self.scanned.T, self.post.T, self.pre.T
+        scanned_t, pre_t, post_t = self.scanned.T, self.post.T, self.pre.T
         return ScanBlockRowOperator._build(scanned_t, pre_t, post_t, n_lead=self.n_lead)
 
 
@@ -251,8 +231,8 @@ class ScanBlockRowOperator(AbstractScanBlockOperator):
         ...     pixel_map = HT(tod)                              # (N, *in) -> (*out,)
     """
 
-    _augment_in = True
-    _augment_out = False
+    _prepend_in = True
+    _prepend_out = False
 
     def mv(self, x: PyTree[Inexact[Array, '...']]) -> PyTree[Inexact[Array, '...']]:
         axis = _get_mesh().axis_names[0]
@@ -272,8 +252,7 @@ class ScanBlockRowOperator(AbstractScanBlockOperator):
         return kernel(self.scanned, self.pre, self.post, x)
 
     def transpose(self) -> AbstractLinearOperator:
-        with jax.sharding.use_abstract_mesh(_EMPTY_MESH):
-            scanned_t, pre_t, post_t = self.scanned.T, self.post.T, self.pre.T
+        scanned_t, pre_t, post_t = self.scanned.T, self.post.T, self.pre.T
         return ScanBlockColumnOperator._build(scanned_t, pre_t, post_t, n_lead=self.n_lead)
 
 
@@ -293,8 +272,8 @@ class ScanAdditionOperator(AbstractScanBlockOperator):
         ...     rhs = A(pixel_map)          # (*in,) -> (*out,)
     """
 
-    _augment_in = False
-    _augment_out = False
+    _prepend_in = False
+    _prepend_out = False
 
     def mv(self, x: PyTree[Inexact[Array, '...']]) -> PyTree[Inexact[Array, '...']]:
         axis = _get_mesh().axis_names[0]
@@ -313,8 +292,7 @@ class ScanAdditionOperator(AbstractScanBlockOperator):
         return kernel(self.scanned, self.pre, self.post, x)
 
     def transpose(self) -> AbstractLinearOperator:
-        with jax.sharding.use_abstract_mesh(_EMPTY_MESH):
-            scanned_t, pre_t, post_t = self.scanned.T, self.post.T, self.pre.T
+        scanned_t, pre_t, post_t = self.scanned.T, self.post.T, self.pre.T
         return ScanAdditionOperator._build(scanned_t, pre_t, post_t, n_lead=self.n_lead)
 
 
@@ -339,17 +317,15 @@ class AbstractScanFusionRule(AbstractCompositionRule):
         # raised from `apply` just as it does from `check`.
         assert isinstance(left, AbstractScanBlockOperator)  # mypy
         assert isinstance(right, AbstractScanBlockOperator)  # mypy
-        with jax.sharding.use_abstract_mesh(_EMPTY_MESH):
-            mid = (left.pre @ right.post).reduce()
+        mid = (left.pre @ right.post).reduce()
         if not isinstance(mid, (IdentityOperator, HomothetyOperator)):
             raise NoReduction
-        with jax.sharding.use_abstract_mesh(_EMPTY_MESH):
-            scanned = (left.scanned @ right.scanned).reduce()
-            if isinstance(mid, HomothetyOperator):
-                scalar = HomothetyOperator(mid.value, in_structure=left.post.out_structure)
-                post = (scalar @ left.post).reduce()
-            else:
-                post = left.post
+        scanned = (left.scanned @ right.scanned).reduce()
+        if isinstance(mid, HomothetyOperator):
+            scalar = HomothetyOperator(mid.value, in_structure=left.post.out_structure)
+            post = (scalar @ left.post).reduce()
+        else:
+            post = left.post
         return [self.reduced_class._build(scanned, right.pre, post, n_lead=left.n_lead)]
 
 
@@ -420,13 +396,12 @@ class HomothetyScanBlockRule(AbstractCompositionRule):
         # Reduce the closed-over maps under the empty mesh (they carry no obs axis), but build the
         # result under the caller's real mesh so `_augment_structure` shards the public structure.
         # Otherwise the fused block would be unsharded and fail to compose with sharded blocks.
-        with jax.sharding.use_abstract_mesh(_EMPTY_MESH):
-            if on_output_side:
-                scalar = HomothetyOperator(homo.value, in_structure=block.post.out_structure)
-                pre, post = block.pre, (scalar @ block.post).reduce()
-            else:
-                scalar = HomothetyOperator(homo.value, in_structure=block.pre.in_structure)
-                pre, post = (block.pre @ scalar).reduce(), block.post
+        if on_output_side:
+            scalar = HomothetyOperator(homo.value, in_structure=block.post.out_structure)
+            pre, post = block.pre, (scalar @ block.post).reduce()
+        else:
+            scalar = HomothetyOperator(homo.value, in_structure=block.pre.in_structure)
+            pre, post = (block.pre @ scalar).reduce(), block.post
         return [type(block)._build(block.scanned, pre, post, n_lead=block.n_lead)]
 
 
@@ -464,13 +439,12 @@ class AbstractScanAdditionFusionRule(AbstractAdditionRule):
         # Assemble the bodies under the empty mesh, but build the result under
         # the caller's real mesh so `_augment_structure` shards the public structure.
         # Otherwise the fused block would be unsharded and fail to compose with sharded blocks.
-        with jax.sharding.use_abstract_mesh(_EMPTY_MESH):
-            if trivial:
-                bodies = (left.scanned + right.scanned).reduce()
-            else:
-                pre = BlockColumnOperator([left.pre, right.pre])
-                scanned = BlockDiagonalOperator([left.scanned, right.scanned])
-                post = BlockRowOperator([left.post, right.post])
+        if trivial:
+            bodies = (left.scanned + right.scanned).reduce()
+        else:
+            pre = BlockColumnOperator([left.pre, right.pre])
+            scanned = BlockDiagonalOperator([left.scanned, right.scanned])
+            post = BlockRowOperator([left.post, right.post])
         if trivial:
             return [self.reduced_class.create(bodies, n_lead=left.n_lead)]
         return [self.reduced_class._build(scanned, pre, post, n_lead=left.n_lead)]

--- a/tests/mapmaking/test_scan_blocks.py
+++ b/tests/mapmaking/test_scan_blocks.py
@@ -103,39 +103,6 @@ def test_structure_shapes() -> None:
     assert op.out_structure.shape == (N_OUT,)
 
 
-def test_structure_sharding(mesh) -> None:
-    blocks = _make_blocks(P('obs'))
-
-    # Structures whose leading axis is the stacked-block axis carry a NamedSharding
-    # with P('obs', None, ...) under the active mesh; non-stacked axes (single-input
-    # column, single-output row/addition) get no sharding.
-    expected_stacked = jax.sharding.NamedSharding(mesh.abstract_mesh, P('obs', None))
-
-    op = ScanBlockDiagonalOperator.create(blocks)
-    for s in jax.tree.leaves(op.in_structure):
-        assert s.sharding == expected_stacked
-    for s in jax.tree.leaves(op.out_structure):
-        assert s.sharding == expected_stacked
-
-    op = ScanBlockColumnOperator.create(blocks)
-    for s in jax.tree.leaves(op.in_structure):
-        assert s.sharding is None
-    for s in jax.tree.leaves(op.out_structure):
-        assert s.sharding == expected_stacked
-
-    op = ScanBlockRowOperator.create(blocks)
-    for s in jax.tree.leaves(op.in_structure):
-        assert s.sharding == expected_stacked
-    for s in jax.tree.leaves(op.out_structure):
-        assert s.sharding is None
-
-    op = ScanAdditionOperator.create(blocks)
-    for s in jax.tree.leaves(op.in_structure):
-        assert s.sharding is None
-    for s in jax.tree.leaves(op.out_structure):
-        assert s.sharding is None
-
-
 # ---------------------------------------------------------------------------
 # Sharded forward
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
When composing operators, we currently require full equality between operator structures (e.g. `self.in_structure == other.out_structure`). This also compares sharding information. But sharding is a runtime layout concern, not related to the actual vector shapes.

This PR introduces a `structure_equal` helper function to replace equality-based comparisons with a less restrictive shape/dtype compatibility check. It required zero changes in the core test suite.

The new behaviour greatly simplifies #152.