### PR TITLE
Optimise PointingOperator matvec by using `lax.map`

### DIFF
--- a/src/furax/mapmaking/_model.py
+++ b/src/furax/mapmaking/_model.py
@@ -54,8 +54,8 @@ class ObservationModel:
             data[ReaderField.DETECTOR_QUATERNIONS],
             data.get(ReaderField.HWP_ANGLES),
             demodulated=config.demodulated,
-            pointing_chunk_size=config.pointing.chunk_size,
             pointing_on_the_fly=config.pointing.on_the_fly,
+            pointing_batch_size=config.pointing.batch_size,
             pointing_interpolate=config.pointing.interpolation == 'bilinear',
             dtype=config.dtype,
         )

--- a/src/furax/mapmaking/acquisition.py
+++ b/src/furax/mapmaking/acquisition.py
@@ -20,7 +20,7 @@ def build_acquisition_operator(
     *,
     demodulated: bool = False,
     pointing_on_the_fly: bool = True,
-    pointing_chunk_size: int = 16,
+    pointing_batch_size: int = 16,
     pointing_interpolate: bool = False,
     dtype: DTypeLike = jnp.float64,
 ) -> AbstractLinearOperator:
@@ -36,7 +36,7 @@ def build_acquisition_operator(
         landscape,
         boresight_quaternions,
         detector_quaternions,
-        chunk_size=pointing_chunk_size,
+        batch_size=pointing_batch_size,
         frame='boresight' if has_hwp else 'detector',
         interpolate=pointing_interpolate,
     )

--- a/src/furax/mapmaking/config.py
+++ b/src/furax/mapmaking/config.py
@@ -440,8 +440,8 @@ class PointingConfig:
     on_the_fly: bool = True
     """Compute pointing on the fly instead of pre-computing pixel indices."""
 
-    chunk_size: int = 32
-    """Number of detector chunks to process at a time when computing pointing on the fly."""
+    batch_size: int = 32
+    """Detector batch size for on-the-fly pointing (set to 0 to use a full batch)."""
 
     interpolation: Literal['nearest', 'bilinear'] = 'nearest'
     """Pixel interpolation scheme used when sampling the sky map."""

--- a/src/furax/mapmaking/mapmaker.py
+++ b/src/furax/mapmaking/mapmaker.py
@@ -687,7 +687,7 @@ class MapMaker:
                 landscape,
                 jnp.asarray(observation.get_boresight_quaternions()),
                 jnp.asarray(observation.get_detector_quaternions()),
-                chunk_size=self.config.pointing.chunk_size,
+                batch_size=self.config.pointing.batch_size,
                 interpolate=self.config.pointing.interpolation == 'bilinear',
             )
             return pointing
@@ -977,7 +977,7 @@ class MapMaker:
                 stokes='IQU',
                 dtype=config.dtype,
                 landscape=self._ground_landscape,
-                chunk_size=config.pointing.chunk_size,
+                batch_size=config.pointing.batch_size,
             )
             ones_tod = jnp.ones(
                 (observation.n_detectors, observation.n_samples), dtype=config.dtype

--- a/src/furax/mapmaking/templates.py
+++ b/src/furax/mapmaking/templates.py
@@ -730,7 +730,7 @@ class GroundTemplateOperator(AbstractLinearOperator):
         stokes: ValidStokesType,
         dtype: DTypeLike,
         landscape: HorizonLandscape | None = None,
-        chunk_size: int = 0,
+        batch_size: int = 0,
     ) -> AbstractLinearOperator:
         # Compute landscape if not provided
         if landscape is None:
@@ -759,7 +759,7 @@ class GroundTemplateOperator(AbstractLinearOperator):
             horizon_landscape,
             boresight_quaternions,
             detector_quaternions,
