### PR TITLE
Rename ValidStokesType to ValidStokesLiteral

### DIFF
--- a/src/furax/_instruments/sky.py
+++ b/src/furax/_instruments/sky.py
@@ -11,7 +11,7 @@ from jaxtyping import Array, DTypeLike, PRNGKeyArray
 from numpy.typing import NDArray
 
 from ..obs.landscapes import FrequencyLandscape
-from ..obs.stokes import Stokes, ValidStokesType
+from ..obs.stokes import Stokes, ValidStokesLiteral
 
 
 class FGBusterInstrument(eqx.Module):
@@ -175,7 +175,7 @@ def get_sky(nside: int, tag: str = 'c1d0s0') -> pysm3.Sky:
 def get_noise_sigma_from_instrument(
     instrument: FGBusterInstrument,
     nside: int,
-    stokes_type: ValidStokesType = 'IQU',
+    stokes_type: ValidStokesLiteral = 'IQU',
     unit: str = 'uK_CMB',
 ) -> Stokes:
     instrument = instrument.depth_conversion(unit)
@@ -204,7 +204,7 @@ def get_observation(
     tag: str = 'c1d0s0',
     noise_ratio: float = 0.0,
     key: PRNGKeyArray | None = None,
-    stokes_type: ValidStokesType = 'IQU',
+    stokes_type: ValidStokesLiteral = 'IQU',
     dtype: DTypeLike = np.float64,
     unit: str = 'uK_CMB',
 ) -> Stokes:
@@ -231,7 +231,7 @@ def get_observation(
             Defaults to 0.0.
         key (PRNGKeyArray, optional): PRNG key for the Gaussian noise realization.
             Required when noise_ratio > 0. Defaults to None.
-        stokes_type (ValidStokesType, optional): The Stokes components
+        stokes_type (ValidStokesLiteral, optional): The Stokes components
             to include ('I', 'QU', 'IQU'). Defaults to 'IQU'.
         dtype (DTypeLike, optional): The data type for the output.
             Defaults to np.float64.

--- a/src/furax/interfaces/sotodlib/observation.py
+++ b/src/furax/interfaces/sotodlib/observation.py
@@ -42,7 +42,7 @@ from furax.obs.stokes import (
     StokesIQUV,
     StokesQU,
     StokesType,
-    ValidStokesType,
+    ValidStokesLiteral,
 )
 
 # Per-process cache of (configs, context) from sotodlib's get_preprocess_context, keyed by
@@ -278,7 +278,7 @@ class SOTODLibObservation(AbstractGroundObservation[AxisManager]):
     def get_demodulated_tods(self, stokes: Literal['IQU']) -> StokesIQU: ...
     @overload
     def get_demodulated_tods(self, stokes: Literal['IQUV']) -> StokesIQUV: ...
-    def get_demodulated_tods(self, stokes: ValidStokesType = 'IQU') -> StokesType:
+    def get_demodulated_tods(self, stokes: ValidStokesLiteral = 'IQU') -> StokesType:
         """Returns the demodulated timestream data as a Stokes pytree.
 
         'IQUV' is not supported.
@@ -403,7 +403,7 @@ class SOTODLibObservation(AbstractGroundObservation[AxisManager]):
             return None
         return AtmosphericNoiseModel(*fit)
 
-    def get_demodulated_noise_model(self, stokes: ValidStokesType = 'IQU') -> NoiseModel:
+    def get_demodulated_noise_model(self, stokes: ValidStokesLiteral = 'IQU') -> NoiseModel:
         """Returns a single noise model covering every requested Stokes leg.
 
         Each Stokes leg is fit independently (I/Q/U noise properties genuinely differ), so the

--- a/src/furax/mapmaking/_observation.py
+++ b/src/furax/mapmaking/_observation.py
@@ -18,7 +18,7 @@ from numpy.typing import NDArray
 
 from furax.math.quaternion import qmul, to_lonlat_angles
 from furax.obs.landscapes import ProjectionType, StokesLandscape
-from furax.obs.stokes import Stokes, StokesI, StokesIQU, StokesIQUV, StokesQU, ValidStokesType
+from furax.obs.stokes import Stokes, StokesI, StokesIQU, StokesIQUV, StokesQU, ValidStokesLiteral
 
 from .noise import NoiseModel
 
@@ -175,14 +175,14 @@ class AbstractObservation(ABC, Generic[T]):
     def get_demodulated_tods(self, stokes: Literal['IQU']) -> StokesIQU: ...
     @overload
     def get_demodulated_tods(self, stokes: Literal['IQUV']) -> StokesIQUV: ...
-    def get_demodulated_tods(self, stokes: ValidStokesType = 'IQU') -> Stokes:
+    def get_demodulated_tods(self, stokes: ValidStokesLiteral = 'IQU') -> Stokes:
         """Returns demodulated timestream data as a Stokes pytree.
 
         Subclasses that support demodulated data should override this method.
         """
         raise NotImplementedError(f'{type(self).__name__} does not support demodulated TODs')
 
-    def get_demodulated_noise_model(self, stokes: ValidStokesType = 'IQU') -> NoiseModel:
+    def get_demodulated_noise_model(self, stokes: ValidStokesLiteral = 'IQU') -> NoiseModel:
         """Returns a single noise model covering every requested Stokes leg.
 
         Its per-detector parameters carry a leading Stokes axis, so I/Q/U may have distinct

--- a/src/furax/mapmaking/_observation.py
+++ b/src/furax/mapmaking/_observation.py
@@ -18,7 +18,14 @@ from numpy.typing import NDArray
 
 from furax.math.quaternion import qmul, to_lonlat_angles
 from furax.obs.landscapes import ProjectionType, StokesLandscape
-from furax.obs.stokes import Stokes, StokesI, StokesIQU, StokesIQUV, StokesQU, ValidStokesLiteral
+from furax.obs.stokes import (
+    StokesI,
+    StokesIQU,
+    StokesIQUV,
+    StokesQU,
+    StokesType,
+    ValidStokesLiteral,
+)
 
 from .noise import NoiseModel
 
@@ -175,7 +182,7 @@ class AbstractObservation(ABC, Generic[T]):
     def get_demodulated_tods(self, stokes: Literal['IQU']) -> StokesIQU: ...
     @overload
     def get_demodulated_tods(self, stokes: Literal['IQUV']) -> StokesIQUV: ...
-    def get_demodulated_tods(self, stokes: ValidStokesLiteral = 'IQU') -> Stokes:
+    def get_demodulated_tods(self, stokes: ValidStokesLiteral = 'IQU') -> StokesType:
         """Returns demodulated timestream data as a Stokes pytree.
 
         Subclasses that support demodulated data should override this method.

--- a/src/furax/mapmaking/_reader.py
+++ b/src/furax/mapmaking/_reader.py
@@ -12,7 +12,7 @@ from jax.typing import DTypeLike
 from jaxtyping import PyTree
 
 from furax.io.readers import AbstractReader
-from furax.obs.stokes import Stokes, ValidStokesType
+from furax.obs.stokes import Stokes, ValidStokesLiteral
 
 from ._observation import (
     AbstractLazyObservation,
@@ -54,7 +54,7 @@ class ObservationReader(AbstractReader, Generic[T]):
         self,
         *args: Sequence[Any],
         demodulated: bool,
-        stokes: ValidStokesType,
+        stokes: ValidStokesLiteral,
         dtype: DTypeLike = jnp.float64,
         common_keywords: dict[str, Any] | None = None,
         shapes: list[tuple[int, ...]] | None = None,
@@ -88,7 +88,7 @@ class ObservationReader(AbstractReader, Generic[T]):
         read_indices: Sequence[int] | None = None,
         requested_fields: Collection[str] | None = None,
         demodulated: bool = False,
-        stokes: ValidStokesType = 'IQU',
+        stokes: ValidStokesLiteral = 'IQU',
         dtype: DTypeLike = jnp.float64,
     ) -> Self:
         """Create a reader, performing I/O to infer data structures.

--- a/src/furax/mapmaking/config.py
+++ b/src/furax/mapmaking/config.py
@@ -10,7 +10,7 @@ from apischema.conversions import Conversion
 from jax.typing import DTypeLike
 
 from furax.obs.landscapes import ProjectionType
-from furax.obs.stokes import ValidStokesType
+from furax.obs.stokes import ValidStokesLiteral
 
 # apischema serializes IntEnum by value (integer) by default; override to use the name instead
 # so that YAML config files show e.g. 'CAR' rather than '0'.
@@ -239,7 +239,7 @@ class WCSConfig:
 
 @dataclass
 class LandscapeConfig:
-    stokes: ValidStokesType = 'IQU'
+    stokes: ValidStokesLiteral = 'IQU'
     healpix: HealpixConfig | None = None
     wcs: WCSConfig | None = None
 

--- a/src/furax/mapmaking/mapmaker.py
+++ b/src/furax/mapmaking/mapmaker.py
@@ -49,7 +49,7 @@ from furax.obs.landscapes import (
 )
 from furax.obs.operators import HWPOperator, LinearPolarizerOperator, QURotationOperator
 from furax.obs.pointing import PointingOperator
-from furax.obs.stokes import Stokes, StokesI, StokesIQU, StokesType, ValidStokesType
+from furax.obs.stokes import Stokes, StokesI, StokesIQU, StokesType, ValidStokesLiteral
 
 from . import templates
 from ._geometry import minimum_enclosing_arc
@@ -577,7 +577,7 @@ def _static_landscape(lc: LandscapeConfig, dtype: DTypeLike) -> StokesLandscape 
 
 def _wcs_landscape_from_geometry(
     wcs_config: WCSConfig,
-    stokes: ValidStokesType,
+    stokes: ValidStokesLiteral,
     dtype: DTypeLike,
 ) -> WCSLandscape:
     """Build a WCSLandscape from an explicit geometry specification."""

--- a/src/furax/mapmaking/preconditioner.py
+++ b/src/furax/mapmaking/preconditioner.py
@@ -1,3 +1,5 @@
+from typing import TypeVar
+
 import jax
 import jax.numpy as jnp
 from jaxtyping import Array, Float, PyTree
@@ -9,6 +11,8 @@ from furax.obs.stokes import Stokes
 # Pass op as an explicit argument so JAX traces its arrays as inputs rather than
 # capturing them as XLA constants (which would happen with jit(op.mv) or jit(op)).
 _apply = jax.jit(lambda op, x: op(x))
+
+_StokesT = TypeVar('_StokesT', bound=Stokes)
 
 
 @symmetric
@@ -59,7 +63,7 @@ class BJPreconditioner(AbstractLinearOperator):
         blocks = jnp.moveaxis(jnp.stack(columns, axis=-1), 0, -2)  # (i, *sky, j) -> (*sky, i, j)
         return cls(blocks, in_structure=in_struct)
 
-    def mv(self, x: Stokes) -> Stokes:
+    def mv(self, x: _StokesT) -> _StokesT:
         # einsum aligns the blocks' trailing (i, j) axes against x.data's leading Stokes axis
         # directly, without physically transposing either array.
         return type(x).from_array(jnp.einsum('...ij,j...->i...', self.blocks, x.data))

--- a/src/furax/mapmaking/templates.py
+++ b/src/furax/mapmaking/templates.py
@@ -42,7 +42,7 @@ from furax.math import bspline, quaternion
 from furax.obs import HWPOperator, LinearPolarizerOperator
 from furax.obs.landscapes import HorizonLandscape
 from furax.obs.pointing import PointingOperator
-from furax.obs.stokes import ValidStokesType
+from furax.obs.stokes import ValidStokesLiteral
 
 from .config import BinsConfig, PolynomialOrders
 
@@ -735,7 +735,7 @@ class GroundTemplateOperator(AbstractLinearOperator):
         boresight_rotation: Float[Array, ' samps'],
         detector_quaternions: Float[Array, 'dets 4'],
         hwp_angles: Float[Array, ' samps'],
-        stokes: ValidStokesType,
+        stokes: ValidStokesLiteral,
         dtype: DTypeLike,
         landscape: HorizonLandscape | None = None,
         batch_size: int = 0,
@@ -794,7 +794,7 @@ class GroundTemplateOperator(AbstractLinearOperator):
         boresight_azimuth: Float[Array, ' samps'],
         boresight_elevation: Float[Array, ' samps'],
         detector_quaternions: Float[Array, 'dets 4'],
-        stokes: ValidStokesType,
+        stokes: ValidStokesLiteral,
         dtype: DTypeLike,
     ) -> HorizonLandscape:
         # First, set up a grid of (az, el) pairs

--- a/src/furax/obs/atmosphere/_operator.py
+++ b/src/furax/obs/atmosphere/_operator.py
@@ -1,4 +1,5 @@
 from dataclasses import field
+from typing import TypeVar
 
 from jaxtyping import Array, Float
 
@@ -6,7 +7,9 @@ from furax import tree
 from furax.math.quaternion import qrot_zaxis
 from furax.obs.landscapes import TangentialLandscape
 from furax.obs.pointing import PointingOperator
-from furax.obs.stokes import StokesI, StokesType
+from furax.obs.stokes import Stokes, StokesI
+
+_StokesT = TypeVar('_StokesT', bound=Stokes)
 
 __all__ = [
     'AtmospherePointingOperator',
@@ -100,7 +103,7 @@ class AtmospherePointingOperator(PointingOperator):
             y + self.wind_displacement[:, 1],
         )
 
-    def _modulate(self, tod: StokesType, qdet_full: Float[Array, '*dims 4']) -> StokesType:
+    def _modulate(self, tod: _StokesT, qdet_full: Float[Array, '*dims 4']) -> _StokesT:
         """Weight each sample by the airmass loading ``1 / sin(el)`` when enabled."""
         if not self.elevation_modulation:
             return tod

--- a/src/furax/obs/landscapes.py
+++ b/src/furax/obs/landscapes.py
@@ -15,7 +15,7 @@ from jaxtyping import Array, DTypeLike, Float, Integer, Key, PyTree, ScalarLike,
 
 from furax.math.quaternion import qrot_zaxis, to_iso_angles
 from furax.obs._samplings import Sampling
-from furax.obs.stokes import Stokes, ValidStokesType
+from furax.obs.stokes import Stokes, ValidStokesLiteral
 
 
 @register_static
@@ -69,7 +69,7 @@ class StokesLandscape(Landscape):
     def __init__(
         self,
         shape: tuple[int, ...] | None = None,
-        stokes: ValidStokesType = 'IQU',
+        stokes: ValidStokesLiteral = 'IQU',
         dtype: DTypeLike = np.float64,
         pixel_shape: tuple[int, ...] | None = None,
     ):
@@ -254,7 +254,7 @@ class WCSLandscape(StokesLandscape):
         self,
         shape: tuple[int, int],
         projection: WCSProjection,
-        stokes: ValidStokesType = 'IQU',
+        stokes: ValidStokesLiteral = 'IQU',
         dtype: DTypeLike = np.float64,
     ) -> None:
         super().__init__(shape, stokes, dtype)
@@ -295,7 +295,7 @@ class WCSLandscape(StokesLandscape):
         cls,
         shape: tuple[int, int],
         wcs: WCS,
-        stokes: ValidStokesType = 'IQU',
+        stokes: ValidStokesLiteral = 'IQU',
         dtype: DTypeLike = np.float64,
     ) -> 'WCSLandscape':
         """Create a WCSLandscape subclass instance from an astropy WCS object.
@@ -329,7 +329,7 @@ class CARLandscape(WCSLandscape):
         self,
         shape: tuple[int, int],
         projection: WCSProjection,
-        stokes: ValidStokesType = 'IQU',
+        stokes: ValidStokesLiteral = 'IQU',
         dtype: DTypeLike = np.float64,
     ) -> None:
         if projection.crval[1] != 0.0:
