### PR TITLE
Stream fused scan-block bodies

### DIFF
--- a/src/furax/mapmaking/_scan_blocks.py
+++ b/src/furax/mapmaking/_scan_blocks.py
@@ -366,10 +366,11 @@ class HomothetyScanBlockRule(AbstractCompositionRule):
         assert split is not None  # mypy
         homo, block, on_output_side = split
         if on_output_side:  # homo @ block: leading shared segment
-            scalar = HomothetyOperator(homo.value, in_structure=block.out_structure)
+            # we need the per-block structure here, not the public one with the leading axis
+            scalar = HomothetyOperator(homo.value, in_structure=block.segments[0].out_structure)
             segments = (Segment(scalar, False),) + block.segments
         else:  # block @ homo: trailing shared segment
-            scalar = HomothetyOperator(homo.value, in_structure=block.in_structure)
+            scalar = HomothetyOperator(homo.value, in_structure=block.segments[-1].in_structure)
             segments = block.segments + (Segment(scalar, False),)
         return [type(block)._build(segments, n_lead=block.n_lead)]
 

--- a/src/furax/mapmaking/_scan_blocks.py
+++ b/src/furax/mapmaking/_scan_blocks.py
@@ -1,7 +1,9 @@
+import functools
 from abc import ABC
 from dataclasses import field
 from typing import ClassVar, Self
 
+import equinox as eqx
 import jax
 import jax.numpy as jnp
 from jax import Array