-            chunk_size=chunk_size,
+            batch_size=batch_size,
         )
 
         polarizer = LinearPolarizerOperator.create(

--- a/src/furax/obs/atmosphere/_operator.py
+++ b/src/furax/obs/atmosphere/_operator.py
@@ -96,8 +96,8 @@ class AtmospherePointingOperator(PointingOperator):
         """Gnomonic projection onto the atmosphere screen, including wind displacement."""
         x, y = self.landscape.quat2xy(qdet_full)
         return (
-            x + self.wind_displacement[None, :, 0],
-            y + self.wind_displacement[None, :, 1],
+            x + self.wind_displacement[:, 0],
+            y + self.wind_displacement[:, 1],
         )
 
     def _modulate(self, tod: StokesType, qdet_full: Float[Array, '*dims 4']) -> StokesType:

--- a/src/furax/obs/atmosphere/_operator.py
+++ b/src/furax/obs/atmosphere/_operator.py
@@ -38,7 +38,7 @@ class AtmospherePointingOperator(PointingOperator):
         qdet: Detector offset quaternions, shape ``(n_detectors, 4)``.
         wind_displacement: Pre-computed wind offset ``(vx * t_k, vy * t_k)`` for each
             sample, shape ``(n_samples, 2)``.
-        chunk_size: Number of detectors processed per chunk (memory/speed trade-off).
+        batch_size: Detector batch size.
         interpolate: If ``True``, use bilinear interpolation; otherwise nearest-neighbour.
         elevation_modulation: If ``True``, weight each sample by ``1 / sin(el)`` (airmass).
     """
@@ -56,7 +56,7 @@ class AtmospherePointingOperator(PointingOperator):
         wind_velocity: Float[Array, '2'],
         times: Float[Array, ' samp'],
         *,
-        chunk_size: int = 16,
+        batch_size: int = 16,
         interpolate: bool = True,
         elevation_modulation: bool = False,
     ) -> 'AtmospherePointingOperator':
@@ -70,7 +70,7 @@ class AtmospherePointingOperator(PointingOperator):
             wind_velocity: Wind velocity ``(vx, vy)`` in the same physical units as
                 ``landscape.height`` per second.
             times: Elapsed time for each sample, shape ``(n_samples,)``.
-            chunk_size: Number of detectors per chunk.
+            batch_size: Detector batch size.
             interpolate: Use bilinear interpolation (default: nearest-neighbour).
             elevation_modulation: Weight each sample by the airmass loading ``1 / sin(el)``.
         """
@@ -82,7 +82,7 @@ class AtmospherePointingOperator(PointingOperator):
             landscape,
             qbore=boresight_quaternions,
             qdet=detector_quaternions,
-            chunk_size=chunk_size,
+            batch_size=batch_size,
             interpolate=interpolate,
             _out_structure=out_structure,
             wind_displacement=wind_displacement,

--- a/src/furax/obs/pointing.py
+++ b/src/furax/obs/pointing.py
@@ -203,19 +203,19 @@ class PointingOperator(AbstractLinearOperator):
         sampled = jnp.sum(x_flat.data[:, indices] * unit_weights, axis=-1)
         return type(x_flat).from_array(sampled)
 
-    def _bin(self, tod_chunk: StokesType, qdet_full: Float[Array, '*dims 4']) -> StokesType:
-        """Scatter-add a TOD chunk into a sky map."""
+    def _bin(self, tod_batch: StokesType, qdet_full: Float[Array, '*dims 4']) -> StokesType:
+        """Scatter-add a batch of TOD into a sky map."""
         sky_shape = self.landscape.shape
         n_pixels = int(np.prod(sky_shape))
         # scatter-add per pixel while keeping the leading Stokes axis of the backing array.
-        arr = tod_chunk.data  # (n_stokes, *det_sample)
+        arr = tod_batch.data  # (n_stokes, *det_sample)
         n_stokes = arr.shape[0]
         zeros = jnp.zeros((n_stokes, n_pixels), self.landscape.dtype)
 
         if not self.interpolate:
             flat_pixels = self._quat2index(qdet_full).ravel()
             binned = zeros.at[:, flat_pixels].add(arr.reshape(n_stokes, -1))
-            return type(tod_chunk).from_array(binned.reshape(n_stokes, *sky_shape))
+            return type(tod_batch).from_array(binned.reshape(n_stokes, *sky_shape))
 
         indices, weights = self._quat2interp(qdet_full)
         valid = indices >= 0
@@ -228,7 +228,7 @@ class PointingOperator(AbstractLinearOperator):
         # over the leading Stokes axis for free).
         contrib = arr[..., None] * valid_weights
         binned = zeros.at[:, flat_indices].add(contrib.reshape(n_stokes, -1))
-        return type(tod_chunk).from_array(binned.reshape(n_stokes, *sky_shape))
+        return type(tod_batch).from_array(binned.reshape(n_stokes, *sky_shape))
 
     def transpose(self) -> AbstractLinearOperator:
         return PointingTransposeOperator(operator=self)
@@ -241,42 +241,42 @@ class PointingTransposeOperator(TransposeOperator):
     def mv(self, x: StokesType) -> StokesType:
         """Performs the 'pointing' operation, i.e. tod->map."""
 
-        def mv_inner(xchunk: StokesType, qdet: Float[Array, 'det 4']) -> StokesType:
+        def mv_inner(xbatch: StokesType, qdet: Float[Array, 'det 4']) -> StokesType:
             # Expand detector quaternions from boresight and offsets
             qdet_full = qmul(self.operator.qbore, qdet[:, None, :])
-            xchunk = self.operator._modulate(xchunk, qdet_full)
+            xbatch = self.operator._modulate(xbatch, qdet_full)
 
-            if isinstance(xchunk, StokesI):
+            if isinstance(xbatch, StokesI):
                 # no rotation needed
-                return self.operator._bin(xchunk, qdet_full)
+                return self.operator._bin(xbatch, qdet_full)
 
             # Rotate back to the celestial frame with the inverse rotation
             cos_angles, sin_angles = to_polarization_angle_cos_sin(qdet_full)
-            rotated = rotate_qu_cs(xchunk, cos_angles, -sin_angles)
+            rotated = rotate_qu_cs(xbatch, cos_angles, -sin_angles)
             return self.operator._bin(rotated, qdet_full)
 
-        # Loop over chunks of detectors
+        # Loop over batches of detectors
         ndet, _ = self.in_structure.shape
         batch_size = min(self.operator.batch_size, ndet)
         if batch_size > 0:
-            n_chunks = (ndet + batch_size - 1) // batch_size
+            n_batches = (ndet + batch_size - 1) // batch_size
         else:
-            n_chunks = 1
+            n_batches = 1
             batch_size = ndet
 
         def body(i: Int[Array, ''], sky: StokesType) -> StokesType:
             idet = jnp.arange(batch_size) + i * batch_size
 
-            # clip, but avoid multiple contributions in the last chunk
+            # clip, but avoid multiple contributions in the last batch
             unique = idet < ndet
             idet = jnp.clip(idet, max=ndet - 1)
 
-            # process chunk
-            sky_chunk = mv_inner(unique[:, None] * x[idet], self.operator.qdet[idet])
+            # process batch
+            sky_batch = mv_inner(unique[:, None] * x[idet], self.operator.qdet[idet])
 
-            # combine the results of the chunks into one sky map
-            return sky + sky_chunk
+            # combine the results of the batches into one sky map
+            return sky + sky_batch
 
         sky_out: StokesType = self.operator.landscape.zeros()
-        sky_out = lax.fori_loop(0, n_chunks, body, sky_out)
+        sky_out = lax.fori_loop(0, n_batches, body, sky_out)
         return sky_out

--- a/src/furax/obs/pointing.py
+++ b/src/furax/obs/pointing.py
@@ -41,7 +41,7 @@ class PointingOperator(AbstractLinearOperator):
         landscape: The sky pixelization (HEALPix landscape).
         qbore: Boresight quaternions, shape (n_samples, 4).
         qdet: Detector quaternions, shape (n_detectors, 4).
-        batch_size: Number of detectors per batch (memory/speed tradeoff).
+        batch_size: Detector batch size (memory/speed tradeoff; see jax.lax.map documentation).
     """
 
     landscape: StokesLandscape
@@ -95,13 +95,13 @@ class PointingOperator(AbstractLinearOperator):
     @jit
     def mv(self, x: StokesType) -> StokesType:
         """Performs the 'un-pointing' operation, i.e. map->tod."""
+        x_flat = x.ravel()
 
-        def mv_inner(qdet: Float[Array, 'det 4']) -> StokesType:
-            # Expand detector quaternions from boresight and offsets
-            # (samples, 4) x (det, 1, 4) -> (det, samples, 4)
-            qdet_full = qmul(self.qbore, qdet[:, None, :])
+        def mv_inner(qdet: Float[Array, ' 4']) -> StokesType:
+            # Expand one detector's quaternion from boresight and offset: (samp, 4)
+            qdet_full = qmul(self.qbore, qdet)
 
-            tod = self._sample(x.ravel(), qdet_full)
+            tod = self._sample(x_flat, qdet_full)
             tod = self._modulate(tod, qdet_full)
 
             if isinstance(tod, StokesI):
@@ -112,35 +112,10 @@ class PointingOperator(AbstractLinearOperator):
             cos_angles, sin_angles = to_polarization_angle_cos_sin(qdet_full)
             return rotate_qu_cs(tod, cos_angles, sin_angles)  # type: ignore[no-any-return]
 
-        # Loop over chunks of detectors
-        ndet, nsamp = self.out_structure.shape
-        batch_size = min(self.batch_size, ndet)
-        if batch_size > 0:
-            n_chunks = (ndet + batch_size - 1) // batch_size
-        else:
-            n_chunks = 1
-            batch_size = ndet
-
-        def body(i: Int[Array, ''], tod: StokesType) -> StokesType:
-            # interval bounds must be static, so we shift the values afterwards
-            idet = jnp.arange(batch_size) + i * batch_size
-
-            # clip array to avoid out of bounds
-            # this means that the last chunk may do redundant work
-            # but avoids recompilation
-            idet = jnp.clip(idet, max=ndet - 1)
-
-            # process chunk
-            tod_chunk = mv_inner(self.qdet[idet])
-
-            # update the output map
-            return type(tod).from_array(tod.data.at[:, idet].set(tod_chunk.data))
-
-        # Start from empty timestream
-        empty = jnp.empty((len(x.stokes), ndet, nsamp), dtype=x.dtype)
-        tod_out: StokesType = type(x).from_array(empty)
-        tod_out = lax.fori_loop(0, n_chunks, body, tod_out)
-        return tod_out
+        tod_out: StokesType = lax.map(mv_inner, self.qdet, batch_size=self.batch_size)
+        # lax.map stacks the new detector axis at position 0
+        # so move it back: (det, n_stokes, samp) -> (n_stokes, det, samp).
+        return type(tod_out).from_array(jnp.moveaxis(tod_out.data, 0, 1))
 
     def as_stokes_i(self, *, interpolate: bool | None = None) -> 'PointingOperator':
         """Return a copy of this operator restricted to StokesI.

--- a/src/furax/obs/pointing.py
+++ b/src/furax/obs/pointing.py
@@ -41,13 +41,13 @@ class PointingOperator(AbstractLinearOperator):
         landscape: The sky pixelization (HEALPix landscape).
         qbore: Boresight quaternions, shape (n_samples, 4).
         qdet: Detector quaternions, shape (n_detectors, 4).
-        chunk_size: Number of detectors per chunk (memory/speed tradeoff).
+        batch_size: Number of detectors per batch (memory/speed tradeoff).
     """
 
     landscape: StokesLandscape
     qbore: Float[Array, 'samp 4']
     qdet: Float[Array, 'det 4']
-    chunk_size: int = field(metadata={'static': True})
+    batch_size: int = field(metadata={'static': True})
     interpolate: bool = field(metadata={'static': True})
     _out_structure: PyTree[jax.ShapeDtypeStruct] = field(metadata={'static': True})
 
@@ -58,7 +58,7 @@ class PointingOperator(AbstractLinearOperator):
         boresight_quaternions: Float[Array, 'samp 4'],
         detector_quaternions: Float[Array, 'det 4'],
         *,
-        chunk_size: int = 16,
+        batch_size: int = 32,
         frame: Literal['boresight', 'detector'] = 'boresight',
         interpolate: bool = False,
     ) -> 'PointingOperator':
@@ -86,7 +86,7 @@ class PointingOperator(AbstractLinearOperator):
             landscape,
             qbore=boresight_quaternions,
             qdet=detector_quaternions,
-            chunk_size=chunk_size,
+            batch_size=batch_size,
             interpolate=interpolate,
             in_structure=landscape.structure,
             _out_structure=out_structure,
@@ -114,16 +114,16 @@ class PointingOperator(AbstractLinearOperator):
 
         # Loop over chunks of detectors
         ndet, nsamp = self.out_structure.shape
-        chunk_size = min(self.chunk_size, ndet)
-        if chunk_size > 0:
-            n_chunks = (ndet + chunk_size - 1) // chunk_size
+        batch_size = min(self.batch_size, ndet)
+        if batch_size > 0:
+            n_chunks = (ndet + batch_size - 1) // batch_size
         else:
             n_chunks = 1
-            chunk_size = ndet
+            batch_size = ndet
 
         def body(i: Int[Array, ''], tod: StokesType) -> StokesType:
             # interval bounds must be static, so we shift the values afterwards
-            idet = jnp.arange(chunk_size) + i * chunk_size
+            idet = jnp.arange(batch_size) + i * batch_size
 
             # clip array to avoid out of bounds
             # this means that the last chunk may do redundant work
@@ -160,7 +160,7 @@ class PointingOperator(AbstractLinearOperator):
             landscape,
             qbore=self.qbore,
             qdet=self.qdet,
-            chunk_size=self.chunk_size,
+            batch_size=self.batch_size,
             interpolate=effective_interpolate,
             in_structure=landscape.structure,
             _out_structure=out_structure,
@@ -282,15 +282,15 @@ class PointingTransposeOperator(TransposeOperator):
 
         # Loop over chunks of detectors
         ndet, _ = self.in_structure.shape
-        chunk_size = min(self.operator.chunk_size, ndet)
-        if chunk_size > 0:
-            n_chunks = (ndet + chunk_size - 1) // chunk_size
+        batch_size = min(self.operator.batch_size, ndet)
+        if batch_size > 0:
+            n_chunks = (ndet + batch_size - 1) // batch_size
         else:
             n_chunks = 1
-            chunk_size = ndet
+            batch_size = ndet
 
         def body(i: Int[Array, ''], sky: StokesType) -> StokesType:
-            idet = jnp.arange(chunk_size) + i * chunk_size
+            idet = jnp.arange(batch_size) + i * batch_size
 
             # clip, but avoid multiple contributions in the last chunk
             unique = idet < ndet

--- a/tests/obs/atmosphere/test_operator.py
+++ b/tests/obs/atmosphere/test_operator.py
@@ -26,7 +26,7 @@ def _make_operator(
     times=None,
     ndet=NDET,
     nsamp=NSAMP,
-    chunk_size=2,
+    batch_size=2,
     seed=0,
     elevation_modulation=False,
 ) -> tuple[AtmospherePointingOperator, TangentialLandscape, StokesI]:
@@ -61,7 +61,7 @@ def _make_operator(
         qdet,
         wind_velocity,
         times,
-        chunk_size=chunk_size,
+        batch_size=batch_size,
         interpolate=False,
         elevation_modulation=elevation_modulation,
     )

--- a/tests/obs/test_pointing.py
+++ b/tests/obs/test_pointing.py
@@ -40,7 +40,7 @@ class TestAsExpandedOperator:
         qbore = _random_unit_quats(key1, (NSAMP,))
         qdet = _random_unit_quats(key2, (NDET,))
 
-        pointing_op = PointingOperator.create(landscape, qbore, qdet, frame=frame, chunk_size=2)
+        pointing_op = PointingOperator.create(landscape, qbore, qdet, frame=frame, batch_size=2)
         sky = landscape.normal(key3)
 
         tod_direct = pointing_op(sky)
@@ -57,7 +57,7 @@ class TestAsExpandedOperator:
         qbore = _random_unit_quats(key1, (NSAMP,))
         qdet = _random_unit_quats(key2, (NDET,))
 
-        pointing_op = PointingOperator.create(landscape, qbore, qdet, frame=frame, chunk_size=2)
+        pointing_op = PointingOperator.create(landscape, qbore, qdet, frame=frame, batch_size=2)
         tod = pointing_op.out_structure
         tod = jax.tree.map(lambda s: jax.random.normal(key3, s.shape, s.dtype), tod)
 


### PR DESCRIPTION
I measured a 1.1x to 1.5x perf improvement on the forward matvec with this PR compared to main, using my local GPU. Unfortunately, we can't do the same with the transpose matvec, because we need to accumulate into a single buffer, which lax.map can't do.

Breaking change: rename `chunk_size` to `batch_size` for consistency with [lax.map](https://docs.jax.dev/en/latest/_autosummary/jax.lax.map.html).