@@ -404,7 +404,7 @@ class HealpixLandscape(StokesLandscape):
     def __init__(
         self,
         nside: int,
-        stokes: ValidStokesType = 'IQU',
+        stokes: ValidStokesLiteral = 'IQU',
         dtype: DTypeLike = np.float64,
         nested: bool = False,
     ) -> None:
@@ -462,7 +462,7 @@ class FrequencyLandscape(HealpixLandscape):
         self,
         nside: int,
         frequencies: Array,
-        stokes: ValidStokesType = 'IQU',
+        stokes: ValidStokesLiteral = 'IQU',
         dtype: DTypeLike = np.float64,
     ):
         super().__init__(nside, stokes, dtype)
@@ -478,7 +478,7 @@ class AstropyWCSLandscape(StokesLandscape):
         self,
         shape: tuple[int, ...],
         wcs: WCS,
-        stokes: ValidStokesType = 'IQU',
+        stokes: ValidStokesLiteral = 'IQU',
         dtype: DTypeLike = np.float64,
     ) -> None:
         super().__init__(shape, stokes, dtype)
@@ -523,7 +523,7 @@ class HorizonLandscape(StokesLandscape):
         shape: tuple[int, ...],
         altitude_limits: tuple[Array, Array],
         azimuth_limits: tuple[Array, Array],
-        stokes: ValidStokesType = 'IQU',
+        stokes: ValidStokesLiteral = 'IQU',
         dtype: DTypeLike = np.float64,
     ) -> None:
         super().__init__(shape, stokes, dtype)
@@ -606,7 +606,7 @@ class TangentialLandscape(StokesLandscape):
         height: float,
         x0: float = 0.0,
         y0: float = 0.0,
-        stokes: ValidStokesType = 'I',
+        stokes: ValidStokesLiteral = 'I',
         dtype: DTypeLike = np.float64,
     ) -> None:
         if stokes != 'I':
@@ -634,7 +634,7 @@ class TangentialLandscape(StokesLandscape):
         height: float,
         x0: float = 0.0,
         y0: float = 0.0,
-        stokes: ValidStokesType = 'I',
+        stokes: ValidStokesLiteral = 'I',
         dtype: DTypeLike = np.float64,
     ) -> 'TangentialLandscape':
         """Create a landscape from physical extent and pixel spacing.

--- a/src/furax/obs/operators/_hwp.py
+++ b/src/furax/obs/operators/_hwp.py
@@ -7,7 +7,7 @@ from jaxtyping import Float
 from furax import AbstractLinearOperator, diagonal
 from furax.core.rules import AbstractCompositionRule
 
-from ..stokes import Stokes, StokesType, ValidStokesType
+from ..stokes import Stokes, StokesType, ValidStokesLiteral
 from ._qu_rotations import QURotationOperator, QURotationTransposeOperator
 from ._transfer_matrix import Stack, mueller_matrix
 
@@ -41,7 +41,7 @@ class HWPOperator(AbstractLinearOperator):
         cls,
         shape: tuple[int, ...],
         dtype: DTypeLike = np.float64,
-        stokes: ValidStokesType = 'IQU',
+        stokes: ValidStokesLiteral = 'IQU',
         *,
         angles: Float[Array, '...'] | None = None,
     ) -> AbstractLinearOperator:
@@ -145,7 +145,7 @@ class NonIdealHWPOperator(AbstractLinearOperator):
         cls,
         shape: tuple[int, ...],
         dtype: DTypeLike = np.float64,
-        stokes: ValidStokesType = 'IQU',
+        stokes: ValidStokesLiteral = 'IQU',
         *,
         mueller: Array,
         angles: Float[Array, '...'] | None = None,

--- a/src/furax/obs/operators/_hwp.py
+++ b/src/furax/obs/operators/_hwp.py
@@ -1,3 +1,5 @@
+from typing import TypeVar
+
 import numpy as np
 from jax import Array
 from jax import numpy as jnp
@@ -7,9 +9,11 @@ from jaxtyping import Float
 from furax import AbstractLinearOperator, diagonal
 from furax.core.rules import AbstractCompositionRule
 
-from ..stokes import Stokes, StokesType, ValidStokesLiteral
+from ..stokes import Stokes, ValidStokesLiteral
 from ._qu_rotations import QURotationOperator, QURotationTransposeOperator
 from ._transfer_matrix import Stack, mueller_matrix
+
+_StokesT = TypeVar('_StokesT', bound=Stokes)
 
 
 @diagonal
@@ -65,7 +69,7 @@ class HWPOperator(AbstractLinearOperator):
         rotated_hwp: AbstractLinearOperator = rot.T @ hwp @ rot
         return rotated_hwp
 
-    def mv(self, x: StokesType) -> Stokes:
+    def mv(self, x: _StokesT) -> _StokesT:
         # Canonical component order is I, Q, U, V: once 'U' is present, it and
         # every component after it (i.e. V) flip sign; I and Q are untouched.
         idx = x.stokes.find('U')
@@ -178,7 +182,7 @@ class NonIdealHWPOperator(AbstractLinearOperator):
         'IQUV': slice(0, 3),
     }
 
-    def mv(self, x: StokesType) -> StokesType:
+    def mv(self, x: _StokesT) -> _StokesT:
         # Slice the Mueller matrix to keep only relevant components
         sl = self._MUELLER_SLICE[x.stokes]
         data = x.data[:3]  # drops V if x has it; no-op otherwise

--- a/src/furax/obs/operators/_polarizers.py
+++ b/src/furax/obs/operators/_polarizers.py
@@ -10,7 +10,7 @@ from ..stokes import (
     StokesI,
     StokesQU,
     StokesType,
-    ValidStokesType,
+    ValidStokesLiteral,
 )
 from ._hwp import HWPOperator
 from ._qu_rotations import QURotationOperator
@@ -33,7 +33,7 @@ class LinearPolarizerOperator(AbstractLinearOperator):
         cls,
         shape: tuple[int, ...],
         dtype: DTypeLike = np.float64,
-        stokes: ValidStokesType = 'IQU',
+        stokes: ValidStokesLiteral = 'IQU',
         *,
         angles: Float[Array, '...'] | None = None,
     ) -> AbstractLinearOperator:

--- a/src/furax/obs/operators/_qu_rotations.py
+++ b/src/furax/obs/operators/_qu_rotations.py
@@ -17,6 +17,7 @@ which encodes successively (from right to left):
 """
 
 from dataclasses import field
