### PR TITLE
Migrate multi-obs mapmaker to furax CG and add verbose option

### DIFF
--- a/docs/development/changelog.md
+++ b/docs/development/changelog.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Renamed scan-block operators to `Stream*` and made the module public (`streaming.py`) (#173)
 - Avoid unnecessary array copies in observation readers (#175)
+- Migrate multi-observation mapmaker to furax CG and support verbose mode (#176)
 
 ## [0.11.3] - 2026-07-14
 

--- a/src/furax/mapmaking/config.py
+++ b/src/furax/mapmaking/config.py
@@ -1,4 +1,4 @@
-from dataclasses import dataclass, field, fields
+from dataclasses import asdict, dataclass, field, fields
 from enum import Enum
 from pathlib import Path
 from typing import Any, Literal, NamedTuple
@@ -51,8 +51,21 @@ class GapTreatment(Enum):
 @dataclass
 class SolverConfig:
     rtol: float = 1e-6
+    """Relative tolerance of iterative solver."""
+
     atol: float = 0
+    """Absolute tolerance of iterative solver."""
+
     max_steps: int = 1_000
+    """Maximum allowed number of iterations steps."""
+
+    verbose: bool = False
+    """Log the residual norm at every iteration."""
+
+    @property
+    def options(self) -> dict[str, Any]:
+        """Dictionary of solver options, minus `verbose`."""
+        return {k: v for k, v in asdict(self).items() if k != 'verbose'}
 
 
 @dataclass

--- a/src/furax/mapmaking/mapmaker.py
+++ b/src/furax/mapmaking/mapmaker.py
@@ -255,7 +255,6 @@ class MultiObservationMapMaker(Generic[T]):
             A_reduced = (selector @ A @ selector.T).reduce()
             M = (selector @ BJ.I @ selector.T).reduce()  # preconditioner
             rhs_reduced = selector(rhs)
-            y0 = M(rhs_reduced)
 
             iteration_callback = None
             if self.config.solver.verbose:
@@ -267,7 +266,6 @@ class MultiObservationMapMaker(Generic[T]):
             result = furax.linalg.cg(
                 A_reduced,
                 rhs_reduced,
-                y0,
                 preconditioner=M,
                 iteration_callback=iteration_callback,
                 **self.config.solver.options,

--- a/src/furax/mapmaking/mapmaker.py
+++ b/src/furax/mapmaking/mapmaker.py
@@ -1,7 +1,7 @@
 import pickle
 from abc import abstractmethod
 from collections.abc import Collection, Sequence
-from dataclasses import asdict, dataclass
+from dataclasses import dataclass
 from functools import cached_property
 from logging import Logger
 from math import prod
@@ -252,30 +252,35 @@ class MultiObservationMapMaker(Generic[T]):
             icov = jnp.moveaxis(icov, [-2, -1], [0, 1])  # (*pixels, ns, ns) → (ns, ns, *pixels)
 
             # Solve the mapmaking system
-            solver = lineax.CG(**asdict(self.config.solver))
-            spd = OperatorTag.POSITIVE_SEMIDEFINITE
-            lx_system = as_lineax_operator(selector @ A @ selector.T, spd)
+            A_reduced = (selector @ A @ selector.T).reduce()
             M = (selector @ BJ.I @ selector.T).reduce()  # preconditioner
-            lx_precond = as_lineax_operator(M, spd)
             rhs_reduced = selector(rhs)
             y0 = M(rhs_reduced)
 
-            solution = lineax.linear_solve(
-                lx_system,
+            iteration_callback = None
+            if self.config.solver.verbose:
+                # log from rank 0 only
+                def iteration_callback(step: Array, r_norm: Array) -> None:
+                    if rank == 0:
+                        logger_info(f'CG step={int(step)} residual={float(r_norm):.6e}')
+
+            result = furax.linalg.cg(
+                A_reduced,
                 rhs_reduced,
-                solver=solver,
-                options={'preconditioner': lx_precond, 'y0': y0},
-                throw=False,
+                y0,
+                preconditioner=M,
+                iteration_callback=iteration_callback,
+                **self.config.solver.options,
             )
-            estimate = selector.T(solution.value)
-            num_steps = solution.stats['num_steps']
+            estimate = selector.T(result.solution)
+            num_steps = result.num_steps
             logger_info(f'Finished mapmaking (iteration steps: {num_steps})')
 
         return MapMakingResults(
             map=estimate,
             icov=icov,
             hit_map=hits,
-            solver_stats=solution.stats,
+            solver_stats={'num_steps': num_steps},
             landscape=self.landscape,
             failed_observations=failed_observations,
         )
@@ -1233,7 +1238,7 @@ class MLMapmaker(MapMaker):
             )
             logger_info('Set up nested PCG for the noise inverse')
 
-        solver = lineax.CG(**asdict(config.solver))
+        solver = lineax.CG(**config.solver.options)
         options = {'solver': solver, 'preconditioner': p}
         if config.use_templates:
             mapmaking_operator = (h.T @ M @ h + reg).I(**options) @ h.T @ M
@@ -1358,7 +1363,7 @@ class TwoStepMapmaker(MapMaker):
         mp = masker
         FA = M - M @ mp @ A @ system_inv @ A.T @ mp @ M
 
-        solver = lineax.CG(**asdict(config.solver))
+        solver = lineax.CG(**config.solver.options)
         with Config(solver=solver):
             template_estimator = (
                 (template_op.T @ mp @ FA @ mp @ template_op).I @ template_op.T @ mp @ FA @ mp
@@ -1485,7 +1490,7 @@ class ATOPMapMaker(MapMaker):
         lhs = h.T @ mp @ ap @ mp @ h
         rhs_op = jax.jit(lambda d: (h.T @ mp @ ap @ mp).reduce()(d))
 
-        solver = lineax.CG(**asdict(self.config.solver))
+        solver = lineax.CG(**self.config.solver.options)
         spd = OperatorTag.POSITIVE_SEMIDEFINITE
         lx_system = as_lineax_operator(lhs, spd)
         lx_precond = as_lineax_operator(preconditioner.reduce(), spd)


### PR DESCRIPTION
## Summary

Migrate from lineax to furax CG in the multi-obs mapmaker (no behavior change).

The mapmaker now supports a "verbose" option to make the CG print its progress at each iteration step.

## Checklist

- [x] Tests added/updated for new or changed behavior
- [x] `uvx prek run -a` passes (ruff, mypy, etc.)
- [x] Added a changelog entry under `[Unreleased]` in `docs/development/changelog.md`, or this PR doesn't need one (e.g. internal refactor, CI-only change)
- [x] Updated docs for user-facing changes (docstrings, `docs/`)
