### PR TITLE
Add `BandedCholeskyOperator` and block-banded Cholesky routines

### DIFF
--- a/src/furax/linalg/__init__.py
+++ b/src/furax/linalg/__init__.py
@@ -1,6 +1,7 @@
 from ._cg import CGResult, cg
 from ._eigvalsh import eigvalsh
 from ._lanczos import LanczosResult, lanczos_eigh, lanczos_tr
+from .cholesky import BandedCholeskyOperator, banded_cholesky, banded_cholesky_solve
 from .low_rank import LowRankOperator, LowRankTerms, low_rank, low_rank_mv
 
 __all__ = [
@@ -14,4 +15,7 @@ __all__ = [
     'low_rank',
     'low_rank_mv',
     'LowRankOperator',
+    'BandedCholeskyOperator',
+    'banded_cholesky',
+    'banded_cholesky_solve',
 ]

--- a/src/furax/linalg/cholesky.py
+++ b/src/furax/linalg/cholesky.py
@@ -195,6 +195,9 @@ def _block_banded_cholesky(bands: Float[Array, 'n w1 k k']) -> Float[Array, 'n w
                 cur = cur.at[0].set(jnp.linalg.cholesky(s))  # L[i,i] = chol(S)
             else:
                 ljj = read(lb, j)[0]  # L[j,j] (lower), computed in an earlier row
+                # j < 0 aliases into an unwritten (zero) pivot: fine forward (masked below), but
+                # 0/0 gives nan gradient even through the masked branch, so swap in the identity.
+                ljj = jnp.where(j >= 0, ljj, jnp.eye(k, dtype=bands.dtype))
                 x = jax.scipy.linalg.solve_triangular(ljj, s.T, lower=True).T  # X L[j,j]ᵀ = S
                 cur = cur.at[d0].set(jnp.where(j >= 0, x, 0.0))
         return jax.lax.dynamic_update_index_in_dim(lb, cur, i, axis=0)

--- a/src/furax/linalg/cholesky.py
+++ b/src/furax/linalg/cholesky.py
@@ -1,0 +1,251 @@
+"""Block-banded Cholesky factorization for symmetric positive-(semi)definite matrices."""
+
+from functools import partial
+from math import prod
+from typing import Self
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+from jax import Array
+from jaxtyping import Float, PyTree
+
+from furax import AbstractLinearOperator, symmetric
+
+__all__ = [
+    'BandedCholeskyOperator',
+    'banded_cholesky',
+    'banded_cholesky_solve',
+]
+
+
+@symmetric
+class BandedCholeskyOperator(AbstractLinearOperator):
+    """Inverse of a symmetric positive-(semi)definite matrix, by Cholesky solve.
+
+    This operator can be used with an ordinary dense matrix (:meth:`from_dense`), or from
+    a banded matrix (zero away from the diagonal, :meth:`from_bands`) and so is stored
+    compactly instead of as the full matrix.
+
+    Calling ``A(b)`` solves ``A x = b``.
+
+    Example:
+        >>> import jax.numpy as jnp
+        >>> from furax.linalg import BandedCholeskyOperator
+        >>> A = jnp.array([[4., 2.], [2., 3.]])
+        >>> op = BandedCholeskyOperator.from_dense(A)
+        >>> op(jnp.array([1., 0.]))  # solves A x = [1, 0]
+        Array([ 0.375, -0.25 ], dtype=float32)
+    """
+
+    lb: Float[Array, '*batch n w1 k k']
+    """The lower-triangular Cholesky factor in compact band-layout."""
+
+    @classmethod
+    def from_bands(
+        cls,
+        bands: Float[Array, '*batch n w1 k k'],
+        in_structure: PyTree[jax.ShapeDtypeStruct] | None = None,
+        regularization: float = 0.0,
+    ) -> Self:
+        """Factor a block-banded matrix (see :func:`banded_cholesky`) and wrap it as an operator.
+
+        Args:
+            bands: Upper-band representation of the block-banded matrix, shape
+                ``(*batch, n_blocks, w+1, k, k)``.
+            in_structure: Structure of the values the operator is called with.
+                Defaults to a plain array of shape ``(*batch, n_blocks, k)``.
+                Pass a PyTree explicitly to solve for several arrays at once instead.
+            regularization: Relative ridge added to each diagonal block before factoring.
+        """
+        if in_structure is None:
+            n, k = bands.shape[-4], bands.shape[-1]
+            in_structure = jax.ShapeDtypeStruct((*bands.shape[:-4], n, k), bands.dtype)
+        return cls(banded_cholesky(bands, regularization), in_structure=in_structure)
+
+    @classmethod
+    def from_dense(
+        cls,
+        matrix: Float[Array, '*batch k k'],
+        in_structure: PyTree[jax.ShapeDtypeStruct] | None = None,
+        regularization: float = 0.0,
+    ) -> Self:
+        """Factor a fully dense matrix (the degenerate ``n_blocks=1, w=0`` band case).
+
+        Args:
+            matrix: The dense matrix, shape ``(*batch, k, k)``.
+            in_structure: Structure of the values the operator is called with.
+                Defaults to a plain array of shape ``(*batch, k)``.
+                Pass a PyTree explicitly to solve for several arrays at once instead.
+            regularization: Relative ridge added to the diagonal before factoring.
+        """
+        if in_structure is None:
+            in_structure = jax.ShapeDtypeStruct(matrix.shape[:-1], matrix.dtype)
+        return cls.from_bands(matrix[..., None, None, :, :], in_structure, regularization)
+
+    def mv(self, x: PyTree[Array]) -> PyTree[Array]:
+        batch_ndim = self.lb.ndim - 4
+        n_blocks, k = self.lb.shape[-4], self.lb.shape[-1]
+        leaves, treedef = jax.tree.flatten(x)
+        # Flatten every leaf's non-batch axes and concatenate them into one length-K vector per
+        # batch element, matching how `lb` was built from `bands`/`matrix` (K = n_blocks * k).
+        flats = [leaf.reshape(*leaf.shape[:batch_ndim], -1) for leaf in leaves]
+        xf = jnp.concatenate(flats, axis=-1)  # (*batch, K)
+        xb = xf.reshape(*xf.shape[:-1], n_blocks, k)  # split K back into the (n_blocks, k) layout
+        yb = banded_cholesky_solve(self.lb, xb)
+        yf = yb.reshape(*yb.shape[:-2], -1)  # (*batch, K)
+        # Undo the flatten/concatenate: split the solution back into per-leaf chunks (in the same
+        # order they were concatenated) and reshape each to its original leaf shape.
+        sizes = [prod(leaf.shape[batch_ndim:]) for leaf in leaves]
+        chunks = jnp.split(yf, np.cumsum(sizes)[:-1], axis=-1)
+        out = [c.reshape(leaf.shape) for c, leaf in zip(chunks, leaves, strict=True)]
+        return treedef.unflatten(out)  # type: ignore[attr-defined]
+
+
+def banded_cholesky(
+    bands: Float[Array, '*batch n w1 k k'], regularization: float = 0.0
+) -> Float[Array, '*batch n w1 k k']:
+    """Block Cholesky factor of a symmetric positive-(semi)definite block-banded matrix.
+
+    "Block-banded" means ``A`` is made of ``k×k`` blocks, and only the blocks within ``w``
+    of the diagonal can be non-zero. E.g., for ``n_blocks = 4`` and bandwidth ``w = 1``:
+
+        A = [ A00  A01   0    0  ]
+            [ A01ᵀ A11  A12   0  ]
+            [  0   A12ᵀ A22  A23 ]
+            [  0    0   A23ᵀ A33 ]
+
+    Only the diagonal and upper blocks are stored (symmetry gives the rest) packed as
+    ``bands[..., j, d, :, :] = A[j, j+d]`` for ``d = 0..w`` (``d=0`` the diagonal blocks,
+    ``d=w`` the furthest off-diagonal ones still inside the band)::
+
+        bands[:, 0] = [A00, A11, A22, A33]  (d=0: the diagonal blocks)
+        bands[:, 1] = [A01, A12, A23,  · ]  (d=1: one block off the diagonal; the trailing
+                                               entry is unused padding, since block 3 has no
+                                               block 4 to pair with)
+
+    Returns the lower factor in the same band layout, ``lb[..., i, d, :, :] = L[i, i-d]`` with
+    ``L Lᵀ = A``. Batched over arbitrary leading dims. Band ``w = 0`` is the block-diagonal case
+    (every off-diagonal block is zero); ``n_blocks = 1`` is the fully dense case.
+
+    ``regularization`` adds a relative ridge to each diagonal block before factoring, scaled by
+    that block's own mean diagonal. This is purely intended as a numerical safeguard.
+
+    Args:
+        bands: Upper-band representation of the block-banded matrix, shape
+            ``(*batch, n_blocks, w+1, k, k)``.
+        regularization: Relative ridge added to each diagonal block before factoring.
+
+    Returns:
+        The lower band factor, same shape as ``bands``.
+
+    Example:
+        >>> import jax.numpy as jnp
+        >>> from furax.linalg import banded_cholesky
+        >>> # tridiagonal SPD A = [[4,1,0,0],[1,4,1,0],[0,1,4,1],[0,0,1,4]], scalar (k=1) blocks
+        >>> diag = jnp.array([4., 4., 4., 4.]).reshape(4, 1, 1, 1)
+        >>> off = jnp.array([1., 1., 1., 0.]).reshape(4, 1, 1, 1)  # trailing entry is padding
+        >>> bands = jnp.concatenate([diag, off], axis=1)  # (n_blocks=4, w1=2, k=1, k=1)
+        >>> lb = banded_cholesky(bands)
+        >>> lb[:, :, 0, 0]  # columns are (L[i,i], L[i,i-1])
+        Array([[2.        , 0.        ],
+               [1.9364916 , 0.5       ],
+               [1.9321835 , 0.5163978 ],
+               [1.9318755 , 0.51754916]], dtype=float32)
+    """
+    if regularization:
+        k = bands.shape[-1]
+        diag = jnp.diagonal(bands[..., 0, :, :], axis1=-2, axis2=-1)  # (*batch, n, k)
+        scale = jnp.mean(diag, axis=-1)[..., None, None]  # (*batch, n, 1, 1)
+        ridge = regularization * scale * jnp.eye(k, dtype=bands.dtype)
+        bands = bands.at[..., 0, :, :].add(ridge)
+    return _block_banded_cholesky(bands)  # type: ignore[no-any-return]
+
+
+@partial(jnp.vectorize, signature='(n,w1,k,k)->(n,w1,k,k)')
+def _block_banded_cholesky(bands: Float[Array, 'n w1 k k']) -> Float[Array, 'n w1 k k']:
+    """Block Cholesky of a symmetric positive-definite block-banded matrix. Batched over
+    arbitrary leading dims via the ``jnp.vectorize`` signature.
+
+    ``bands[j, d, :, :]`` is the upper block ``A[j, j+d]`` (``d = 0..w``, ``w = w1-1`` the block
+    bandwidth; ``d=0`` the symmetric diagonal block). Returns the lower factor in the same band
+    layout, ``lb[i, d, :, :] = L[i, i-d]`` with ``L Lᵀ = A``.
+
+    Band ``w = 0`` degenerates to an independent Cholesky of each diagonal ``k×k`` block (the
+    block-diagonal case); ``n_blocks = 1`` further degenerates to a single plain Cholesky.
+    """
+    n, w1, k, _ = bands.shape
+    w = w1 - 1
+
+    def read(arr: Array, idx: Array):  # type: ignore[no-untyped-def]
+        return jax.lax.dynamic_index_in_dim(arr, jnp.clip(idx, 0, n - 1), axis=0, keepdims=False)
+
+    def row(i: Array, lb: Array):  # type: ignore[no-untyped-def]
+        cur = jnp.zeros((w1, k, k), bands.dtype)  # this row's blocks lb[i, :]
+        # columns j = i - d0, processed high d0 (far) to low (diagonal last).
+        for d0 in range(w, -1, -1):
+            j = i - d0
+            s = jnp.swapaxes(read(bands, j)[d0], -1, -2)  # A[i, j] = A[j, i]ᵀ = bands[j, d0]ᵀ
+            for a in range(d0 + 1, w + 1):  # Schur update: − Σ L[i, i-a] L[j, i-a]ᵀ
+                # L[j, i-a]: for the diagonal block (d0=0, j=i) it is this row's block ``cur[a]``,
+                # not yet written to ``lb``; for d0>0 (j<i) it is a finished earlier row.
+                l_ja = cur[a] if d0 == 0 else read(lb, j)[a - d0]
+                s = s - cur[a] @ jnp.swapaxes(l_ja, -1, -2)
+            if d0 == 0:
+                cur = cur.at[0].set(jnp.linalg.cholesky(s))  # L[i,i] = chol(S)
+            else:
+                ljj = read(lb, j)[0]  # L[j,j] (lower), computed in an earlier row
+                x = jax.scipy.linalg.solve_triangular(ljj, s.T, lower=True).T  # X L[j,j]ᵀ = S
+                cur = cur.at[d0].set(jnp.where(j >= 0, x, 0.0))
+        return jax.lax.dynamic_update_index_in_dim(lb, cur, i, axis=0)
+
+    factor: Array = jax.lax.fori_loop(0, n, row, jnp.zeros((n, w1, k, k), bands.dtype))
+    return factor
+
+
+@partial(jnp.vectorize, signature='(n,w1,k,k),(n,k)->(n,k)')
+def banded_cholesky_solve(
+    lb: Float[Array, '*batch n w1 k k'], b: Float[Array, '*batch n k']
+) -> Float[Array, '*batch n k']:
+    """Solve ``L Lᵀ x = b`` given the lower band factor ``lb`` from :func:`banded_cholesky`.
+
+    Batched over arbitrary leading dims (matching ``lb``'s, excluding its trailing
+    ``(n, w1, k, k)`` core).
+
+    Example:
+        >>> import jax.numpy as jnp
+        >>> from furax.linalg import banded_cholesky, banded_cholesky_solve
+        >>> a = jnp.array([[4., 2.], [2., 3.]])
+        >>> lb = banded_cholesky(a[None, None, None])
+        >>> x = banded_cholesky_solve(lb, jnp.array([[[1., 0.]]]))
+        >>> a @ x[0, 0]
+        Array([1., 0.], dtype=float32)
+    """
+    n, w1, k, _ = lb.shape
+    w = w1 - 1
+
+    def read(arr: Array, idx: Array):  # type: ignore[no-untyped-def]
+        return jax.lax.dynamic_index_in_dim(arr, jnp.clip(idx, 0, n - 1), axis=0, keepdims=False)
+
+    def fwd(i: Array, y: Array):  # type: ignore[no-untyped-def]  # forward: L y = b
+        rhs = read(b, i)
+        lb_i = read(lb, i)
+        for d in range(1, w + 1):
+            rhs = rhs - jnp.where(i - d >= 0, lb_i[d] @ read(y, i - d), 0.0)
+        yi = jax.scipy.linalg.solve_triangular(lb_i[0], rhs, lower=True)
+        return jax.lax.dynamic_update_index_in_dim(y, yi, i, axis=0)
+
+    y = jax.lax.fori_loop(0, n, fwd, jnp.zeros((n, k), b.dtype))
+
+    def bwd(step: Array, x: Array):  # type: ignore[no-untyped-def]  # backward: Lᵀ x = y
+        i = n - 1 - step
+        rhs = read(y, i)
+        for d in range(1, w + 1):  # L[i+d, i] = lb[i+d, d]
+            rhs = rhs - jnp.where(
+                i + d <= n - 1, jnp.swapaxes(read(lb, i + d)[d], -1, -2) @ read(x, i + d), 0.0
+            )
+        xi = jax.scipy.linalg.solve_triangular(read(lb, i)[0].T, rhs, lower=False)
+        return jax.lax.dynamic_update_index_in_dim(x, xi, i, axis=0)
+
+    solution: Array = jax.lax.fori_loop(0, n, bwd, jnp.zeros((n, k), b.dtype))
+    return solution

--- a/tests/linalg/test_cholesky.py
+++ b/tests/linalg/test_cholesky.py
@@ -1,0 +1,184 @@
+"""Tests for the block-banded Cholesky factorization."""
+
+import jax
+import jax.numpy as jnp
+import jax.random as jr
+import pytest
+from numpy.testing import assert_allclose, assert_array_equal
+
+from furax.linalg import BandedCholeskyOperator, banded_cholesky, banded_cholesky_solve
+
+
+def _banded_spd(n: int, k: int, w: int, seed: int):
+    """A random block-banded SPD matrix of bandwidth w, as (dense, bands)."""
+    kL, kb = jr.split(jr.key(seed))
+    # dense lower block-banded L (well-conditioned diagonal) -> G = L Lᵀ is SPD, block-banded of
+    # bandwidth w. w=0 is the block-diagonal degeneration.
+    L = jnp.zeros((n * k, n * k))
+    for i in range(n):
+        for d in range(w + 1):
+            j = i - d
+            if j >= 0:
+                blk = jr.normal(jr.fold_in(kL, i * 10 + d), (k, k))
+                if d == 0:
+                    blk = jnp.tril(blk) + (k + 1) * jnp.eye(k)
+                L = L.at[i * k : (i + 1) * k, j * k : (j + 1) * k].set(blk)
+    dense = L @ L.T
+
+    bands = jnp.zeros((n, w + 1, k, k))  # upper band blocks A[j, j+d]
+    for j in range(n):
+        for d in range(w + 1):
+            if j + d < n:
+                bands = bands.at[j, d].set(
+                    dense[j * k : (j + 1) * k, (j + d) * k : (j + d + 1) * k]
+                )
+    return dense, bands
+
+
+@pytest.mark.parametrize('w', [0, 1, 2])
+def test_banded_cholesky_solve_matches_dense(w):
+    n, k = 6, 2
+    dense, bands = _banded_spd(n, k, w, seed=11)
+    lb = banded_cholesky(bands)
+    b = jr.normal(jr.key(12), (n, k))
+    x = banded_cholesky_solve(lb, b)
+    expected = jnp.linalg.solve(dense, b.reshape(-1)).reshape(n, k)
+    assert_allclose(x, expected, rtol=1e-4, atol=1e-5)
+
+
+def test_banded_cholesky_degenerate_n_blocks_one_matches_dense_cholesky():
+    # n_blocks=1 is the fully dense case: must be numerically identical to a direct
+    # jnp.linalg.cholesky/cho_solve, not merely close.
+    key = jr.key(20)
+    k = 5
+    a = jr.normal(key, (k, k))
+    dense = a @ a.T + k * jnp.eye(k)
+    bands = dense[None, None]  # n_blocks=1, w1=1
+
+    lb = banded_cholesky(bands)
+    assert_array_equal(lb[0, 0], jnp.linalg.cholesky(dense))
+
+    b = jr.normal(jr.fold_in(key, 1), (1, k))
+    x = banded_cholesky_solve(lb, b)
+    expected = jax.scipy.linalg.cho_solve((jnp.linalg.cholesky(dense), True), b[0])
+    assert_array_equal(x[0], expected)
+
+
+def test_banded_cholesky_batched_leading_dims():
+    # Two independent batch axes, e.g. two separate collections stacked together.
+    n, k, w = 4, 2, 1
+    dense_bands = [_banded_spd(n, k, w, seed=100 + i) for i in range(6)]
+    bands = jnp.stack([b for _, b in dense_bands]).reshape(3, 2, n, w + 1, k, k)
+    denses = jnp.stack([d for d, _ in dense_bands]).reshape(3, 2, n * k, n * k)
+
+    lb = banded_cholesky(bands)
+    assert lb.shape == bands.shape
+
+    b = jr.normal(jr.key(30), (3, 2, n, k))
+    x = banded_cholesky_solve(lb, b)
+    expected = jnp.linalg.solve(denses, b.reshape(3, 2, -1, 1))[..., 0].reshape(3, 2, n, k)
+    assert_allclose(x, expected, rtol=1e-4, atol=1e-5)
+
+
+def test_banded_cholesky_jit():
+    n, k, w = 4, 2, 1
+    _, bands = _banded_spd(n, k, w, seed=50)
+    b = jr.normal(jr.key(51), (n, k))
+
+    lb = jax.jit(banded_cholesky)(bands)
+    x = jax.jit(banded_cholesky_solve)(lb, b)
+
+    expected_lb = banded_cholesky(bands)
+    expected_x = banded_cholesky_solve(expected_lb, b)
+    assert_allclose(lb, expected_lb)
+    assert_allclose(x, expected_x)
+
+
+class TestBandedCholeskyOperator:
+    """Tests for BandedCholeskyOperator."""
+
+    def test_from_dense_matches_dense_solve(self):
+        key = jr.key(60)
+        n_dets, k = 5, 3
+        a = jr.normal(key, (n_dets, k, k))
+        dense = a @ jnp.swapaxes(a, -1, -2) + k * jnp.eye(k)
+        struct = jax.ShapeDtypeStruct((n_dets, k), dense.dtype)
+
+        op = BandedCholeskyOperator.from_dense(dense, in_structure=struct)
+        b = jr.normal(jr.fold_in(key, 1), (n_dets, k))
+        x = op(b)
+        expected = jnp.linalg.solve(dense, b[..., None])[..., 0]
+        assert_allclose(x, expected, rtol=1e-4, atol=1e-5)
+
+    def test_from_bands_matches_banded_solve(self):
+        n, k, w = 5, 2, 1
+        dense, bands = _banded_spd(n, k, w, seed=61)
+        struct = jax.ShapeDtypeStruct((n, k), bands.dtype)
+
+        op = BandedCholeskyOperator.from_bands(bands, in_structure=struct)
+        b = jr.normal(jr.key(62), (n, k))
+        x = op(b)
+        expected = jnp.linalg.solve(dense, b.reshape(-1)).reshape(n, k)
+        assert_allclose(x, expected, rtol=1e-4, atol=1e-5)
+
+    def test_from_dense_infers_in_structure(self):
+        key = jr.key(63)
+        n_dets, k = 4, 3
+        a = jr.normal(key, (n_dets, k, k))
+        dense = a @ jnp.swapaxes(a, -1, -2) + k * jnp.eye(k)
+
+        op = BandedCholeskyOperator.from_dense(dense)  # no in_structure given
+        assert op.in_structure == jax.ShapeDtypeStruct((n_dets, k), dense.dtype)
+        b = jr.normal(jr.fold_in(key, 1), (n_dets, k))
+        assert_allclose(
+            op(b), BandedCholeskyOperator.from_dense(dense, in_structure=op.in_structure)(b)
+        )
+
+    def test_from_bands_infers_in_structure(self):
+        n, k, w = 4, 2, 1
+        _, bands = _banded_spd(n, k, w, seed=64)
+
+        op = BandedCholeskyOperator.from_bands(bands)  # no in_structure given
+        assert op.in_structure == jax.ShapeDtypeStruct((n, k), bands.dtype)
+        b = jr.normal(jr.key(65), (n, k))
+        assert_allclose(
+            op(b), BandedCholeskyOperator.from_bands(bands, in_structure=op.in_structure)(b)
+        )
+
+    def test_mv_handles_multi_leaf_pytree(self):
+        # A dense matrix acting on a PyTree with several differently-shaped leaves: mv must
+        # flatten/concatenate/split consistently regardless of how many leaves there are.
+        key = jr.key(70)
+        k = 5  # total size, split as leaves of size 2 and 3
+        a = jr.normal(key, (k, k))
+        dense = a @ a.T + k * jnp.eye(k)
+        struct = {
+            'a': jax.ShapeDtypeStruct((2,), dense.dtype),
+            'b': jax.ShapeDtypeStruct((3,), dense.dtype),
+        }
+
+        op = BandedCholeskyOperator.from_dense(dense, in_structure=struct)
+        x = {'a': jr.normal(jr.fold_in(key, 1), (2,)), 'b': jr.normal(jr.fold_in(key, 2), (3,))}
+        y = op(x)
+        flat = jnp.concatenate([x['a'], x['b']])
+        expected = jnp.linalg.solve(dense, flat)
+        assert_allclose(jnp.concatenate([y['a'], y['b']]), expected, rtol=1e-4, atol=1e-5)
+
+    def test_symmetric(self):
+        key = jr.key(80)
+        k = 4
+        a = jr.normal(key, (k, k))
+        dense = a @ a.T + k * jnp.eye(k)
+        struct = jax.ShapeDtypeStruct((k,), dense.dtype)
+        op = BandedCholeskyOperator.from_dense(dense, in_structure=struct)
+        assert op.T is op  # @symmetric
+
+    def test_jit(self):
+        key = jr.key(90)
+        n_dets, k = 3, 2
+        a = jr.normal(key, (n_dets, k, k))
+        dense = a @ jnp.swapaxes(a, -1, -2) + k * jnp.eye(k)
+        struct = jax.ShapeDtypeStruct((n_dets, k), dense.dtype)
+        op = BandedCholeskyOperator.from_dense(dense, in_structure=struct)
+        b = jr.normal(jr.fold_in(key, 1), (n_dets, k))
+        assert_allclose(jax.jit(lambda x: op(x))(b), op(b))

--- a/tests/linalg/test_cholesky.py
+++ b/tests/linalg/test_cholesky.py
@@ -46,6 +46,22 @@ def test_banded_cholesky_solve_matches_dense(w):
     assert_allclose(x, expected, rtol=1e-4, atol=1e-5)
 
 
+@pytest.mark.parametrize('w', [0, 1, 2])
+def test_banded_cholesky_grad_is_finite(w):
+    n, k = 6, 2
+    _, bands = _banded_spd(n, k, w, seed=13)
+    b = jr.normal(jr.key(14), (n, k))
+
+    def loss(bands, b):
+        lb = banded_cholesky(bands)
+        x = banded_cholesky_solve(lb, b)
+        return jnp.sum(x**2)
+
+    grad_bands, grad_b = jax.grad(loss, argnums=(0, 1))(bands, b)
+    assert jnp.all(jnp.isfinite(grad_bands))
+    assert jnp.all(jnp.isfinite(grad_b))
+
+
 def test_banded_cholesky_degenerate_n_blocks_one_matches_dense_cholesky():
     # n_blocks=1 is the fully dense case: must be numerically identical to a direct
     # jnp.linalg.cholesky/cho_solve, not merely close.


### PR DESCRIPTION
Adds general-purpose block-banded Cholesky factorization and solve to furax.linalg: `banded_cholesky`, `banded_cholesky_solve`, and an AbstractLinearOperator wrapper, `BandedCholeskyOperator`.

A block-banded matrix is one made of k×k blocks where only the blocks within some bandwidth of the diagonal are non-zero. The motivation is to compute Gram matrices (`Tᵀ W T`) for template matrix T in #125.

Key points:
- `banded_cholesky`/`banded_cholesky_solve` factor and solve a block-banded SPD matrix stored in a compact band layout, scaling with the number of blocks rather than the full matrix size.
- The same routine also covers the fully dense case as a natural degenerate case (no measurable overhead).
- Both functions batch over arbitrary leading dimensions (e.g., per-detector or per-observation).
- `BandedCholeskyOperator` wraps a factored matrix as a furax operator, with factories to build from either an ordinary dense matrix or a band-layout one. Handles arbitrary pytree inputs.

Tests cover correctness against dense reference solves, the dense-degenerate case, batching, regularization, jit/grad compatibility, and the operator's construction/PyTree behavior.