+from typing import TypeVar
 
 import jax
 import numpy as np
@@ -31,13 +32,14 @@ from furax.core.rules import AbstractCompositionRule, NoReduction
 
 from ..stokes import (
     Stokes,
-    StokesType,
     ValidStokesLiteral,
 )
 
+_StokesT = TypeVar('_StokesT', bound=Stokes)
+
 
 @jax.jit
-def rotate_qu(x: StokesType, angles: Float[Array, '...']) -> StokesType:
+def rotate_qu(x: _StokesT, angles: Float[Array, '...']) -> _StokesT:
     """Rotate QU Stokes parameters by the given angles (in radians).
 
     The transpose rotation is obtained by passing ``-angles``.
@@ -47,10 +49,10 @@ def rotate_qu(x: StokesType, angles: Float[Array, '...']) -> StokesType:
 
 @jax.jit
 def rotate_qu_cs(
-    x: StokesType,
+    x: _StokesT,
     cos_angles: Float[Array, '...'],
     sin_angles: Float[Array, '...'],
-) -> StokesType:
+) -> _StokesT:
     """Rotate QU Stokes parameters given precomputed cos(a) and sin(a).
 
     The transpose rotation is obtained by negating ``sin_angles``.
@@ -96,7 +98,7 @@ class QURotationOperator(AbstractLinearOperator):
         structure = Stokes.class_for(stokes).structure_for(shape, dtype)
         return cls(angles=angles, atomic=atomic, in_structure=structure)
 
-    def mv(self, x: StokesType) -> StokesType:
+    def mv(self, x: _StokesT) -> _StokesT:
         return rotate_qu(x, self.angles)  # type: ignore[no-any-return]
 
     def transpose(self) -> AbstractLinearOperator:
@@ -106,7 +108,7 @@ class QURotationOperator(AbstractLinearOperator):
 class QURotationTransposeOperator(AbstractLazyInverseOrthogonalOperator):
     operator: QURotationOperator
 
-    def mv(self, x: StokesType) -> StokesType:
+    def mv(self, x: _StokesT) -> _StokesT:
         return rotate_qu(x, -self.operator.angles)  # type: ignore[no-any-return]
 
 

--- a/src/furax/obs/operators/_qu_rotations.py
+++ b/src/furax/obs/operators/_qu_rotations.py
@@ -32,7 +32,7 @@ from furax.core.rules import AbstractCompositionRule, NoReduction
 from ..stokes import (
     Stokes,
     StokesType,
-    ValidStokesType,
+    ValidStokesLiteral,
 )
 
 
@@ -88,7 +88,7 @@ class QURotationOperator(AbstractLinearOperator):
         cls,
         shape: tuple[int, ...],
         dtype: DTypeLike = np.float64,
-        stokes: ValidStokesType = 'IQU',
+        stokes: ValidStokesLiteral = 'IQU',
         *,
         angles: Float[Array, '...'],
         atomic: bool = False,

--- a/src/furax/obs/pointing.py
+++ b/src/furax/obs/pointing.py
@@ -1,6 +1,6 @@
 import copy
 from dataclasses import field
-from typing import Literal
+from typing import Literal, TypeVar
 
 import jax
 import jax.numpy as jnp
@@ -19,11 +19,13 @@ from furax.math.quaternion import (
 )
 from furax.obs.landscapes import StokesLandscape
 from furax.obs.operators._qu_rotations import QURotationOperator, rotate_qu_cs
-from furax.obs.stokes import Stokes, StokesI, StokesType
+from furax.obs.stokes import Stokes, StokesI
 
 __all__ = [
     'PointingOperator',
 ]
+
+_StokesT = TypeVar('_StokesT', bound=Stokes)
 
 
 class PointingOperator(AbstractLinearOperator):
@@ -93,11 +95,11 @@ class PointingOperator(AbstractLinearOperator):
         )
 
     @jit
-    def mv(self, x: StokesType) -> StokesType:
+    def mv(self, x: _StokesT) -> _StokesT:
         """Performs the 'un-pointing' operation, i.e. map->tod."""
         x_flat = x.ravel()
 
-        def mv_inner(qdet: Float[Array, ' 4']) -> StokesType:
+        def mv_inner(qdet: Float[Array, ' 4']) -> _StokesT:
             # Expand one detector's quaternion from boresight and offset: (samp, 4)
             qdet_full = qmul(self.qbore, qdet)
 
@@ -112,7 +114,7 @@ class PointingOperator(AbstractLinearOperator):
             cos_angles, sin_angles = to_polarization_angle_cos_sin(qdet_full)
             return rotate_qu_cs(tod, cos_angles, sin_angles)  # type: ignore[no-any-return]
 
-        tod_out: StokesType = lax.map(mv_inner, self.qdet, batch_size=self.batch_size)
+        tod_out: _StokesT = lax.map(mv_inner, self.qdet, batch_size=self.batch_size)
         # lax.map stacks the new detector axis at position 0
         # so move it back: (det, n_stokes, samp) -> (n_stokes, det, samp).
         return type(tod_out).from_array(jnp.moveaxis(tod_out.data, 0, 1))