@@ -20,79 +22,49 @@ from furax.core import (
 from furax.core.rules import AbstractAdditionRule, AbstractCompositionRule, NoReduction
 
 
-def _get_mesh() -> AbstractMesh:
-    mesh = jax.sharding.get_abstract_mesh()
-    if mesh.empty:
-        raise RuntimeError('active mesh context required')
-    return mesh
+class Segment(eqx.Module):
+    """One segment of a scan-block body."""
 
+    operator: AbstractLinearOperator
+    stacked: bool = eqx.field(static=True)
 
-def _leading_size(operator: AbstractLinearOperator) -> int:
-    """Observation-axis size of a freshly *stacked* operator: every leaf shares its leading axis.
+    @property
+    def trivial(self) -> bool:
+        """A trivial segment is a shared IdentityOperator."""
+        return not self.stacked and isinstance(self.operator, IdentityOperator)
 
-    Safe only at the stacking boundary — `AbstractScanBlockOperator.create` called on an
-    operator built by stacking `N` per-observation operators along a new axis 0. There the
-    caller's contract guarantees every leaf carries that axis, so the first array leaf's leading
-    dimension is unambiguous. Downstream the size is carried explicitly (`n`), never re-inferred.
-    """
-    for leaf in jax.tree.leaves(operator):
-        if jnp.ndim(leaf) >= 1:
-            return int(jnp.shape(leaf)[0])
-    raise RuntimeError('cannot infer observation-axis size: operator has no array leaf')
+    @property
+    def in_structure(self) -> PyTree[jax.ShapeDtypeStruct]:
+        return self.operator.in_structure
 
+    @property
+    def out_structure(self) -> PyTree[jax.ShapeDtypeStruct]:
+        return self.operator.out_structure
 
-def _check_scanned(scanned: AbstractLinearOperator, n_lead: int) -> None:
-    """Assert the scanned body is strictly obs-stacked: every leaf leads with the obs axis `n_lead`.
+    def transpose(self) -> 'Segment':
+        return Segment(self.operator.T, self.stacked)
 
-    This is an invariant check, not a classifier. A leaf that does not lead with `n` means a
-    non-observation operator leaked into the scanned body (a bug), and it raises loudly. Closed-over
-    maps (`pre`/`post`) are deliberately *not* checked — they may carry leaves of any shape
-    (scalars, shared-across-observation matrices), which is precisely the lifted limitation.
-    """
-    for leaf in jax.tree.leaves(scanned):
-        if jnp.ndim(leaf) < 1 or jnp.shape(leaf)[0] != n_lead:
-            raise ValueError(
-                f'scanned body leaf has shape {jnp.shape(leaf)}, but every leaf must lead with'
-                f'the observation axis of size {n_lead=}; closed-over maps belong in pre/post'
-            )
-
-
-def _prepend_axis(
-    structure: PyTree[jax.ShapeDtypeStruct],
-    axis_size: int,
-) -> PyTree[jax.ShapeDtypeStruct]:
-    return jax.tree.map(lambda s: jax.ShapeDtypeStruct((axis_size, *s.shape), s.dtype), structure)
+    def reduce(self) -> 'Segment':
+        return Segment(self.operator.reduce(), self.stacked)
 
 
 class AbstractScanBlockOperator(AbstractLinearOperator, ABC):
     """Base class for operators that apply a batched pytree operator slice-by-slice via scan.
 
-    The per-observation operator is stored as three explicit pieces whose composition is the
-    effective `i`-th block `post @ scanned_i @ pre`:
-
-    - `scanned`: the body, built by stacking `N` per-observation operators along a new axis 0.
-      It is *strictly* obs-stacked — every leaf leads with that axis — and is sliced one observation
-      at a time by `jax.lax.scan`.
-    - `pre` / `post`: closed-over input- and output-side maps broadcast across observations (a
-      scalar `−1` left by reduction of `W − …`, a shared basis matrix, ...). They are *not*
-      sliced and carry no observation axis; their leaves may be any shape. Two maps (rather than one)
-      keep the representation closed under transpose: `(post @ scanned)ᵀ = scannedᵀ @ postᵀ` turns
-      an output-side map into an input-side one.
-
-    The axis size `n_lead` is carried explicitly rather than re-inferred from leaf shapes, so the
-    scanned/closed-over distinction never depends on a shape coincidence.
+    The effective per-observation operator is stored as a list of "segments" (:class:`Segment`).
+    Segments are in composition (left-to-right) order: segments[0] is applied last (output side),
+    segments[-1] first (input side). Each segment is tagged obs-*stacked* (sliced per observation)
+    or *shared* (broadcast across observations).
 
     The "block" denomination refers to how each slice appears in the global operator matrix:
     subclasses arrange the N per-slice operators as blocks of a larger matrix (diagonal, column, or
-    row layout). The `_prepend_in` / `_prepend_out` class flags say whether the block prepends the
-    observation axis to its input / output structure.
+    row layout). The `_prepend_in`/`_prepend_out` class flags say whether the block prepends the
+    observation axis to its input/output structure.
 
     An active mesh context is required when calling `mv`; use `jax.set_mesh` beforehand.
     """
 
-    scanned: AbstractLinearOperator
-    pre: AbstractLinearOperator
-    post: AbstractLinearOperator
+    segments: tuple[Segment, ...]
     n_lead: int = field(kw_only=True, metadata={'static': True})
 
     _prepend_in: ClassVar[bool]
@@ -100,53 +72,63 @@ class AbstractScanBlockOperator(AbstractLinearOperator, ABC):
 
     @classmethod
     def create(cls, operator: AbstractLinearOperator, *, n_lead: int | None = None) -> Self:
-        """Wrap a freshly stacked operator as a block with trivial (identity) closed-over maps.
+        """Wrap a freshly stacked operator as a block with a single stacked segment.
 
-        `n` is inferred from the leaves only here, at the stacking boundary (see `_leading_size`);
-        operator-algebra rules carry it explicitly instead.
+        Args:
+            operator: The per-observation operator, stacked along a leading (observation) axis.
+            n_lead: The observation-axis size. If not explicitly provided, is inferred from the
+                operator leaves. Required if the operator has no array leaves.
         """
-        if len(jax.tree.leaves(operator)) == 0 and n_lead is None:
-            raise RuntimeError('unable to infer structures from operator with no leaf')
         if n_lead is None:
             n_lead = _leading_size(operator)
-        pre = IdentityOperator(in_structure=operator.in_structure)
-        post = IdentityOperator(in_structure=operator.out_structure)
-        return cls._build(operator, pre, post, n_lead=n_lead)
+        return cls._build((Segment(operator, True),), n_lead=n_lead)
 
     @classmethod
-    def _build(
-        cls,
-        scanned: AbstractLinearOperator,
-        pre: AbstractLinearOperator,
-        post: AbstractLinearOperator,
-        *,
-        n_lead: int,
-    ) -> Self:
-        _check_scanned(scanned, n_lead)
-        per_obs_in = pre.in_structure
+    def _build(cls, segments: tuple[Segment, ...], *, n_lead: int) -> Self:
+        segments = _normalize(segments)
+        for seg in segments:
+            if seg.stacked:
+                _check_stacked(seg.operator, n_lead)
+        per_obs_in = segments[-1].in_structure  # rightmost segment is applied first
         if cls._prepend_in:
             in_structure = _prepend_axis(per_obs_in, axis_size=n_lead)
         else:
             in_structure = per_obs_in
-        return cls(scanned, pre, post, n_lead=n_lead, in_structure=in_structure)
+        return cls(segments, n_lead=n_lead, in_structure=in_structure)
 
     @property
     def out_structure(self) -> PyTree[jax.ShapeDtypeStruct]:
-        per_obs_out = self.post.out_structure
+        per_obs_out = self.segments[0].out_structure  # leftmost segment is applied last
         if self._prepend_out:
             return _prepend_axis(per_obs_out, axis_size=self.n_lead)
         return per_obs_out
 
     @property
     def operator(self) -> AbstractLinearOperator:
-        """Effective per-observation operator `post @ scanned @ pre` (for introspection)."""
-        return (self.post @ self.scanned @ self.pre).reduce()
+        """Effective per-observation operator (composition of the segments; for introspection)."""
+        # segments is never empty (see _normalize), so _compose needs no fallback structure
+        return _compose(tuple(seg.operator for seg in self.segments))
 
     def reduce(self) -> AbstractLinearOperator:
-        scanned = self.scanned.reduce()
-        pre = self.pre.reduce()
-        post = self.post.reduce()
-        return type(self)._build(scanned, pre, post, n_lead=self.n_lead)
+        segments = tuple(seg.reduce() for seg in self.segments)
+        return type(self)._build(segments, n_lead=self.n_lead)
+
+    def _partition(
+        self,
+    ) -> tuple[tuple[AbstractLinearOperator, ...], tuple[AbstractLinearOperator, ...]]:
+        """Split each segment's operator into (dynamic, static): stacked segments expose their
+        arrays to the scan, shared segments keep everything static (broadcast across observations).
+        """
+        dyn: list[AbstractLinearOperator] = []
+        stat: list[AbstractLinearOperator] = []
+        for seg in self.segments:
+            if seg.stacked:
+                dyn_i, stat_i = eqx.partition(seg.operator, eqx.is_array)
+            else:
+                dyn_i, stat_i = eqx.partition(seg.operator, lambda _: False)
+            dyn.append(dyn_i)
+            stat.append(stat_i)
+        return tuple(dyn), tuple(stat)
 
 
 class ScanBlockDiagonalOperator(AbstractScanBlockOperator):
@@ -167,21 +149,22 @@ class ScanBlockDiagonalOperator(AbstractScanBlockOperator):
 
     def mv(self, x: PyTree[Inexact[Array, '...']]) -> PyTree[Inexact[Array, '...']]:
         axis = _get_mesh().axis_names[0]
+        dyn, static = self._partition()
 
         @jax.shard_map(out_specs=P(axis), check_vma=False)
-        def kernel(scanned, pre, post, x):  # type: ignore[no-untyped-def]
+        def kernel(dyn, static, x):  # type: ignore[no-untyped-def]
             def step(_, args):  # type: ignore[no-untyped-def]
-                scanned_i, x_i = args
-                return None, post(scanned_i(pre(x_i)))
+                dyn_i, x_i = args
+                return None, _apply_chain(dyn_i, static, x_i)
 
-            _, out = jax.lax.scan(step, None, (scanned, x))
+            _, out = jax.lax.scan(step, None, (dyn, x))
             return out
 
-        return kernel(self.scanned, self.pre, self.post, x)
+        return kernel(dyn, static, x)
 
     def transpose(self) -> AbstractLinearOperator:
-        scanned_t, pre_t, post_t = self.scanned.T, self.post.T, self.pre.T
-        return ScanBlockDiagonalOperator._build(scanned_t, pre_t, post_t, n_lead=self.n_lead)
+        segments = tuple(seg.transpose() for seg in reversed(self.segments))
+        return ScanBlockDiagonalOperator._build(segments, n_lead=self.n_lead)
 
 
 class ScanBlockColumnOperator(AbstractScanBlockOperator):
@@ -202,20 +185,21 @@ class ScanBlockColumnOperator(AbstractScanBlockOperator):
 
     def mv(self, x: PyTree[Inexact[Array, '...']]) -> PyTree[Inexact[Array, '...']]:
         axis = _get_mesh().axis_names[0]
+        dyn, static = self._partition()
 
         @jax.shard_map(out_specs=P(axis), check_vma=False)
-        def kernel(scanned, pre, post, x):  # type: ignore[no-untyped-def]
-            def step(_, scanned_i):  # type: ignore[no-untyped-def]
-                return None, post(scanned_i(pre(x)))
+        def kernel(dyn, static, x):  # type: ignore[no-untyped-def]
+            def step(_, dyn_i):  # type: ignore[no-untyped-def]
+                return None, _apply_chain(dyn_i, static, x)
 
-            _, out = jax.lax.scan(step, None, scanned)
+            _, out = jax.lax.scan(step, None, dyn)
             return out
 
-        return kernel(self.scanned, self.pre, self.post, x)
+        return kernel(dyn, static, x)
 
     def transpose(self) -> AbstractLinearOperator:
-        scanned_t, pre_t, post_t = self.scanned.T, self.post.T, self.pre.T
-        return ScanBlockRowOperator._build(scanned_t, pre_t, post_t, n_lead=self.n_lead)
+        segments = tuple(seg.transpose() for seg in reversed(self.segments))
+        return ScanBlockRowOperator._build(segments, n_lead=self.n_lead)
 
 
 class ScanBlockRowOperator(AbstractScanBlockOperator):
@@ -236,24 +220,25 @@ class ScanBlockRowOperator(AbstractScanBlockOperator):
 
     def mv(self, x: PyTree[Inexact[Array, '...']]) -> PyTree[Inexact[Array, '...']]:
         axis = _get_mesh().axis_names[0]
-        out_structure = self.post.out_structure
+        out_structure = self.segments[0].out_structure
+        dyn, static = self._partition()
 
         @jax.shard_map(out_specs=P(), check_vma=False)
-        def kernel(scanned, pre, post, x):  # type: ignore[no-untyped-def]
+        def kernel(dyn, static, x):  # type: ignore[no-untyped-def]
             def step(carry, args):  # type: ignore[no-untyped-def]
-                scanned_i, x_i = args
-                return tree.add(carry, post(scanned_i(pre(x_i)))), None
+                dyn_i, x_i = args
+                return tree.add(carry, _apply_chain(dyn_i, static, x_i)), None
 
             # pcast makes the replicated zeros match the varying carry type inside shard_map
             init = jax.lax.pcast(tree.zeros_like(out_structure), axis, to='varying')
-            out, _ = jax.lax.scan(step, init, (scanned, x))
+            out, _ = jax.lax.scan(step, init, (dyn, x))
             return jax.lax.psum(out, axis_name=axis)
 
-        return kernel(self.scanned, self.pre, self.post, x)
+        return kernel(dyn, static, x)
 
     def transpose(self) -> AbstractLinearOperator:
-        scanned_t, pre_t, post_t = self.scanned.T, self.post.T, self.pre.T
-        return ScanBlockColumnOperator._build(scanned_t, pre_t, post_t, n_lead=self.n_lead)
+        segments = tuple(seg.transpose() for seg in reversed(self.segments))
+        return ScanBlockColumnOperator._build(segments, n_lead=self.n_lead)
 
 
 class ScanAdditionOperator(AbstractScanBlockOperator):
@@ -277,34 +262,32 @@ class ScanAdditionOperator(AbstractScanBlockOperator):
 
     def mv(self, x: PyTree[Inexact[Array, '...']]) -> PyTree[Inexact[Array, '...']]:
         axis = _get_mesh().axis_names[0]
-        out_structure = self.post.out_structure
+        out_structure = self.segments[0].out_structure
+        dyn, static = self._partition()
 
         @jax.shard_map(out_specs=P(), check_vma=False)
-        def kernel(scanned, pre, post, x):  # type: ignore[no-untyped-def]
-            def step(carry, scanned_i):  # type: ignore[no-untyped-def]
-                return tree.add(carry, post(scanned_i(pre(x)))), None
+        def kernel(dyn, static, x):  # type: ignore[no-untyped-def]
+            def step(carry, dyn_i):  # type: ignore[no-untyped-def]
+                return tree.add(carry, _apply_chain(dyn_i, static, x)), None
 
             # pcast makes the replicated zeros match the varying carry type inside shard_map
             init = jax.lax.pcast(tree.zeros_like(out_structure), axis, to='varying')
-            out, _ = jax.lax.scan(step, init, scanned)
+            out, _ = jax.lax.scan(step, init, dyn)
             return jax.lax.psum(out, axis_name=axis)
 
-        return kernel(self.scanned, self.pre, self.post, x)
+        return kernel(dyn, static, x)
 
     def transpose(self) -> AbstractLinearOperator:
-        scanned_t, pre_t, post_t = self.scanned.T, self.post.T, self.pre.T
-        return ScanAdditionOperator._build(scanned_t, pre_t, post_t, n_lead=self.n_lead)
+        segments = tuple(seg.transpose() for seg in reversed(self.segments))
+        return ScanAdditionOperator._build(segments, n_lead=self.n_lead)
 
 
 class AbstractScanFusionRule(AbstractCompositionRule):
     """Fuse a composition of two scan-block operators into one scan block.
 
-    Per observation the product is `post1 s1 pre1 @ post2 s2 pre2`. The bodies `s1 @ s2` fuse;
-    the inner closed-over maps meet at the junction `mid = left.pre @ right.post` (between the two
-    bodies). The rule fires only when `mid` commutes past a body — i.e. `mid` is an identity or a
-    scalar `HomothetyOperator` — in which case it slides to the output edge and
-    multiplies `post1`. The outer maps `left.post` / `right.pre` ride along as the fused block's
-    `post` / `pre`. A non-commuting junction defers (`NoReduction`) to an outer composition.
+    In composition order the segment lists simply concatenate. The obs-independent maps that meet
+    at the junction ride along as shared segments; a non-scalar junction fuses just like a scalar
+    one. Whatever adjacent segments can genuinely merge do so in the reduced class constructor.
     """
 
     reduced_class: type[AbstractScanBlockOperator]
@@ -312,21 +295,10 @@ class AbstractScanFusionRule(AbstractCompositionRule):
     def apply(
         self, left: AbstractLinearOperator, right: AbstractLinearOperator
     ) -> list[AbstractLinearOperator]:
-        # The junction test lives here rather than in `check` so the reduction of
-        # `left.pre @ right.post` is computed once; the registry catches a `NoReduction`
-        # raised from `apply` just as it does from `check`.
         assert isinstance(left, AbstractScanBlockOperator)  # mypy
         assert isinstance(right, AbstractScanBlockOperator)  # mypy
-        mid = (left.pre @ right.post).reduce()
-        if not isinstance(mid, (IdentityOperator, HomothetyOperator)):
-            raise NoReduction
-        scanned = (left.scanned @ right.scanned).reduce()
-        if isinstance(mid, HomothetyOperator):
-            scalar = HomothetyOperator(mid.value, in_structure=left.post.out_structure)
-            post = (scalar @ left.post).reduce()
-        else:
-            post = left.post
-        return [self.reduced_class._build(scanned, right.pre, post, n_lead=left.n_lead)]
+        segments = left.segments + right.segments
+        return [self.reduced_class._build(segments, n_lead=left.n_lead)]
 
 
 class ScanBlockDiagonalScanBlockDiagonalRule(AbstractScanFusionRule):
@@ -362,12 +334,12 @@ class ScanBlockRowScanBlockColumnRule(AbstractScanFusionRule):
 
 
 class HomothetyScanBlockRule(AbstractCompositionRule):
-    """`Homothety @ ScanBlock = ScanBlock` with the scalar folded into a closed-over map.
+    """`Homothety @ ScanBlock = ScanBlock` with the scalar attached as a shared segment.
 
-    The scalar attaches to the closed-over `post` (output side) or `pre` (input side) map
-    depending on which side it sits — it is *not* folded into the scanned body, so the body stays
-    strictly obs-stacked. A scalar commutes through a linear operator, so the surrounding sum still
-    collapses to a single fused scan block via the addition-fusion rules.
+    The scalar becomes a shared (obs-independent) segment on the output side (``Homothety @ block``)
+    or input side (``block @ Homothety``); it is not sliced. A scalar commutes through a linear
+    operator, so the surrounding sum still collapses to a single fused scan block via the addition-
+    fusion rules.
     """
 
     operator_class = HomothetyOperator
@@ -393,27 +365,25 @@ class HomothetyScanBlockRule(AbstractCompositionRule):
         split = self._split(left, right)
         assert split is not None  # mypy
         homo, block, on_output_side = split
-        # Reduce the closed-over maps under the empty mesh (they carry no obs axis), but build the
-        # result under the caller's real mesh so `_augment_structure` shards the public structure.
-        # Otherwise the fused block would be unsharded and fail to compose with sharded blocks.
-        if on_output_side:
-            scalar = HomothetyOperator(homo.value, in_structure=block.post.out_structure)
-            pre, post = block.pre, (scalar @ block.post).reduce()
-        else:
-            scalar = HomothetyOperator(homo.value, in_structure=block.pre.in_structure)
-            pre, post = (block.pre @ scalar).reduce(), block.post
-        return [type(block)._build(block.scanned, pre, post, n_lead=block.n_lead)]
+        if on_output_side:  # homo @ block: leading shared segment
+            scalar = HomothetyOperator(homo.value, in_structure=block.out_structure)
+            segments = (Segment(scalar, False),) + block.segments
+        else:  # block @ homo: trailing shared segment
+            scalar = HomothetyOperator(homo.value, in_structure=block.in_structure)
+            segments = block.segments + (Segment(scalar, False),)
+        return [type(block)._build(segments, n_lead=block.n_lead)]
 
 
 class AbstractScanAdditionFusionRule(AbstractAdditionRule):
     """Fuse a sum of two scan-block operators of the same kind into one scan block.
 
-    When both operands have trivial closed-over maps the bodies add directly. Otherwise
-    the per-branch maps are kept out of the strictly obs-stacked body: `pre` maps fan the
-    input into a `BlockColumnOperator`, the two bodies sit on a `BlockDiagonalOperator`,
-    and the `post` maps recombine through a `BlockRowOperator`. The composite per observation
-    is `post1 s1 pre1 x + post2 s2 pre2 x` — keeping `W − W T G⁻¹ Tᵀ W` a single fused block
-    while the scalar/shared maps stay closed over rather than folded into the body.
+    Each operand is split into ``(pre, core, post)`` around its single stacked segment. When both
+    have trivial (identity) shared maps the cores add directly. Otherwise the shared maps are kept
+    out of the sliced body: the ``pre`` maps fan the input into a ``BlockColumnOperator``, the two
+    cores sit on a ``BlockDiagonalOperator`` (the one stacked segment), and the ``post`` maps
+    recombine through a ``BlockRowOperator``.
+
+    An operand without exactly one stacked segment cannot be laid out this way, so the rule defers.
     """
 
     reduced_class: type[AbstractScanBlockOperator]
@@ -433,21 +403,22 @@ class AbstractScanAdditionFusionRule(AbstractAdditionRule):
     ) -> list[AbstractLinearOperator]:
         assert isinstance(left, AbstractScanBlockOperator)  # mypy
         assert isinstance(right, AbstractScanBlockOperator)  # mypy
