### PR TITLE
Avoid unnecessary copies in observation readers

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -6,6 +6,5 @@
 
 - [ ] Tests added/updated for new or changed behavior
 - [ ] `uvx prek run -a` passes (ruff, mypy, etc.)
-- [ ] Added a changelog entry under `[Unreleased]` in `docs/development/changelog.md`, or this PR
-      doesn't need one (e.g. internal refactor, CI-only change)
+- [ ] Added a changelog entry under `[Unreleased]` in `docs/development/changelog.md`, or this PR doesn't need one (e.g. internal refactor, CI-only change)
 - [ ] Updated docs for user-facing changes (docstrings, `docs/`)

--- a/docs/development/changelog.md
+++ b/docs/development/changelog.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Renamed scan-block operators to `Stream*` and made the module public (`streaming.py`) (#173)
+- Avoid unnecessary array copies in observation readers (#175)
 
 ## [0.11.3] - 2026-07-14
 

--- a/src/furax/io/readers.py
+++ b/src/furax/io/readers.py
@@ -278,9 +278,7 @@ class AbstractReader(ABC):
         subclasses may override to apply field-specific padding.
         """
         return jax.tree.map(
-            lambda leaf, pad: (
-                np.pad(leaf, [(0, p) for p in pad]) if len(pad) > 0 else np.asarray(leaf)
-            ),
+            lambda leaf, pad: np.pad(leaf, [(0, p) for p in pad]) if any(pad) else np.asarray(leaf),
             data,
             padding,
         )

--- a/src/furax/mapmaking/_reader.py
+++ b/src/furax/mapmaking/_reader.py
@@ -332,13 +332,19 @@ class ObservationReader(AbstractReader, Generic[T]):
         stokes = self.stokes
         target_dtype = self.dtype
 
+        def cast(x: Any) -> Any:
+            return x.astype(target_dtype, copy=False)
+
+        def cast_bool(x: Any) -> Any:
+            return x.astype(bool, copy=False)
+
         def get_sample_data(obs: AbstractObservation[T]) -> Any:
             tods: Stokes | np.ndarray
             if demodulated:
                 tods = obs.get_demodulated_tods(stokes=stokes)
             else:
                 tods = obs.get_tods()
-            return jax.tree.map(lambda x: x.astype(target_dtype, copy=False), tods)
+            return jax.tree.map(cast, tods)
 
         def get_noise_model_fits(obs: AbstractObservation[T]) -> Any:
             if demodulated:
@@ -346,14 +352,14 @@ class ObservationReader(AbstractReader, Generic[T]):
             else:
                 model = if_none_raise_error(obs.get_noise_model())
             fits = model.to_array()
-            return jax.tree.map(lambda x: x.astype(target_dtype, copy=False), fits)
+            return jax.tree.map(cast, fits)
 
         def get_timestamps(obs: AbstractObservation[T]) -> Any:
             # The pipeline uses only time differences, so anchor each observation at its
             # own start. Subtracting in float64 keeps the samples resolved when cast to
             # float32; the absolute epoch is read from the interface where needed.
             timestamps = np.asarray(obs.get_timestamps(), dtype=np.float64)
-            return (timestamps - timestamps[0]).astype(target_dtype, copy=False)
+            return cast(timestamps - timestamps[0])
 
         return {
             ReaderField.METADATA: lambda obs: HashedObservationMetadata.from_observation(obs),
@@ -361,24 +367,14 @@ class ObservationReader(AbstractReader, Generic[T]):
             ReaderField.VALID_SAMPLE_MASKS: lambda obs: obs.get_sample_mask(),
             ReaderField.VALID_SCANNING_MASKS: lambda obs: obs.get_scanning_mask(),
             ReaderField.TIMESTAMPS: get_timestamps,
-            ReaderField.HWP_ANGLES: lambda obs: obs.get_hwp_angles().astype(
-                target_dtype, copy=False
-            ),
-            ReaderField.DETECTOR_QUATERNIONS: lambda obs: obs.get_detector_quaternions().astype(
-                target_dtype, copy=False
-            ),
-            ReaderField.BORESIGHT_QUATERNIONS: lambda obs: obs.get_boresight_quaternions().astype(
-                target_dtype, copy=False
-            ),
+            ReaderField.HWP_ANGLES: lambda obs: cast(obs.get_hwp_angles()),
+            ReaderField.DETECTOR_QUATERNIONS: lambda obs: cast(obs.get_detector_quaternions()),
+            ReaderField.BORESIGHT_QUATERNIONS: lambda obs: cast(obs.get_boresight_quaternions()),
             ReaderField.NOISE_MODEL_FITS: get_noise_model_fits,
-            ReaderField.AZIMUTH: lambda obs: obs.get_azimuth().astype(target_dtype, copy=False),
-            ReaderField.ELEVATION: lambda obs: obs.get_elevation().astype(target_dtype, copy=False),
-            ReaderField.LEFT_SCAN_MASK: lambda obs: obs.get_left_scan_mask().astype(
-                bool, copy=False
-            ),
-            ReaderField.RIGHT_SCAN_MASK: lambda obs: obs.get_right_scan_mask().astype(
-                bool, copy=False
-            ),
+            ReaderField.AZIMUTH: lambda obs: cast(obs.get_azimuth()),
+            ReaderField.ELEVATION: lambda obs: cast(obs.get_elevation()),
+            ReaderField.LEFT_SCAN_MASK: lambda obs: cast_bool(obs.get_left_scan_mask()),
+            ReaderField.RIGHT_SCAN_MASK: lambda obs: cast_bool(obs.get_right_scan_mask()),
             ReaderField.SCANNING_INTERVALS: lambda obs: np.asarray(
                 obs.get_scanning_intervals(), dtype=np.int32
             ),

--- a/src/furax/mapmaking/_reader.py
+++ b/src/furax/mapmaking/_reader.py
@@ -338,7 +338,7 @@ class ObservationReader(AbstractReader, Generic[T]):
                 tods = obs.get_demodulated_tods(stokes=stokes)
             else:
                 tods = obs.get_tods()
-            return jax.tree.map(lambda x: x.astype(target_dtype), tods)
+            return jax.tree.map(lambda x: x.astype(target_dtype, copy=False), tods)
 
         def get_noise_model_fits(obs: AbstractObservation[T]) -> Any:
             if demodulated:
@@ -346,14 +346,14 @@ class ObservationReader(AbstractReader, Generic[T]):
             else:
                 model = if_none_raise_error(obs.get_noise_model())
             fits = model.to_array()
-            return jax.tree.map(lambda x: x.astype(target_dtype), fits)
+            return jax.tree.map(lambda x: x.astype(target_dtype, copy=False), fits)
 
         def get_timestamps(obs: AbstractObservation[T]) -> Any:
             # The pipeline uses only time differences, so anchor each observation at its
             # own start. Subtracting in float64 keeps the samples resolved when cast to
             # float32; the absolute epoch is read from the interface where needed.
             timestamps = np.asarray(obs.get_timestamps(), dtype=np.float64)
-            return (timestamps - timestamps[0]).astype(target_dtype)
+            return (timestamps - timestamps[0]).astype(target_dtype, copy=False)
 
         return {
             ReaderField.METADATA: lambda obs: HashedObservationMetadata.from_observation(obs),
@@ -361,18 +361,24 @@ class ObservationReader(AbstractReader, Generic[T]):
             ReaderField.VALID_SAMPLE_MASKS: lambda obs: obs.get_sample_mask(),
             ReaderField.VALID_SCANNING_MASKS: lambda obs: obs.get_scanning_mask(),
             ReaderField.TIMESTAMPS: get_timestamps,
-            ReaderField.HWP_ANGLES: lambda obs: obs.get_hwp_angles().astype(target_dtype),
+            ReaderField.HWP_ANGLES: lambda obs: obs.get_hwp_angles().astype(
+                target_dtype, copy=False
+            ),
             ReaderField.DETECTOR_QUATERNIONS: lambda obs: obs.get_detector_quaternions().astype(
-                target_dtype
+                target_dtype, copy=False
             ),
             ReaderField.BORESIGHT_QUATERNIONS: lambda obs: obs.get_boresight_quaternions().astype(
-                target_dtype
+                target_dtype, copy=False
             ),
             ReaderField.NOISE_MODEL_FITS: get_noise_model_fits,
-            ReaderField.AZIMUTH: lambda obs: obs.get_azimuth().astype(target_dtype),
-            ReaderField.ELEVATION: lambda obs: obs.get_elevation().astype(target_dtype),
-            ReaderField.LEFT_SCAN_MASK: lambda obs: obs.get_left_scan_mask().astype(bool),
-            ReaderField.RIGHT_SCAN_MASK: lambda obs: obs.get_right_scan_mask().astype(bool),
+            ReaderField.AZIMUTH: lambda obs: obs.get_azimuth().astype(target_dtype, copy=False),
+            ReaderField.ELEVATION: lambda obs: obs.get_elevation().astype(target_dtype, copy=False),
+            ReaderField.LEFT_SCAN_MASK: lambda obs: obs.get_left_scan_mask().astype(
+                bool, copy=False
+            ),
+            ReaderField.RIGHT_SCAN_MASK: lambda obs: obs.get_right_scan_mask().astype(
+                bool, copy=False
+            ),
             ReaderField.SCANNING_INTERVALS: lambda obs: np.asarray(
                 obs.get_scanning_intervals(), dtype=np.int32
             ),


### PR DESCRIPTION
## Summary

What it says in the title. Reduces transient memory during data staging.

## Checklist

- [x] Tests added/updated for new or changed behavior
- [x] `uvx prek run -a` passes (ruff, mypy, etc.)
- [x] Added a changelog entry under `[Unreleased]` in `docs/development/changelog.md`, or this PR doesn't need one (e.g. internal refactor, CI-only change)
- [x] Updated docs for user-facing changes (docstrings, `docs/`)