@@ -176,7 +178,7 @@ class PointingOperator(AbstractLinearOperator):
         """
         return self.landscape.quat2interp(qdet_full)
 
-    def _modulate(self, tod: StokesType, qdet_full: Float[Array, '*dims 4']) -> StokesType:
+    def _modulate(self, tod: _StokesT, qdet_full: Float[Array, '*dims 4']) -> _StokesT:
         """Hook applied to the sampled TOD (identity in the base class).
 
         Subclasses override this to inject a per-sample diagonal weighting. Because the
@@ -185,7 +187,7 @@ class PointingOperator(AbstractLinearOperator):
         """
         return tod
 
-    def _sample(self, x_flat: StokesType, qdet_full: Float[Array, '*dims 4']) -> StokesType:
+    def _sample(self, x_flat: _StokesT, qdet_full: Float[Array, '*dims 4']) -> _StokesT:
         """Sample the flat map at positions given by qdet_full."""
         if not self.interpolate:
             return x_flat[self._quat2index(qdet_full)]
@@ -203,7 +205,7 @@ class PointingOperator(AbstractLinearOperator):
         sampled = jnp.sum(x_flat.data[:, indices] * unit_weights, axis=-1)
         return type(x_flat).from_array(sampled)
 
-    def _bin(self, tod_batch: StokesType, qdet_full: Float[Array, '*dims 4']) -> StokesType:
+    def _bin(self, tod_batch: _StokesT, qdet_full: Float[Array, '*dims 4']) -> _StokesT:
         """Scatter-add a batch of TOD into a sky map."""
         sky_shape = self.landscape.shape
         n_pixels = int(np.prod(sky_shape))
@@ -238,10 +240,10 @@ class PointingTransposeOperator(TransposeOperator):
     operator: PointingOperator
 
     @jit
-    def mv(self, x: StokesType) -> StokesType:
+    def mv(self, x: _StokesT) -> _StokesT:
         """Performs the 'pointing' operation, i.e. tod->map."""
 
-        def mv_inner(xbatch: StokesType, qdet: Float[Array, 'det 4']) -> StokesType:
+        def mv_inner(xbatch: _StokesT, qdet: Float[Array, 'det 4']) -> _StokesT:
             # Expand detector quaternions from boresight and offsets
             qdet_full = qmul(self.operator.qbore, qdet[:, None, :])
             xbatch = self.operator._modulate(xbatch, qdet_full)
@@ -252,7 +254,7 @@ class PointingTransposeOperator(TransposeOperator):
 
             # Rotate back to the celestial frame with the inverse rotation
             cos_angles, sin_angles = to_polarization_angle_cos_sin(qdet_full)
-            rotated = rotate_qu_cs(xbatch, cos_angles, -sin_angles)
+            rotated: _StokesT = rotate_qu_cs(xbatch, cos_angles, -sin_angles)
             return self.operator._bin(rotated, qdet_full)
 
         # Loop over batches of detectors
@@ -264,7 +266,7 @@ class PointingTransposeOperator(TransposeOperator):
             n_batches = 1
             batch_size = ndet
 
-        def body(i: Int[Array, ''], sky: StokesType) -> StokesType:
+        def body(i: Int[Array, ''], sky: _StokesT) -> _StokesT:
             idet = jnp.arange(batch_size) + i * batch_size
 
             # clip, but avoid multiple contributions in the last batch
@@ -277,6 +279,6 @@ class PointingTransposeOperator(TransposeOperator):
             # combine the results of the batches into one sky map
             return sky + sky_batch
 
-        sky_out: StokesType = self.operator.landscape.zeros()
+        sky_out: _StokesT = self.operator.landscape.zeros()
         sky_out = lax.fori_loop(0, n_batches, body, sky_out)
         return sky_out

--- a/src/furax/obs/stokes.py
+++ b/src/furax/obs/stokes.py
@@ -23,9 +23,16 @@ from furax.tree import (
     zeros_like,
 )
 
-__all__ = ['Stokes', 'StokesI', 'StokesQU', 'StokesIQU', 'StokesIQUV', 'ValidStokesType']
+__all__ = [
+    'Stokes',
+    'StokesI',
+    'StokesQU',
+    'StokesIQU',
+    'StokesIQUV',
+    'ValidStokesLiteral',
+]
 
-ValidStokesType = Literal['I', 'QU', 'IQU', 'IQUV']
+ValidStokesLiteral = Literal['I', 'QU', 'IQU', 'IQUV']
 
 
 @dataclass
@@ -63,7 +70,7 @@ class Stokes(ABC):
         True
     """
 
-    stokes: ClassVar[ValidStokesType]
+    stokes: ClassVar[ValidStokesLiteral]
     data: Array
 
     def __init__(self, *args: Any, **kwargs: Any) -> None:
@@ -264,7 +271,7 @@ class Stokes(ABC):
     @classmethod
     def class_for(cls, stokes: str) -> type['StokesType']:
         """Returns the StokesPyTree subclass associated to the specified Stokes types."""
-        if stokes not in get_args(ValidStokesType):
+        if stokes not in get_args(ValidStokesLiteral):
             raise ValueError(f'Invalid Stokes parameters: {stokes!r}')
         requested_cls = {
             'I': StokesI,
@@ -317,7 +324,7 @@ class Stokes(ABC):
             )
         if keywords:
             stokes = ''.join(sorted(keywords))
-            if stokes not in get_args(ValidStokesType):
+            if stokes not in get_args(ValidStokesLiteral):
                 raise TypeError(
                     f"Invalid Stokes vectors: {stokes!r}. Use 'I', 'QU', 'IQU' or 'IQUV'."
                 )
@@ -376,22 +383,22 @@ class Stokes(ABC):
 
 @register_dataclass_with_keys
 class StokesI(Stokes):
-    stokes: ClassVar[ValidStokesType] = 'I'
+    stokes: ClassVar[ValidStokesLiteral] = 'I'
 
 
 @register_dataclass_with_keys
 class StokesQU(Stokes):
-    stokes: ClassVar[ValidStokesType] = 'QU'
+    stokes: ClassVar[ValidStokesLiteral] = 'QU'
 
 
 @register_dataclass_with_keys
 class StokesIQU(Stokes):
-    stokes: ClassVar[ValidStokesType] = 'IQU'
+    stokes: ClassVar[ValidStokesLiteral] = 'IQU'
 
 
 @register_dataclass_with_keys
 class StokesIQUV(Stokes):
-    stokes: ClassVar[ValidStokesType] = 'IQUV'
+    stokes: ClassVar[ValidStokesLiteral] = 'IQUV'
 
 
 StokesType = StokesI | StokesQU | StokesIQU | StokesIQUV

--- a/tests/mapmaking/helpers.py
+++ b/tests/mapmaking/helpers.py
@@ -15,7 +15,7 @@ from furax.mapmaking import (
 )
 from furax.mapmaking.noise import AtmosphericNoiseModel, NoiseModel
 from furax.obs.landscapes import ProjectionType, StokesLandscape