-        trivial = all(
-            isinstance(op, IdentityOperator) for op in (left.pre, left.post, right.pre, right.post)
-        )
-        # Assemble the bodies under the empty mesh, but build the result under
-        # the caller's real mesh so `_augment_structure` shards the public structure.
-        # Otherwise the fused block would be unsharded and fail to compose with sharded blocks.
+        split_left = _split_core(left)
+        split_right = _split_core(right)
+        if split_left is None or split_right is None:
+            raise NoReduction  # not a single-stacked-core body: defer to a plain AdditionOperator
+        pre_l, core_l, post_l = split_left
+        pre_r, core_r, post_r = split_right
+        trivial = all(isinstance(op, IdentityOperator) for op in (pre_l, post_l, pre_r, post_r))
         if trivial:
-            bodies = (left.scanned + right.scanned).reduce()
-        else:
-            pre = BlockColumnOperator([left.pre, right.pre])
-            scanned = BlockDiagonalOperator([left.scanned, right.scanned])
-            post = BlockRowOperator([left.post, right.post])
-        if trivial:
-            return [self.reduced_class.create(bodies, n_lead=left.n_lead)]
-        return [self.reduced_class._build(scanned, pre, post, n_lead=left.n_lead)]
+            core = (core_l + core_r).reduce()
+            return [self.reduced_class._build((Segment(core, True),), n_lead=left.n_lead)]
+        pre = BlockColumnOperator([pre_l, pre_r])
+        core = BlockDiagonalOperator([core_l, core_r])
+        post = BlockRowOperator([post_l, post_r])
+        # composition order: post @ core @ pre
+        segments = (Segment(post, False), Segment(core, True), Segment(pre, False))
+        return [self.reduced_class._build(segments, n_lead=left.n_lead)]
 
 
 class ScanBlockDiagonalAdditionRule(AbstractScanAdditionFusionRule):
