### PR TITLE
Fix CG instability past convergence with stabilisation enabled

### DIFF
--- a/src/furax/linalg/_cg.py
+++ b/src/furax/linalg/_cg.py
@@ -148,6 +148,10 @@ def cg(
 
     p = z
     rz = tree.dot(r, z)  # r^T z (or r^T M^{-1} r)
+    eps = jnp.finfo(rz.real.dtype).eps
+    # `rz` is a residual energy, so square the relative norm floor. The 100*eps
+    # margin catches roundoff-level residuals before stabilisation can amplify them.
+    rz_floor = (100 * eps) ** 2 * jnp.abs(rz)
 
     r0_norm = tree.norm(r)
     # residuals[0] = initial residual; residuals[i+1] = residual after step i.
@@ -162,20 +166,23 @@ def cg(
 
         Ap = A(p)
         pAp = tree.dot(p, Ap)
+        active = jnp.abs(rz) > rz_floor
 
         # `pAp == 0` only at convergence (p -> 0), handled by `safe_pAp`
         # `pAp < 0` is genuine negative curvature, which a positive definite A should never produce
         if truncate:
             # Negative curvature: take no step this iteration and flag the loop to stop.
-            truncated = pAp < 0
+            truncated = active & (pAp < 0)
             safe_pAp = jnp.where(pAp == 0, 1.0, pAp)
-            alpha = jnp.where(truncated, 0.0, rz / safe_pAp)
+            alpha = jnp.where(active & ~truncated, rz / safe_pAp, 0.0)
         else:
             truncated = c.truncated
             if check_curvature:
-                pAp = eqx.error_if(pAp, pAp < 0, 'cg: negative curvature detected p^T A p < 0')
+                pAp = eqx.error_if(
+                    pAp, active & (pAp < 0), 'cg: negative curvature detected p^T A p < 0'
+                )
             safe_pAp = jnp.where(pAp == 0, 1.0, pAp)
-            alpha = rz / safe_pAp
+            alpha = jnp.where(active, rz / safe_pAp, 0.0)
 
         x = tree.add(x, tree.mul(alpha, p))
 
@@ -197,8 +204,11 @@ def cg(
 
         z = M(r)
         rz_new = tree.dot(r, z)
-        safe_rz = jnp.where(rz == 0, 1.0, rz)
-        beta = rz_new / safe_rz
+        # Once the preconditioned residual energy reaches the floating-point floor,
+        # fixed-iteration CG should become inert. This avoids dividing true-residual
+        # roundoff by true-residual roundoff after stabilisation.
+        safe_rz = jnp.where(active, rz, 1.0)
+        beta = jnp.where(jnp.abs(rz_new) > rz_floor, rz_new / safe_rz, 0.0)
 
         p = tree.add(z, tree.mul(beta, p))
 

--- a/tests/linalg/test_cg.py
+++ b/tests/linalg/test_cg.py
@@ -9,7 +9,12 @@ from jax.sharding import AxisType, NamedSharding
 from jax.sharding import PartitionSpec as P
 from numpy.testing import assert_allclose
 
-from furax import BlockDiagonalOperator, DiagonalOperator, IdentityOperator
+from furax import (
+    BlockDiagonalOperator,
+    DenseBlockDiagonalOperator,
+    DiagonalOperator,
+    IdentityOperator,
+)
 from furax.linalg import CGResult, cg
 from furax.tree import as_structure
 
@@ -21,6 +26,19 @@ def _diagonal_system(n: int = 5):
     b = jnp.ones(n, dtype=float)
     x_true = b / d
     return A, b, x_true
+
+
+def _dense_spd_system(
+    n: int, condition: float, seed: int
+) -> tuple[DenseBlockDiagonalOperator, jax.Array, jax.Array, jax.Array]:
+    key = jax.random.key(seed)
+    q, _ = jnp.linalg.qr(jax.random.normal(key, (n, n), dtype=jnp.float64))
+    eigenvalues = jnp.geomspace(1.0 / condition, 1.0, n)
+    matrix = (q * eigenvalues) @ q.T
+    b = jax.random.normal(jax.random.key(seed + 1000), (n,), dtype=jnp.float64)
+    A = DenseBlockDiagonalOperator(matrix, in_structure=as_structure(b))
+    x_true = jnp.linalg.solve(matrix, b)
+    return A, matrix, b, x_true
 
 
 class TestCGBasic:
@@ -89,6 +107,33 @@ class TestCGPyTree:
 
         result = cg(A, b, max_steps=20)
         assert tree_equal(result.solution, x_true, rtol=1e-10)
+
+
+class TestCGStabilisation:
+    def test_over_iteration_with_stabilisation_is_inert_after_convergence(self):
+        A, _, b, x_true = _dense_spd_system(n=5, condition=1e3, seed=7)
+
+        result = cg(A, b, max_steps=1000, rtol=0.0, atol=0.0)
+
+        rel_error = jnp.linalg.norm(result.solution - x_true) / jnp.linalg.norm(x_true)
+        assert_allclose(rel_error, 0.0, atol=1e-12)
+
+    def test_stabilisation_still_tracks_true_residual_on_long_solve(self):
+        A, matrix, b, _ = _dense_spd_system(n=50, condition=1e3, seed=0)
+
+        recursive = cg(A, b, max_steps=200, rtol=0.0, atol=0.0, stabilise_every=0)
+        stabilised = cg(A, b, max_steps=200, rtol=0.0, atol=0.0)
+
+        norm_b = jnp.linalg.norm(b)
+        recursive_true = jnp.linalg.norm(b - matrix @ recursive.solution) / norm_b
+        stabilised_true = jnp.linalg.norm(b - matrix @ stabilised.solution) / norm_b
+        recursive_reported = recursive.residuals[-1] / norm_b
+        stabilised_reported = stabilised.residuals[-1] / norm_b
+
+        assert stabilised_true < recursive_true
+        assert jnp.abs(stabilised_reported - stabilised_true) < jnp.abs(
+            recursive_reported - recursive_true
+        )
 
 
 class TestCGJit:


### PR DESCRIPTION
Fix `furax.linalg.cg` instability when fixed-iteration solves continue past convergence with residual stabilisation enabled.

The CG loop now freezes numerical updates once the preconditioned residual energy reaches a dtype-relative floating-point floor. This prevents periodic true-residual recomputation from turning roundoff-level residuals into large beta updates, while preserving stabilisation for long solves where it still tracks drift.

Details

- Adds an `rz_floor` based on the initial `r^T M r`.
- Sets `alpha = 0` once `r^T M r` is at the numerical floor.
- Sets `beta = 0` when the new residual energy is also at the floor.
- Keeps fixed-iteration mode semantics: `rtol=atol=0` still runs to `max_steps`, but post-convergence iterations become inert.
- Keeps negative-curvature handling inactive once the residual energy is numerically exhausted.

Tests

- Added a regression test for over-iterating a converged SPD solve with default `stabilise_every=10`.
- Added a long ill-conditioned solve test showing stabilisation still tracks/improves the true residual versus recursive residual updates.
- Ran existing and new CG tests.