-from furax.obs.stokes import Stokes, ValidStokesType
+from furax.obs.stokes import Stokes, ValidStokesLiteral
 
 
 class FakeObservation(AbstractObservation[None]):
@@ -85,7 +85,7 @@ class FakeObservation(AbstractObservation[None]):
         rng = np.random.default_rng(self._seed)
         return rng.normal(size=(self._n_dets, self._n_samples)).astype(np.float32)
 
-    def get_demodulated_tods(self, stokes: ValidStokesType = 'IQU') -> Any:
+    def get_demodulated_tods(self, stokes: ValidStokesLiteral = 'IQU') -> Any:
         # One synthetic (dets, samps) stream per requested Stokes component.
         kls = Stokes.class_for(stokes)
         rng = np.random.default_rng(self._seed + 1)
@@ -94,7 +94,7 @@ class FakeObservation(AbstractObservation[None]):
         ]
         return kls.from_stokes(*streams)
 
-    def get_demodulated_noise_model(self, stokes: ValidStokesType = 'IQU') -> NoiseModel:
+    def get_demodulated_noise_model(self, stokes: ValidStokesLiteral = 'IQU') -> NoiseModel:
         # One white-noise fit per Stokes component. Rows match AtmosphericNoiseModel's
         # fields: (sigma, alpha, fk, f0).
         n = self._n_dets