@@ -480,3 +451,100 @@ class ScanAdditionAdditionRule(AbstractScanAdditionFusionRule):
     left_operator_class = ScanAdditionOperator
     right_operator_class = ScanAdditionOperator
     reduced_class = ScanAdditionOperator
+
+
+# ---------------------------------------------------------------------------
+# Private helpers
+# ---------------------------------------------------------------------------
+
+
+def _get_mesh() -> AbstractMesh:
+    mesh = jax.sharding.get_abstract_mesh()
+    if mesh.empty:
+        raise RuntimeError('active mesh context required')
+    return mesh
+
+
+def _leading_size(operator: AbstractLinearOperator) -> int:
+    """Observation-axis size of a *stacked* operator: all (array) leaves share a leading axis.
+
+    This only returns the leading axis size of the first leaf encountered. It does not check that
+    all leaves have consistent dimensions (see :func:`_check_stacked` for that).
+    """
+    for leaf in jax.tree.leaves(operator):
+        if eqx.is_array(leaf) and jnp.ndim(leaf) >= 1:
+            return jnp.shape(leaf)[0]
+    raise RuntimeError('cannot infer leading axis size: no non-scalar array leaf')
+
+
+def _prepend_axis(
+    structure: PyTree[jax.ShapeDtypeStruct], axis_size: int
+) -> PyTree[jax.ShapeDtypeStruct]:
+    return jax.tree.map(lambda s: jax.ShapeDtypeStruct((axis_size, *s.shape), s.dtype), structure)
+
+
+def _check_stacked(operator: AbstractLinearOperator, n_lead: int) -> None:
+    """Assert every array leaf of an *stacked* segment leads with the same axis size."""
+    for leaf in jax.tree.leaves(operator):
+        if eqx.is_array(leaf) and (jnp.ndim(leaf) < 1 or jnp.shape(leaf)[0] != n_lead):
+            msg = f'expected leading axis size {n_lead=}, got shape {jnp.shape(leaf)}'
+            raise ValueError(msg)
+
+
+def _compose(
+    operators: tuple[AbstractLinearOperator, ...],
+    in_structure: PyTree[jax.ShapeDtypeStruct] | None = None,
+) -> AbstractLinearOperator:
+    """Effective operator of a composition-ordered operator list (``operators[-1]`` applied first).
+
+    ``in_structure`` is only needed for the empty list, where it gives the identity its structure.
+    """
+    if not operators:
+        if in_structure is None:
+            raise ValueError('_compose of an empty operator list requires in_structure')
+        return IdentityOperator(in_structure=in_structure)
+    return functools.reduce(lambda acc, operator: acc @ operator, operators).reduce()
+
+
+def _normalize(segments: tuple[Segment, ...]) -> tuple[Segment, ...]:
+    """Drop trivial shared identities and merge consecutive same-tag segments."""
+    merged: list[Segment] = []
+    for seg in segments:
+        if seg.trivial:
+            continue  # drop shared identities
+        if merged and merged[-1].stacked == seg.stacked:
+            # composition order: merged[-1] is to the left (applied later), seg to the right
+            merged[-1] = Segment((merged[-1].operator @ seg.operator).reduce(), seg.stacked)
+        else:
+            merged.append(seg)
+    # keep at least one segment, even if all were trivial
+    return tuple(merged) or (segments[0],)
+
+
+def _split_core(
+    op: AbstractScanBlockOperator,
+) -> tuple[AbstractLinearOperator, AbstractLinearOperator, AbstractLinearOperator] | None:
+    """Split a body into ``(pre, core, post)`` around its single stacked segment, or ``None``."""
+    stacked = [i for i, seg in enumerate(op.segments) if seg.stacked]
+    if len(stacked) != 1:
+        return None
+    i = stacked[0]
+    core = op.segments[i].operator
+    post = _compose(tuple(seg.operator for seg in op.segments[:i]), core.out_structure)
+    pre = _compose(tuple(seg.operator for seg in op.segments[i + 1 :]), core.in_structure)
+    return pre, core, post
+
+
+def _apply_chain(
+    dyn: tuple[AbstractLinearOperator, ...],
+    static: tuple[AbstractLinearOperator, ...],
+    x: PyTree[Inexact[Array, '...']],
+) -> PyTree[Inexact[Array, '...']]:
+    """Apply one observation's segment chain, recombining each segment from its dyn/static split.
+
+    Segments are in composition order, so the last one is applied first (innermost).
+    """
+    y = x
+    for dyn_i, static_i in zip(reversed(dyn), reversed(static), strict=True):
+        y = eqx.combine(dyn_i, static_i)(y)
+    return y

--- a/tests/mapmaking/test_scan_blocks.py
+++ b/tests/mapmaking/test_scan_blocks.py
@@ -7,12 +7,13 @@ from jaxtyping import Array, Inexact, PyTree
 from numpy.testing import assert_allclose
 
 from furax import AbstractLinearOperator, tree
-from furax.core import DiagonalOperator, HomothetyOperator, IdentityOperator
+from furax.core import DiagonalOperator, HomothetyOperator
 from furax.mapmaking._scan_blocks import (
     ScanAdditionOperator,
     ScanBlockColumnOperator,
     ScanBlockDiagonalOperator,
     ScanBlockRowOperator,
+    Segment,
 )
 
 # ---------------------------------------------------------------------------
@@ -226,12 +227,13 @@ def test_sharded_fusion_ht_w_h() -> None:
 
 
 def test_homothety_on_block_lands_in_closed_over_map() -> None:
-    # `(-2) * block` folds the scalar into a closed-over map (here the input-side `pre`, since
-    # `c * op` puts the scalar on the input side), leaving the scanned body strictly obs-stacked.
+    # `(-2) * block` attaches the scalar as a shared segment on the input side (rightmost in
+    # composition order, since `c * op` puts the scalar on the input side), leaving the stacked core.
     blocks = _make_blocks(P('obs'))
     op = ((-2.0) * ScanBlockDiagonalOperator.create(blocks)).reduce()
     assert isinstance(op, ScanBlockDiagonalOperator)