--- a/tests/mapmaking/test_mapmaker.py
+++ b/tests/mapmaking/test_mapmaker.py
@@ -32,7 +32,7 @@ from furax.mapmaking.config import (
 from furax.mapmaking.mapmaker import MLMapmaker, get_obs_distribution_to_process
 from furax.mapmaking.noise import WhiteNoiseModel
 from furax.obs.landscapes import ProjectionType
-from furax.obs.stokes import ValidStokesType
+from furax.obs.stokes import ValidStokesLiteral
 from tests.mapmaking.helpers import (
     FailingLazyObservation,
     FakeGroundObservation,
@@ -325,7 +325,7 @@ class TestATOPStokesValidation:
     (or an empty list) rather than an interface or ``.h5`` fixture.
     """
 
-    def _base_config(self, stokes: ValidStokesType) -> MapMakingConfig:
+    def _base_config(self, stokes: ValidStokesLiteral) -> MapMakingConfig:
         return MapMakingConfig(
             method=Methods.ATOP,
             atop_tau=ATOP_TAU,
@@ -364,7 +364,7 @@ def _observations(name: str, demodulated: bool = False) -> list[AbstractLazyObse
 
 def _config(
     landscape_type: Literal['healpix', 'car'],
-    stokes: ValidStokesType,
+    stokes: ValidStokesLiteral,
     demodulated: bool = False,
     interpolation: Literal['nearest', 'bilinear'] = 'nearest',
     method: Methods = Methods.BINNED,

--- a/tests/obs/conftest.py
+++ b/tests/obs/conftest.py
@@ -2,10 +2,10 @@ from typing import get_args
 
 import pytest
 
-from furax.obs.stokes import ValidStokesType
+from furax.obs.stokes import ValidStokesLiteral
 
 
-@pytest.fixture(params=get_args(ValidStokesType))
-def stokes(request: pytest.FixtureRequest) -> ValidStokesType:
+@pytest.fixture(params=get_args(ValidStokesLiteral))
+def stokes(request: pytest.FixtureRequest) -> ValidStokesLiteral:
     """Parametrized fixture for I, QU, IQU and IQUV."""
     return request.param

--- a/tests/obs/operators/test_hwp.py
+++ b/tests/obs/operators/test_hwp.py
@@ -4,10 +4,10 @@ import jax.numpy as jnp
 from furax.core import CompositionOperator
 from furax.obs import HWPOperator, QURotationOperator
 from furax.obs.operators._qu_rotations import QURotationTransposeOperator
-from furax.obs.stokes import Stokes, StokesI, StokesIQUV, ValidStokesType
+from furax.obs.stokes import Stokes, StokesI, StokesIQUV, ValidStokesLiteral
 
 
-def test_hwp(stokes: ValidStokesType) -> None:
+def test_hwp(stokes: ValidStokesLiteral) -> None:
     hwp = HWPOperator.create(shape=(), stokes=stokes)
     cls = Stokes.class_for(stokes)
     x = cls.ones(())
@@ -18,14 +18,14 @@ def test_hwp(stokes: ValidStokesType) -> None:
     assert equinox.tree_equal(actual_y, expected_y)
 
 
-def test_hwp_orthogonal(stokes: ValidStokesType) -> None:
+def test_hwp_orthogonal(stokes: ValidStokesLiteral) -> None:
     hwp = HWPOperator.create(shape=(), stokes=stokes)
     x = Stokes.class_for(stokes).ones(())
     y = (hwp.T @ hwp)(x)
     assert equinox.tree_equal(y, x)
 
 
-def test_qu_rotation_hwp_rule(stokes: ValidStokesType) -> None:
+def test_qu_rotation_hwp_rule(stokes: ValidStokesLiteral) -> None:
     in_structure = Stokes.class_for(stokes).structure_for(())
     hwp = HWPOperator(in_structure=in_structure)
     rot = QURotationOperator(jnp.array(1.0), in_structure=in_structure)
@@ -73,7 +73,7 @@ def test_rotating_hwp_iquv() -> None:
     assert equinox.tree_equal(actual_y, expected_y, atol=1e-15, rtol=1e-15)
 
 
-def test_rotating_hwp_orthogonal(stokes: ValidStokesType) -> None:
+def test_rotating_hwp_orthogonal(stokes: ValidStokesLiteral) -> None:
     hwp = HWPOperator.create(shape=(), stokes=stokes, angles=1.1)
     x = Stokes.class_for(stokes).ones(())
     y = (hwp.T @ hwp)(x)

--- a/tests/obs/operators/test_polarizers.py
+++ b/tests/obs/operators/test_polarizers.py
@@ -5,11 +5,11 @@ from numpy.testing import assert_allclose, assert_array_equal
 
 from furax.core import CompositionOperator
 from furax.obs import HWPOperator, LinearPolarizerOperator, QURotationOperator
-from furax.obs.stokes import Stokes, StokesI, StokesIQU, ValidStokesType
+from furax.obs.stokes import Stokes, StokesI, StokesIQU, ValidStokesLiteral
 from furax.tree import as_structure
 
 
-def test_as_matrix(stokes: ValidStokesType) -> None:
+def test_as_matrix(stokes: ValidStokesLiteral) -> None:
     polarizer = LinearPolarizerOperator.create(shape=(), stokes=stokes)
     stokes_slice = {'I': slice(0, 1), 'QU': slice(1, 3), 'IQU': slice(0, 3), 'IQUV': slice(0, 4)}[
         stokes
@@ -18,7 +18,7 @@ def test_as_matrix(stokes: ValidStokesType) -> None:
     assert_array_equal(polarizer.as_matrix(), expected_matrix)
 
 
-def test_transpose_as_matrix(stokes: ValidStokesType) -> None:
+def test_transpose_as_matrix(stokes: ValidStokesLiteral) -> None:
     polarizer = LinearPolarizerOperator.create(shape=(), stokes=stokes)
     stokes_slice = {
         'I': slice(0, 1),
@@ -30,7 +30,7 @@ def test_transpose_as_matrix(stokes: ValidStokesType) -> None:
     assert_array_equal(polarizer.T.as_matrix(), expected_matrix)
 
 
-def test_hwp_rule(stokes: ValidStokesType) -> None:
+def test_hwp_rule(stokes: ValidStokesLiteral) -> None:
     polarizer = LinearPolarizerOperator.create(shape=(), stokes=stokes)
     hwp = HWPOperator.create(shape=(), stokes=stokes)
     op = polarizer @ hwp
@@ -39,7 +39,7 @@ def test_hwp_rule(stokes: ValidStokesType) -> None:
     assert_array_equal(reduced_op.as_matrix(), op.as_matrix())
 
 
-def test_hwp_rule_with_angles(stokes: ValidStokesType) -> None:
+def test_hwp_rule_with_angles(stokes: ValidStokesLiteral) -> None:
     polarizer = LinearPolarizerOperator.create(shape=(), stokes=stokes, angles=1.0)
     hwp = HWPOperator.create(shape=(), stokes=stokes, angles=2.0)
     op = (polarizer @ hwp).reduce()
@@ -77,7 +77,7 @@ def test_create_direct_iqu() -> None:
     assert_allclose(y, expected_y, atol=1e-15, rtol=1e-15)
 
 
-def test_create_transpose(stokes: ValidStokesType) -> None:
+def test_create_transpose(stokes: ValidStokesLiteral) -> None:
     angles = np.deg2rad(15)
     polarizer = LinearPolarizerOperator.create(shape=(2, 5), stokes=stokes, angles=angles)
     x = jnp.array([[1.0, 2, 3, 4, 5], [1, 1, 1, 1, 1]])

--- a/tests/obs/operators/test_qu_rotations.py
+++ b/tests/obs/operators/test_qu_rotations.py
@@ -6,7 +6,7 @@ import furax as fx
 from furax import IdentityOperator
 from furax.core import CompositionOperator
 from furax.obs import QURotationOperator
-from furax.obs.stokes import Stokes, StokesI, StokesIQU, ValidStokesType
+from furax.obs.stokes import Stokes, StokesI, StokesIQU, ValidStokesLiteral
 
 
 def test_i() -> None:
@@ -39,14 +39,14 @@ def test_iqu() -> None:
     assert equinox.tree_equal(actual_y, expected_y, atol=1e-15, rtol=1e-15)
 
 
-def test_orthogonal(stokes: ValidStokesType) -> None:
+def test_orthogonal(stokes: ValidStokesLiteral) -> None:
     hwp = QURotationOperator.create(shape=(), stokes=stokes, angles=1.1)
     x = fx.tree.ones_like(hwp.out_structure)
     y = hwp.T(hwp(x))
     assert equinox.tree_equal(y, x, atol=1e-15, rtol=1e-15)
 
 
-def test_matmul(stokes: ValidStokesType) -> None:
+def test_matmul(stokes: ValidStokesLiteral) -> None:
     structure = Stokes.class_for(stokes).structure_for(())
     hwp = QURotationOperator(1.1, in_structure=structure)
     assert isinstance(hwp @ hwp.T, IdentityOperator)
@@ -57,7 +57,7 @@ def test_matmul(stokes: ValidStokesType) -> None:
     'transpose_left, transpose_right, expected_value',
     [(False, False, 3), (False, True, -1), (True, False, 1), (True, True, -3)],
 )
-def test_rules(stokes: ValidStokesType, transpose_left, transpose_right, expected_value) -> None:
+def test_rules(stokes: ValidStokesLiteral, transpose_left, transpose_right, expected_value) -> None:
     structure = Stokes.class_for(stokes).structure_for(())
     left = QURotationOperator(1, in_structure=structure)
     if transpose_left:
@@ -80,7 +80,7 @@ def test_rules(stokes: ValidStokesType, transpose_left, transpose_right, expecte
     [(False, False), (False, True), (True, False), (True, True)],
 )
 def test_atomic_prevents_reduction(
-    stokes: ValidStokesType,
+    stokes: ValidStokesLiteral,
     atomic_left: bool,
     atomic_right: bool,
     transpose_left: bool,
@@ -98,7 +98,7 @@ def test_atomic_prevents_reduction(
     assert isinstance(reduced_op, CompositionOperator) and len(reduced_op.operands) == 2
 
 
-def test_atomic_identity_still_reduces(stokes: ValidStokesType) -> None:
+def test_atomic_identity_still_reduces(stokes: ValidStokesLiteral) -> None:
     structure = Stokes.class_for(stokes).structure_for(())
     op = QURotationOperator(1.1, atomic=True, in_structure=structure)
 

--- a/tests/obs/test_landscapes.py
+++ b/tests/obs/test_landscapes.py
@@ -16,10 +16,10 @@ from furax.obs.landscapes import (
     WCSLandscape,
     WCSProjection,
 )
-from furax.obs.stokes import Stokes, ValidStokesType
+from furax.obs.stokes import Stokes, ValidStokesLiteral
 
 
-def test_healpix_landscape(stokes: ValidStokesType) -> None:
+def test_healpix_landscape(stokes: ValidStokesLiteral) -> None:
     nside = 64
     npixel = 12 * nside**2
 
@@ -35,7 +35,7 @@ def test_healpix_landscape(stokes: ValidStokesType) -> None:
         assert_array_equal(leaf, 1.0)
 
 
-def test_frequency_landscape(stokes: ValidStokesType) -> None:
+def test_frequency_landscape(stokes: ValidStokesLiteral) -> None:
     nside = 64
     npixel = 12 * nside**2
     frequencies = jnp.array([10, 20, 30])

--- a/tests/obs/test_likelihood.py
+++ b/tests/obs/test_likelihood.py
@@ -17,7 +17,7 @@ from furax.obs.operators import (
     NoiseDiagonalOperator,
     SynchrotronOperator,
 )
-from furax.obs.stokes import ValidStokesType
+from furax.obs.stokes import ValidStokesLiteral
 
 
 def check_tree(x, y) -> bool:
@@ -25,7 +25,7 @@ def check_tree(x, y) -> bool:
 
 
 @pytest.fixture
-def likelihood_setup(stokes: ValidStokesType):
+def likelihood_setup(stokes: ValidStokesLiteral):
     # Setup parameters
     nside = 4
     nu = jnp.arange(10.0, 50.0, 10.0)

--- a/tests/obs/test_pointing.py
+++ b/tests/obs/test_pointing.py
@@ -7,7 +7,7 @@ from numpy.testing import assert_array_almost_equal
 import furax.tree as ftree
 from furax.obs.landscapes import CARLandscape, HealpixLandscape, StokesLandscape, WCSProjection
 from furax.obs.pointing import PointingOperator
-from furax.obs.stokes import ValidStokesType
+from furax.obs.stokes import ValidStokesLiteral
 
 NSIDE = 4
 NDET, NSAMP = 3, 10
@@ -16,7 +16,7 @@ NDET, NSAMP = 3, 10
 _CAR_PROJECTION = WCSProjection(crpix=(180.5, 90.5), crval=(180.0, 0.0), cdelt=(-1.0, 1.0))
 
 
-def _make_landscape(landscape_type: str, stokes: ValidStokesType) -> StokesLandscape:
+def _make_landscape(landscape_type: str, stokes: ValidStokesLiteral) -> StokesLandscape:
     if landscape_type == 'healpix':
         return HealpixLandscape(NSIDE, stokes)
     return CARLandscape((180, 360), _CAR_PROJECTION, stokes)

--- a/tests/obs/test_stokes.py
+++ b/tests/obs/test_stokes.py
@@ -12,7 +12,7 @@ from jax import Array
 from jaxtyping import Float
 from numpy.testing import assert_array_equal
 
-from furax.obs.stokes import Stokes, ValidStokesType
+from furax.obs.stokes import Stokes, ValidStokesLiteral
 
 
 @pytest.mark.parametrize(
@@ -28,7 +28,7 @@ def test_class_for(any_stokes: str) -> None:
         assert cls.stokes == any_stokes
 
 
-def test_from_stokes_args(stokes: ValidStokesType) -> None:
+def test_from_stokes_args(stokes: ValidStokesLiteral) -> None:
     arrays = [jnp.ones(1) for _ in stokes]
     pytree = Stokes.from_stokes(*arrays)
     assert type(pytree) is Stokes.class_for(stokes)
@@ -48,7 +48,7 @@ def test_from_stokes_kwargs(any_stokes: str) -> None:
         assert type(pytree) is Stokes.class_for(any_stokes)
 
 
-def test_from_iquv(stokes: ValidStokesType) -> None:
+def test_from_iquv(stokes: ValidStokesLiteral) -> None:
     arrays = {stoke: jnp.array(istoke) for istoke, stoke in enumerate('IQUV', 1)}
     cls = Stokes.class_for(stokes)
     pytree = cls.from_iquv(*arrays.values())
@@ -57,7 +57,7 @@ def test_from_iquv(stokes: ValidStokesType) -> None:
         assert getattr(pytree, stoke.lower()) == arrays[stoke]
 
 
-def test_ravel(stokes: ValidStokesType) -> None:
+def test_ravel(stokes: ValidStokesLiteral) -> None:
     shape = (4, 2)
     arrays = {k: jnp.ones(shape) for k in stokes}
     pytree = Stokes.from_stokes(**arrays)
@@ -66,7 +66,7 @@ def test_ravel(stokes: ValidStokesType) -> None:
         assert getattr(raveled_pytree, stoke.lower()).shape == (8,)
 
 
-def test_reshape(stokes: ValidStokesType) -> None:
+def test_reshape(stokes: ValidStokesLiteral) -> None:
     shape = (4, 2)
     new_shape = (2, 2, 2)
     arrays = {k: jnp.ones(shape) for k in stokes}
@@ -86,7 +86,7 @@ def test_reshape(stokes: ValidStokesType) -> None:
         (lambda c, s, d: c.full(s, 2, d), 2),
     ],
 )
-def test_zeros(stokes: ValidStokesType, shape: tuple[int, ...], dtype, factory, value) -> None:
+def test_zeros(stokes: ValidStokesLiteral, shape: tuple[int, ...], dtype, factory, value) -> None:
     cls = Stokes.class_for(stokes)
     pytree = factory(cls, shape, dtype)
     for stoke in stokes:
@@ -98,7 +98,7 @@ def test_zeros(stokes: ValidStokesType, shape: tuple[int, ...], dtype, factory, 
 
 @pytest.mark.parametrize('shape', [(10,), (2, 10)])
 @pytest.mark.parametrize('dtype', [np.float32, np.float64])
-def test_structure(stokes: ValidStokesType, shape: tuple[int, ...], dtype) -> None:
+def test_structure(stokes: ValidStokesLiteral, shape: tuple[int, ...], dtype) -> None:
     array = jnp.zeros(shape, dtype)
     pytree = Stokes.from_stokes(*[array for _ in stokes])
     expected_pytree_structure = Stokes.class_for(stokes).structure_for(shape, dtype)
@@ -111,7 +111,7 @@ def test_structure(stokes: ValidStokesType, shape: tuple[int, ...], dtype) -> No
 
 @pytest.mark.parametrize('shape', [(10,), (2, 10)])
 @pytest.mark.parametrize('dtype', [np.float32, np.float64])
-def test_structure_for(stokes: ValidStokesType, shape: tuple[int, ...], dtype) -> None:
+def test_structure_for(stokes: ValidStokesLiteral, shape: tuple[int, ...], dtype) -> None:
     structure = Stokes.class_for(stokes).structure_for(shape, dtype)
     array = jnp.zeros(shape, dtype)
     pytree = Stokes.from_stokes(*[array for _ in stokes])
@@ -120,7 +120,7 @@ def test_structure_for(stokes: ValidStokesType, shape: tuple[int, ...], dtype) -
     assert structure == expected_structure
 
 
-def test_matmul(stokes: ValidStokesType) -> None:
+def test_matmul(stokes: ValidStokesLiteral) -> None:
     cls = Stokes.class_for(stokes)
     x = cls.ones((2, 3))
     y = cls.full((2, 3), 2)
@@ -174,7 +174,7 @@ def test_matmul(stokes: ValidStokesType) -> None:
     ],
 )
 def test_operation_scalar_or_array(
-    stokes: ValidStokesType,
+    stokes: ValidStokesLiteral,
     operation: Callable[[Any, Any], Any],
     reverse: bool,
     value: float | Float[Array, ''],
@@ -212,7 +212,7 @@ def test_operation_scalar_or_array(
     ],
 )
 def test_operation_pytree(
-    stokes: ValidStokesType,
+    stokes: ValidStokesLiteral,
     operation: Callable[[Any, Any], Any],
     expected_value: float,
     do_jit: bool,
@@ -244,7 +244,7 @@ def test_operation_incompatible_pytree(operation: Callable[[Any, Any], Any]) -> 
         operation(a, b)
 
 
-def test_from_array_preserves_numpy(stokes: ValidStokesType) -> None:
+def test_from_array_preserves_numpy(stokes: ValidStokesLiteral) -> None:
     cls = Stokes.class_for(stokes)
     array = np.ones((len(stokes), 3), dtype=np.float32)
     pytree = cls.from_array(array)


### PR DESCRIPTION
Renames `ValidStokesType` to `ValidStokesLiteral` because the previous name was confusing.

Also includes some typing improvements, mostly for functions that return the same Stokes type they eat.