-    assert isinstance(op.pre, HomothetyOperator)
+    assert [seg.stacked for seg in op.segments] == [True, False]
+    assert isinstance(op.segments[-1].operator, HomothetyOperator)
     x = jax.device_put(RNG.standard_normal((N_OBS, N_IN), dtype=np.float64), P('obs'))
     x_np = np.array(jax.device_get(x))
     expected = np.stack([-2.0 * (m @ x_np[i]) for i, m in enumerate(_per_obs(blocks))])
@@ -307,22 +309,24 @@ def test_fused_block_composes_with_sharded_block() -> None:
 
 
 def test_create_carries_explicit_obs_size() -> None:
-    # n is declared, not re-inferred from leaf shapes downstream; create starts with trivial maps.
+    # n is declared, not re-inferred from leaf shapes downstream; create starts with one stacked seg.
     W = ScanBlockDiagonalOperator.create(_make_blocks(P('obs')))
     assert W.n_lead == N_OBS
-    assert W.scanned.matrix.shape[0] == N_OBS
-    assert isinstance(W.pre, IdentityOperator)
-    assert isinstance(W.post, IdentityOperator)
+    assert len(W.segments) == 1
+    assert W.segments[0].stacked
+    assert W.segments[0].operator.matrix.shape[0] == N_OBS
 
 
 def test_non_scalar_static_post_is_applied() -> None:
-    # a NON-scalar closed-over map (a shared-across-observation diagonal, leaf shape (N_OUT,) with no
-    # obs axis) is a valid post map: it must be accepted (no scalar requirement) and applied.
+    # a NON-scalar shared segment (a shared-across-observation diagonal, leaf shape (N_OUT,) with no
+    # obs axis) is a valid output-side segment: it must be accepted and applied after the core.
     blocks = _make_blocks(P('obs'))  # per-obs (N_OUT, N_IN)
     d = jax.device_put(RNG.standard_normal((N_OUT,), dtype=np.float64), P())
     post = DiagonalOperator(d, in_structure=jax.ShapeDtypeStruct((N_OUT,), jnp.float64))
-    pre = IdentityOperator(in_structure=blocks.in_structure)
-    op = ScanBlockDiagonalOperator._build(blocks, pre, post, n_lead=N_OBS)  # must not raise
+    # composition order (post @ core): post is applied after the sliced core, so it comes first
+    op = ScanBlockDiagonalOperator._build(
+        (Segment(post, False), Segment(blocks, True)), n_lead=N_OBS
+    )
     x = jax.device_put(RNG.standard_normal((N_OBS, N_IN), dtype=np.float64), P('obs'))
     x_np = np.array(jax.device_get(x))
     d_np = np.array(jax.device_get(d))
@@ -331,13 +335,15 @@ def test_non_scalar_static_post_is_applied() -> None:
 
 
 def test_transpose_roundtrips_static() -> None:
-    # an output-side (post) map moves to the input side (pre) under transpose, symmetrically.
+    # an input-side shared map moves to the output side under transpose (segments reverse).
     blocks = _make_blocks(P('obs'))
     op = ((-3.0) * ScanBlockDiagonalOperator.create(blocks)).reduce()
-    assert isinstance(op.pre, HomothetyOperator)
+    assert isinstance(op.segments[-1].operator, HomothetyOperator)  # input side (applied first)
     op_T = op.T
     assert isinstance(op_T, ScanBlockDiagonalOperator)
-    assert isinstance(op_T.post, HomothetyOperator)
+    assert isinstance(
+        op_T.segments[0].operator, HomothetyOperator
+    )  # now output side (applied last)
     y = jax.device_put(RNG.standard_normal((N_OBS, N_OUT), dtype=np.float64), P('obs'))
     y_np = np.array(jax.device_get(y))
     expected = np.stack([-3.0 * (m.T @ y_np[i]) for i, m in enumerate(_per_obs(blocks))])
@@ -360,9 +366,7 @@ def test_addition_fusion_defers_on_obs_size_mismatch() -> None:
 
 
 def test_check_scanned_rejects_non_obs_body_leaf() -> None:
-    # a scanned body leaf that does not lead with the obs axis is a mis-stacked operator: raise.
+    # a stacked segment leaf that does not lead with the obs axis is a mis-tagged operator: raise.
     bad = _make_blocks()  # leaves lead with N_OBS
-    pre = IdentityOperator(in_structure=bad.in_structure)
-    post = IdentityOperator(in_structure=bad.out_structure)
-    with pytest.raises(ValueError, match='observation axis'):
-        ScanBlockDiagonalOperator._build(bad, pre, post, n_lead=N_OBS + 1)
+    with pytest.raises(ValueError, match='leading axis size'):
+        ScanBlockDiagonalOperator._build((Segment(bad, True),), n_lead=N_OBS + 1)


### PR DESCRIPTION
Store a scan-block body as an ordered list of tagged `Segment`s (operator + static `stacked` flag) in composition order, replacing the `(scanned, pre, post)` triple. Fusion becomes segment concatenation and obs-independent maps ride along as shared segments, so the composition streams one observation at a time whatever the junction map is. The stacked/shared split is carried by the tag, never inferred from leaf shapes.