### PR TITLE
Split long documentation pages and improve `MapMakingConfig` docs

### DIFF
--- a/docs/api/core.md
+++ b/docs/api/core.md
@@ -1,5 +1,0 @@
-# `furax.core`
-
-::: furax.core
-    options:
-      show_submodules: true

--- a/docs/api/core/algebra.md
+++ b/docs/api/core/algebra.md
@@ -1,0 +1,25 @@
+# Algebra
+
+Base operator class, algebraic tags, and composition/addition/inverse machinery.
+
+::: furax.core.AbstractLinearOperator
+::: furax.core.AbstractLazyInverseOperator
+::: furax.core.AbstractLazyInverseOrthogonalOperator
+::: furax.core.TransposeOperator
+::: furax.core.InverseOperator
+::: furax.core.AdditionOperator
+::: furax.core.CompositionOperator
+::: furax.core.IdentityOperator
+::: furax.core.HomothetyOperator
+::: furax.core.OperatorTag
+::: furax.core.asoperator
+::: furax.core.square
+::: furax.core.symmetric
+::: furax.core.orthogonal
+::: furax.core.diagonal
+::: furax.core.tridiagonal
+::: furax.core.lower_triangular
+::: furax.core.upper_triangular
+::: furax.core.positive_semidefinite
+::: furax.core.negative_semidefinite
+::: furax.core.idempotent

--- a/docs/api/core/composite.md
+++ b/docs/api/core/composite.md
@@ -1,0 +1,11 @@
+# Composite operators
+
+Block and diagonal operators built by combining sub-operators.
+
+::: furax.core.BlockRowOperator
+::: furax.core.BlockDiagonalOperator
+::: furax.core.BlockColumnOperator
+::: furax.core.DenseBlockDiagonalOperator
+::: furax.core.DiagonalOperator
+::: furax.core.BroadcastDiagonalOperator
+::: furax.core.SumOperator

--- a/docs/api/core/special.md
+++ b/docs/api/core/special.md
@@ -1,0 +1,7 @@
+# Special operators
+
+Fourier and Toeplitz operators.
+
+::: furax.core.FourierOperator
+::: furax.core.SymmetricBandToeplitzOperator
+::: furax.core.dense_symmetric_band_toeplitz

--- a/docs/api/core/structural.md
+++ b/docs/api/core/structural.md
@@ -1,0 +1,10 @@
+# Structural operators
+
+Shape, indexing, masking and pytree manipulation operators.
+
+::: furax.core.MoveAxisOperator
+::: furax.core.RavelOperator
+::: furax.core.ReshapeOperator
+::: furax.core.IndexOperator
+::: furax.core.MaskOperator
+::: furax.core.TreeOperator

--- a/docs/api/distributed.md
+++ b/docs/api/distributed.md
@@ -1,3 +1,5 @@
 # `furax.distributed`
 
 ::: furax.distributed
+    options:
+      show_root_heading: false

--- a/docs/api/exceptions.md
+++ b/docs/api/exceptions.md
@@ -1,3 +1,5 @@
 # `furax.exceptions`
 
 ::: furax.exceptions
+    options:
+      show_root_heading: false

--- a/docs/api/furax.md
+++ b/docs/api/furax.md
@@ -5,3 +5,5 @@ Top-level public API re-exported from the `furax` namespace.
 ::: furax
     options:
       members_order: __all__
+      members: false
+      show_root_heading: false

--- a/docs/api/interfaces.md
+++ b/docs/api/interfaces.md
@@ -3,3 +3,5 @@
 ::: furax.interfaces
     options:
       show_submodules: true
+      show_root_heading: false
+      show_root_members_full_path: true

--- a/docs/api/io.md
+++ b/docs/api/io.md
@@ -3,3 +3,5 @@
 ::: furax.io
     options:
       show_submodules: true
+      show_root_heading: false
+      show_root_members_full_path: true

--- a/docs/api/linalg.md
+++ b/docs/api/linalg.md
@@ -3,3 +3,5 @@
 ::: furax.linalg
     options:
       show_submodules: true
+      show_root_heading: false
+      show_root_members_full_path: true

--- a/docs/api/mapmaking.md
+++ b/docs/api/mapmaking.md
@@ -1,5 +1,0 @@
-# `furax.mapmaking`
-
-::: furax.mapmaking
-    options:
-      show_submodules: true

--- a/docs/api/mapmaking/config.md
+++ b/docs/api/mapmaking/config.md
@@ -1,3 +1,6 @@
 # Configuration
 
-::: furax.mapmaking.MapMakingConfig
+::: furax.mapmaking.config
+    options:
+      show_root_heading: false
+      members_order: __all__

--- a/docs/api/mapmaking/config.md
+++ b/docs/api/mapmaking/config.md
@@ -1,0 +1,3 @@
+# Configuration
+
+::: furax.mapmaking.MapMakingConfig

--- a/docs/api/mapmaking/mapmaker.md
+++ b/docs/api/mapmaking/mapmaker.md
@@ -1,0 +1,7 @@
+# Mapmaker
+
+Multi-observation mapmaker and its results, plus gap-filling.
+
+::: furax.mapmaking.MultiObservationMapMaker
+::: furax.mapmaking.MapMakingResults
+::: furax.mapmaking.gap_fill

--- a/docs/api/mapmaking/observation.md
+++ b/docs/api/mapmaking/observation.md
@@ -1,0 +1,14 @@
+# Observations
+
+Observation data model and reader.
+
+::: furax.mapmaking.AbstractObservation
+::: furax.mapmaking.AbstractLazyObservation
+::: furax.mapmaking.AbstractGroundObservation
+::: furax.mapmaking.AbstractSatelliteObservation
+::: furax.mapmaking.FileBackedLazyObservation
+::: furax.mapmaking.HashedObservationMetadata
+::: furax.mapmaking.ObservationBufferShapes
+::: furax.mapmaking.ReaderField
+::: furax.mapmaking.ObservationReader
+::: furax.mapmaking.logger

--- a/docs/api/mapmaking/preconditioner.md
+++ b/docs/api/mapmaking/preconditioner.md
@@ -1,0 +1,3 @@
+# Preconditioner
+
+::: furax.mapmaking.BJPreconditioner

--- a/docs/api/math.md
+++ b/docs/api/math.md
@@ -3,3 +3,5 @@
 ::: furax.math
     options:
       show_submodules: true
+      show_root_heading: false
+      show_root_members_full_path: true

--- a/docs/api/obs.md
+++ b/docs/api/obs.md
@@ -1,5 +1,0 @@
-# `furax.obs`
-
-::: furax.obs
-    options:
-      show_submodules: true

--- a/docs/api/obs/atmosphere.md
+++ b/docs/api/obs/atmosphere.md
@@ -1,0 +1,5 @@
+# Atmosphere
+
+::: furax.obs.atmosphere.AtmospherePointingOperator
+::: furax.obs.atmosphere.profile_neg_log_likelihood
+::: furax.obs.atmosphere.simulate_kolmogorov_screen

--- a/docs/api/obs/beam.md
+++ b/docs/api/obs/beam.md
@@ -1,0 +1,4 @@
+# Beam
+
+::: furax.obs.operators.BeamOperator
+::: furax.obs.operators.BeamOperatorIQU

--- a/docs/api/obs/landscapes.md
+++ b/docs/api/obs/landscapes.md
@@ -1,0 +1,15 @@
+# Landscapes
+
+Stokes-aware sky pixelisation: HEALPix, WCS, and horizon/tangential projections.
+
+::: furax.obs.landscapes.Landscape
+::: furax.obs.landscapes.StokesLandscape
+::: furax.obs.landscapes.ProjectionType
+::: furax.obs.landscapes.WCSProjection
+::: furax.obs.landscapes.WCSLandscape
+::: furax.obs.landscapes.CARLandscape
+::: furax.obs.landscapes.HealpixLandscape
+::: furax.obs.landscapes.FrequencyLandscape
+::: furax.obs.landscapes.AstropyWCSLandscape
+::: furax.obs.landscapes.HorizonLandscape
+::: furax.obs.landscapes.TangentialLandscape

--- a/docs/api/obs/likelihoods.md
+++ b/docs/api/obs/likelihoods.md
@@ -1,0 +1,9 @@
+# Likelihoods
+
+Spectral likelihood and sky-signal helpers for component separation.
+
+::: furax.obs.spectral_log_likelihood
+::: furax.obs.negative_log_likelihood
+::: furax.obs.spectral_cmb_variance
+::: furax.obs.sky_signal
+::: furax.obs.preconditionner

--- a/docs/api/obs/pointing.md
+++ b/docs/api/obs/pointing.md
@@ -1,0 +1,6 @@
+# Pointing
+
+Boresight + detector quaternions to sky pixels, on-the-fly.
+
+::: furax.obs.pointing.PointingOperator
+::: furax.obs.pointing.PointingTransposeOperator

--- a/docs/api/obs/polarization.md
+++ b/docs/api/obs/polarization.md
@@ -1,0 +1,15 @@
+# Polarization modulation
+
+HWP (including the physical transfer-matrix model), polarizer, and QU-rotation operators.
+
+::: furax.obs.operators.HWPOperator
+::: furax.obs.operators.NonIdealHWPOperator
+::: furax.obs.operators.hwp_mueller_from_stack
+::: furax.obs.operators.LinearPolarizerOperator
+::: furax.obs.operators.QURotationOperator
+::: furax.obs.operators.Material
+::: furax.obs.operators.Layer
+::: furax.obs.operators.Stack
+::: furax.obs.operators.mueller_matrix
+::: furax.obs.operators.SO_MF_HWP_STACK
+::: furax.obs.operators.SO_HF_HWP_STACK

--- a/docs/api/obs/seds.md
+++ b/docs/api/obs/seds.md
@@ -1,0 +1,10 @@
+# SED operators
+
+Spectral energy distribution operators for component separation.
+
+::: furax.obs.operators.AbstractSEDOperator
+::: furax.obs.operators.CMBOperator
+::: furax.obs.operators.DustOperator
+::: furax.obs.operators.SynchrotronOperator
+::: furax.obs.operators.MixingMatrixOperator
+::: furax.obs.operators.NoiseDiagonalOperator

--- a/docs/api/obs/stokes.md
+++ b/docs/api/obs/stokes.md
@@ -1,0 +1,10 @@
+# Stokes containers
+
+Single-array Stokes containers (components stacked on the leading axis).
+
+::: furax.obs.stokes.Stokes
+::: furax.obs.stokes.StokesI
+::: furax.obs.stokes.StokesQU
+::: furax.obs.stokes.StokesIQU
+::: furax.obs.stokes.StokesIQUV
+::: furax.obs.stokes.ValidStokesLiteral

--- a/docs/api/tree.md
+++ b/docs/api/tree.md
@@ -1,3 +1,5 @@
 # `furax.tree`
 
 ::: furax.tree
+    options:
+      show_root_heading: false

--- a/docs/development/changelog.md
+++ b/docs/development/changelog.md
@@ -9,9 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Renamed scan-block operators to `Stream*` and made the module public (`streaming.py`) (#173)
+- Rename scan-block operators to `Stream*` and make the module public (`streaming.py`) (#173)
 - Avoid unnecessary array copies in observation readers (#175)
 - Migrate multi-observation mapmaker to furax CG and support verbose mode (#176)
+- Split long API documentation pages (#179)
+- Improve `MapMakingConfig` documentation and add examples (#179)
 
 ## [0.11.3] - 2026-07-14
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -79,7 +79,7 @@ weighted_data = weight_op(stokes_data)
 - **Examples**: [Component separation](examples/component_separation.md),
   [Mapmaking](examples/mapmaking.md)
 - **API Reference**: [`furax`](api/furax.md) top-level namespace, plus per-subpackage pages
-  ([`core`](api/core.md), [`obs`](api/obs.md), [`mapmaking`](api/mapmaking.md),
+  ([`core`](api/core/algebra.md), [`obs`](api/obs/pointing.md), [`mapmaking`](api/mapmaking/observation.md),
   [`math`](api/math.md), [`linalg`](api/linalg.md), [`io`](api/io.md),
   [`interfaces`](api/interfaces.md), [`tree`](api/tree.md))
 - **Development**: [Contributing](development/contributing.md),

--- a/src/furax/mapmaking/config.py
+++ b/src/furax/mapmaking/config.py
@@ -1,3 +1,5 @@
+"""Hierarchical configuration system for mapmaking runs."""
+
 from dataclasses import asdict, dataclass, field, fields
 from enum import Enum
 from pathlib import Path
@@ -17,44 +19,110 @@ from furax.obs.stokes import ValidStokesLiteral
 serializer(Conversion(lambda p: p.name, source=ProjectionType, target=str))
 deserializer(Conversion(lambda s: ProjectionType[s], source=str, target=ProjectionType))
 
+# Docs order: main config first, then its sub-configs grouped by topic.
+__all__ = [
+    'MapMakingConfig',
+    'Methods',
+    'PointingConfig',
+    'WeightingConfig',
+    'WeightingMode',
+    'NoiseSource',
+    'NoiseFitConfig',
+    'SolverConfig',
+    'GapsConfig',
+    'GapTreatment',
+    'GapFillingConfig',
+    'NestedConfig',
+    'LandscapeConfig',
+    'HealpixConfig',
+    'WCSConfig',
+    'SkyPatch',
+    'TemplatesConfig',
+    'PolynomialOrders',
+    'PolynomialConfig',
+    'ScanSynchronousConfig',
+    'BinsConfig',
+    'BinAzSynchronousConfig',
+    'HWPSynchronousConfig',
+    'AzHWPSynchronousConfig',
+    'BinAzHWPSynchronousConfig',
+    'SplineHWPSSConfig',
+    'GroundConfig',
+    'SotodlibConfig',
+]
+
 
 class Methods(Enum):
+    """Mapmaking algorithm selector (see [`MapMakingConfig.method`][])."""
+
     BINNED = 'Binned'
+    """Invert the diagonal mapmaking system directly and skip the iterative solve.
+
+    Only available when diagonal weights are used (see [`MapMakingConfig.weighting`][]).
+    """
+
     MAXL = 'ML'
+    """Classic maximum-likelihood mapmaking solve via conjugate gradient iteration."""
+
     TWOSTEP = 'TwoStep'
+    """Two-step mapmaking (destriper-like)."""
+
     ATOP = 'ATOP'
+    """Polarisation (QU only) estimator using deprojection of short baselines.
+
+    See [`MapMakingConfig.atop_tau`][].
+    """
 
 
 class WeightingMode(Enum):
-    IDENTITY = 'identity'  # identity inverse-noise, no weighting
-    DIAGONAL = 'diagonal'  # white (diagonal) weighting
-    TOEPLITZ = 'toeplitz'  # atmospheric 1/f, banded Toeplitz weighting
+    """Structure of the weighting matrix (see [`WeightingConfig.mode`][])."""
+
+    IDENTITY = 'identity'
+    """No weighting (identity matrix)."""
+
+    DIAGONAL = 'diagonal'
+    """Diagonal weighting (white noise model)."""
+
+    TOEPLITZ = 'toeplitz'
+    """Banded Toeplitz weighting ($1/f$ noise model)."""
 
 
 class NoiseSource(Enum):
-    FIT = 'fit'  # fit the noise model from the TOD PSD
-    PRECOMPUTED = 'precomputed'  # read precomputed noise parameters from the data pipeline
+    """Where the noise model used for weighting comes from (see [`WeightingConfig.source`][])."""
+
+    FIT = 'fit'
+    """Fit the noise model from the TOD PSD."""
+
+    PRECOMPUTED = 'precomputed'
+    """Read precomputed noise parameters from the data pipeline."""
 
 
 class GapTreatment(Enum):
     """How flagged samples enter the correlated-noise GLS weighting.
 
-    For white/diagonal weights all three coincide (`M W M = M W` for mask `M`);
-    the distinction only matters in the correlated (Toeplitz/atmospheric) regime.
+    For diagonal weights all three coincide ($M W M = M W$ for mask $M$ and diagonal $W$);
+    the distinction only matters in the correlated regime.
     """
 
-    INNER_MASK = 'inner_mask'  # W = M N⁻¹ M (unbiased but suboptimal; cheap)
-    FILL = 'fill'  # gap-fill the RHS with a constrained noise realization (single-realization use)
-    NESTED = 'nested'  # W = M (M N M)⁻¹ M = W_exact (unbiased and minimum-variance)
+    INNER_MASK = 'inner_mask'
+    """$W = M N^{-1} M$ (unbiased but suboptimal; cheap)."""
+
+    FILL = 'fill'
+    """Gap-fill the RHS with a constrained noise realization (single-realization use)."""
+
+    NESTED = 'nested'
+    """$W = M (M N M)^{-1} M$ (unbiased and minimum-variance)."""
 
 
 @dataclass
 class SolverConfig:
+    """Options for the iterative (conjugate gradient) solver."""
+
     rtol: float = 1e-6
-    """Relative tolerance of iterative solver."""
+    """Relative tolerance."""
 
     atol: float = 0
-    """Absolute tolerance of iterative solver."""
+    """Absolute tolerance."""
 
     max_steps: int = 1_000
     """Maximum allowed number of iterations steps."""
@@ -70,69 +138,57 @@ class SolverConfig:
 
 @dataclass
 class NoiseFitConfig:
+    r"""Options for fitting a parametric $1/f$ noise model to each detector's TOD PSD."""
+
     nperseg: int = 2_048
-    """Welch window length in samples for PSD estimation."""
+    """Welch window length in samples."""
 
     max_iter: int = 100
-    """Maximum number of iterations"""
+    """Maximum number of minimiser iterations."""
 
     tol: float = 1e-10
-    """Relative minimiser tolerance (step size and function value change)"""
+    """Relative minimiser tolerance (step size and function value change)."""
 
     min_freq_nyquist: float = 1e-8
-    """Only use f >= min_freq * nyquist for noise fitting"""
+    r"""Only use $f \geq$ `min_freq_nyquist` $\times f_\mathrm{Nyquist}$ for noise fitting."""
 
     max_freq_nyquist: float = 1
-    """Only use f < max_freq * nyquist for noise fitting"""
+    r"""Only use $f <$ `max_freq_nyquist` $\times f_\mathrm{Nyquist}$ for noise fitting."""
 
     low_freq_nyquist: float = 0.02
-    """The PSD at f < low_freq * nyquist is assumed to be dominated by 1/f noise"""
+    r"""PSD at $f <$ `low_freq_nyquist` $\times f_\mathrm{Nyquist}$ assumed dominated by $1/f$."""
 
     high_freq_nyquist: float = 0.02
-    """The PSD at f > high_freq * nyquist is assumed to be dominated by white noise"""
+    r"""PSD at $f >$ `high_freq_nyquist` $\times f_\mathrm{Nyquist}$ assumed white."""
 
     mask_hwp_harmonics: bool = True
-    """Mask HWP harmonics: 1f, 2f, 4f"""
+    """Mask HWP harmonics: $1f$, $2f$, $4f$."""
 
     mask_ptc_harmonics: bool = False
-    """Mask PTC harmonics: 1f, 2f"""
+    """Mask PTC harmonics: $1f$, $2f$."""
 
     freq_mask_width: float = 0.5
-    """Full width [Hz] of the frequency mask (if used) around HWP and PTC harmonics"""
+    """Full width of the frequency mask (if used) around HWP and PTC harmonics, in Hz."""
 
     ptc_freq: float = 1.4
-    """PTC frequency [Hz] used for masking (if used)"""
+    """PTC frequency used for masking (if used), in Hz."""
 
 
 @dataclass
 class WeightingConfig:
-    """Configuration for the inverse-noise / weighting matrix used in mapmaking.
-
-    ``mode`` selects the structure of the inverse-noise matrix:
-
-    - ``IDENTITY``: identity matrix (no weighting).
-    - ``DIAGONAL``: diagonal white-noise weighting (default).
-    - ``TOEPLITZ``: banded Toeplitz weighting for atmospheric (1/f) noise.
-
-    ``source`` selects where the noise model comes from: ``FIT`` (default) fits it from the
-    TOD power spectral density using ``fitting``; ``PRECOMPUTED`` reads noise parameters from
-    the data pipeline (``fitting`` is then ignored).
-
-    ``correlation_length`` sets the Toeplitz bandwidth (in samples) of the inverse-noise
-    operator.  It is only used in ``TOEPLITZ`` mode and is ignored otherwise.
-    """
+    """Configuration for the inverse-noise / weighting matrix used in mapmaking."""
 
     mode: WeightingMode = WeightingMode.DIAGONAL
-    """Inverse-noise weighting matrix structure."""
+    """Matrix structure."""
 
     source: NoiseSource = NoiseSource.FIT
-    """Where the noise model comes from: fit from the TOD PSD or read precomputed parameters."""
+    """Where the noise model comes from."""
 
     correlation_length: int = 1_000
-    """Toeplitz bandwidth in samples.  Only relevant in ``TOEPLITZ`` mode."""
+    """Toeplitz bandwidth in samples.  Only relevant in `TOEPLITZ` mode."""
 
     fitting: NoiseFitConfig = field(default_factory=NoiseFitConfig)
-    """Options for fitting the noise PSD to the data.  Ignored when ``source`` is PRECOMPUTED."""
+    """Options for fitting the noise PSD to the data."""
 
     @property
     def diagonal_matrix(self) -> bool:
@@ -145,14 +201,17 @@ class HealpixConfig:
     """Configuration for a HEALPix output map.
 
     Examples:
-        In a YAML config file:
+        YAML config section
 
-        healpix:
-          nside: 512
+            healpix:
+                nside: 512
     """
 
     nside: int = 512
+    """HEALPix resolution parameter."""
+
     ordering: Literal['nest', 'ring'] = 'ring'
+    """Pixel ordering scheme. Only ``'ring'`` is currently supported."""
 
     def __post_init__(self) -> None:
         if self.ordering == 'nest':
@@ -164,12 +223,12 @@ class SkyPatch:
     """Explicit rectangular sky patch for WCS map construction.
 
     Examples:
-        In a YAML config file:
+        YAML config section
 
-        patch:
-          center: [30.0, -10.0]  # ra, dec in degrees
-          width: 20.0
-          height: 10.0
+            patch:
+                center: [30.0, -10.0]  # ra, dec in degrees
+                width: 20.0
+                height: 10.0
     """
 
     center: tuple[float, float]
@@ -186,34 +245,34 @@ class SkyPatch:
 class WCSConfig:
     """Configuration for a WCS-projected output map.
 
-    ``projection`` applies to all modes except ``geometry_file``, where it is read from the file.
-
     The map extent is determined by exactly one of three mutually exclusive modes:
 
-    1. **geometry_file**: read shape and WCS directly from a FITS/HDF file via
-       ``pixell.enmap.read_map_geometry``. All other fields are ignored.
-    2. **patch**: build a rectangular patch of sky at the given ``resolution``.
-    3. **auto** (no geometry specified): scan the observations to compute each observation's
-       bounding box, take their union, and pixelise at the given ``resolution``.
+    - read from `geometry_file` (shape and WCS come from the file, all other fields ignored);
+    - an explicit `patch` pixelised at `resolution`; or
+    - automatic footprint detection from the observations (when neither is set), also pixelised
+        at `resolution`.
+
+    `projection` applies to the `patch`/auto modes only.
 
     Examples:
-        In a YAML config file:
+        Auto footprint at 4 arcmin resolution
 
-        # Auto footprint at 4 arcmin resolution
-        car:
-          resolution: 4.0
+            car:
+                resolution: 4.0
 
-        # Explicit patch
-        car:
-          resolution: 4.0
-          patch:
-            center: [30.0, -10.0]
-            width: 20.0
-            height: 10.0
+        Explicit patch
 
-        # Geometry from file
-        car:
-          geometry_file: /path/to/map.fits
+            car:
+                resolution: 4.0
+                patch:
+                    center: [30.0, -10.0]
+                    width: 20.0
+                    height: 10.0
+
+        Geometry from file
+
+            car:
+                geometry_file: /path/to/map.fits
     """
 
     projection: ProjectionType = ProjectionType.CAR
@@ -223,10 +282,10 @@ class WCSConfig:
     """Pixel resolution in arcminutes."""
 
     geometry_file: str | None = None
-    """Path to a FITS or HDF map file from which to read the output geometry."""
+    """Path to a FITS/HDF map file to read shape and WCS from via `pixell.enmap.read_map_geometry`."""
 
     patch: SkyPatch | None = None
-    """Explicit sky patch definition. Mutually exclusive with ``geometry_file``."""
+    """Explicit sky patch definition."""
 
     def __post_init__(self) -> None:
         if self.geometry_file is not None and self.patch is not None:
@@ -234,14 +293,22 @@ class WCSConfig:
 
     @property
     def has_geometry(self) -> bool:
+        """True if geometry is fixed by the configuration"""
         return self.geometry_file is not None or self.patch is not None
 
 
 @dataclass
 class LandscapeConfig:
+    """Configuration of the output sky map: its Stokes components and pixelisation."""
+
     stokes: ValidStokesLiteral = 'IQU'
+    """Which Stokes components (`'I'`, `'QU'`, `'IQU'`, or `'IQUV'`) the output map holds."""
+
     healpix: HealpixConfig | None = None
+    """HEALPix pixelisation. Mutually exclusive with ``wcs``."""
+
     wcs: WCSConfig | None = None
+    """WCS (CAR) pixelisation. Mutually exclusive with ``healpix``."""
 
     def __post_init__(self) -> None:
         if (self.healpix is None) == (self.wcs is None):
@@ -252,7 +319,10 @@ class PolynomialOrders(NamedTuple):
     """A polynomial order range, inclusive."""
 
     min_order: int = 0
+    """Lowest polynomial order in the range."""
+
     max_order: int = 3
+    """Highest polynomial order in the range."""
 
     @property
     def n_orders(self) -> int:
@@ -262,20 +332,25 @@ class PolynomialOrders(NamedTuple):
 
 @dataclass
 class BinsConfig:
-    """A piecewise basis that bins a variable into ``n_bins`` intervals.
-
-    With ``interpolate = False`` each sample is hard-assigned to its bin. With
-    ``interpolate = True`` samples are spread over neighbouring bin centres using
-    triangular (or, if ``smooth``, sin^2) weights.
-    """
+    """Configuration for binning a variable into `n_bins` intervals."""
 
     n_bins: int = 4
+    """Number of bins."""
+
     interpolate: bool = False
+    """Spread each sample over neighbouring bin centres instead of hard-assigning it to its bin.
+
+    Interpolation uses triangular weights, or sin^2 if `smooth` is set.
+    """
+
     smooth: bool = False
+    """When `interpolate` is set, use sin^2 weights instead of triangular ones."""
 
 
 @dataclass
 class PolynomialConfig:
+    """Polynomial drift template (per-detector low-order Legendre polynomial in time)."""
+
     legendre: PolynomialOrders = PolynomialOrders(0, 3)
     """Legendre orders for the polynomial drift template."""
 
@@ -288,44 +363,66 @@ class ScanSynchronousConfig:
     """
 
     legendre: PolynomialOrders = PolynomialOrders(3, 7)
+    """Legendre orders for the azimuth-dependent basis."""
 
 
 @dataclass
 class BinAzSynchronousConfig:
     """Binned azimuth-synchronous signal, no HWP coupling.
 
-    The binned counterpart of `ScanSynchronousConfig`.
+    The binned counterpart of [`ScanSynchronousConfig`][].
     """
 
     bins: BinsConfig = field(default_factory=BinsConfig)
+    """Azimuth binning."""
 
 
 @dataclass
 class HWPSynchronousConfig:
+    """HWP-synchronous signal on a global Fourier (harmonic) basis in HWP angle."""
+
     n_harmonics: int = 3
+    """Number of HWP harmonics to fit."""
 
 
 @dataclass
 class AzHWPSynchronousConfig:
+    """Joint azimuth/HWP-synchronous signal: Legendre in azimuth times Fourier in HWP angle."""
+
     legendre: PolynomialOrders = PolynomialOrders(0, 3)
+    """Legendre orders for the azimuth-dependent basis."""
+
     n_harmonics: int = 4
+    """Number of HWP harmonics to fit."""
+
     split_scans: bool = False
+    """Fit independent coefficients per subscan instead of shared ones."""
 
 
 @dataclass
 class BinAzHWPSynchronousConfig:
+    """Joint azimuth/HWP-synchronous signal: azimuth binning times Fourier in HWP angle.
+
+    The binned-azimuth counterpart of [`AzHWPSynchronousConfig`][].
+    """
+
     bins: BinsConfig = field(default_factory=BinsConfig)
+    """Azimuth binning."""
+
     n_harmonics: int = 4
+    """Number of HWP harmonics to fit."""
 
 
 @dataclass
 class SplineHWPSSConfig:
+    """HWP-synchronous signal on a cubic B-spline basis in HWP angle."""
+
     n_knots: int | None = None
-    """Number of spline knots. If set, takes precedence over samples_per_knot."""
+    """Number of spline knots. If set, takes precedence over `samples_per_knot`."""
     samples_per_knot: int | None = 4000
-    """Number of samples per knot. Defaults to 4000."""
+    """Number of samples per knot."""
     harmonics: tuple[int, ...] = (4,)
-    """HWP harmonics to fit with splines. Defaults to (4,)."""
+    """HWP harmonics to fit with splines."""
 
     def __post_init__(self) -> None:
         if self.n_knots is None and self.samples_per_knot is None:
@@ -344,21 +441,55 @@ class SplineHWPSSConfig:
 
 @dataclass
 class GroundConfig:
-    azimuth_resolution: float = 0.05  # ~3 deg
-    elevation_resolution: float = 0.05  # ~3 deg
+    """Ground pickup template: binned in (azimuth, elevation)."""
+
+    azimuth_resolution: float = 0.05
+    """Azimuth bin width in radians.
+
+    Defaults to 0.05 (~3 deg).
+    """
+
+    elevation_resolution: float = 0.05
+    """Elevation bin width in radians.
+
+    Defaults to 0.05 (~3 deg).
+    """
 
 
 @dataclass
 class TemplatesConfig:
+    """Selection and configuration of templates to deproject/fit alongside sky map reconstruction.
+
+    Each field is `None` by default, meaning that template is disabled; setting it to an instance
+    of its config class enables the corresponding template with those options.
+    """
+
     polynomial: PolynomialConfig | None = None
+    """Per-detector polynomial template."""
+
     scan_synchronous: ScanSynchronousConfig | None = None
+    """Scan-synchronous (azimuth-only) template on a global Legendre basis."""
+
     binaz_synchronous: BinAzSynchronousConfig | None = None
+    """Scan-synchronous (azimuth-only) template on a binned azimuth basis."""
+
     hwp_synchronous: HWPSynchronousConfig | None = None
+    """HWP-synchronous template on a global Fourier (harmonic) basis."""
+
     azhwp_synchronous: AzHWPSynchronousConfig | None = None
+    """Joint azimuth/HWP-synchronous template, Legendre in azimuth times Fourier in HWP angle."""
+
     binazhwp_synchronous: BinAzHWPSynchronousConfig | None = None
+    """Joint azimuth/HWP-synchronous template, binned azimuth times Fourier in HWP angle."""
+
     spline_hwpss: SplineHWPSSConfig | None = None
+    """HWP-synchronous template on a cubic B-spline basis in HWP angle."""
+
     ground: GroundConfig | None = None
+    """Ground pickup template, binned in (azimuth, elevation)."""
+
     regularization: float = 0.0
+    """Ridge regularization strength applied to the template regression."""
 
     @classmethod
     def full_defaults(cls) -> 'TemplatesConfig':
@@ -376,6 +507,7 @@ class TemplatesConfig:
 
     @property
     def empty(self) -> bool:
+        """True when every template is disabled."""
         return all(getattr(self, f.name) is None for f in fields(self))
 
 
@@ -393,12 +525,7 @@ class GapFillingConfig:
     """The relative tolerance of the solver for the gap-filling solve"""
 
     precondition: bool = False
-    """Precondition the flagged-subspace solve with the covariance from the noise model.
-
-    Off by default: it speeds up convergence only for few gaps wider than the correlation length, and
-    *slows* the common case of many short gaps (turnarounds/glitches) where the bare system is already
-    well-conditioned. Enable for observations dominated by a few wide gaps.
-    """
+    """Precondition the flagged-subspace solve with the noise-model covariance (off by default)."""
 
 
 @dataclass
@@ -406,24 +533,22 @@ class NestedConfig:
     """Inner-solver options for the nested-inverse gap weight (`GapTreatment.NESTED`)."""
 
     max_flag_fraction: float = 0.3
-    """Flagged-fraction budget; observations flagged above this fall back to INNER_MASK."""
+    """Flagged-fraction budget; observations flagged above this fall back to `INNER_MASK`."""
 
     inner_steps: int = 20
-    """Fixed number of inner CG iterations for the flagged-block solve."""
+    """Maximum number of inner CG iterations for the flagged-block solve.
+
+    Set `rtol = atol = 0` to force exactly this number of steps.
+    """
 
     rtol: float = 0.0
-    """Relative tolerance of the inner solver (0 forces exactly ``inner_steps`` iterations)."""
+    """Relative tolerance."""
 
     atol: float = 0.0
-    """Absolute tolerance of the inner solver (0 forces exactly ``inner_steps`` iterations)."""
+    """Absolute tolerance."""
 
     precondition: bool = False
-    """Precondition the inner flagged-block CG with the covariance from the noise model.
-
-    Off by default: it helps only for few gaps wider than the correlation length, and *slows* the
-    common case of many short gaps (turnarounds/glitches) where the bare inner block is already
-    well-conditioned. Enable for observations dominated by a few wide gaps.
-    """
+    """Use the noise-model covariance to precondition the solve (off by default)."""
 
 
 @dataclass
@@ -431,24 +556,18 @@ class GapsConfig:
     """Configuration options related to the treatment of gaps."""
 
     treatment: GapTreatment = GapTreatment.FILL
-    """How flagged samples enter the weighting (see [`GapTreatment`][])."""
+    """How flagged samples enter the weighting."""
 
     fill_options: GapFillingConfig = field(default_factory=GapFillingConfig)
-    """Options to pass to the gap-filling operator (used when ``treatment`` is ``FILL``)."""
+    """Options to pass to the gap-filling operator (when `treatment` is `FILL`)."""
 
     nested: NestedConfig = field(default_factory=NestedConfig)
-    """Inner-solver options (used when ``treatment`` is ``NESTED``)."""
+    """Inner-solver options (when `treatment` is `NESTED`)."""
 
 
 @dataclass
 class PointingConfig:
-    """Configuration options for pointing computation.
-
-    ``interpolation`` controls how the sky map is sampled:
-
-    - ``'nearest'``: nearest-neighbor (default, fastest).
-    - ``'bilinear'``: bilinear interpolation using the four nearest pixels.
-    """
+    """Configuration options for pointing computation."""
 
     on_the_fly: bool = True
     """Compute pointing on the fly instead of pre-computing pixel indices."""
@@ -457,7 +576,11 @@ class PointingConfig:
     """Detector batch size for on-the-fly pointing (set to 0 to use a full batch)."""
 
     interpolation: Literal['nearest', 'bilinear'] = 'nearest'
-    """Pixel interpolation scheme used when sampling the sky map."""
+    """Pixel interpolation scheme used when sampling the sky map.
+
+    - ``'nearest'``: nearest-neighbor (default, fastest).
+    - ``'bilinear'``: bilinear interpolation using the four nearest pixels.
+    """
 
 
 @dataclass
@@ -478,32 +601,59 @@ class SotodlibConfig:
     """Apply HWP wobble correction to the line of sight."""
 
     noise_source: Literal['preprocess', 'mapmaking'] = 'preprocess'
-    """Which precomputed noise model to use when fit_noise_model is False.
-
-    'preprocess': use per-stoke noise fits (noiseT, noiseQ, noiseU) from preprocessing.
-    'mapmaking': use the white noise estimate from noiseQ_mapmaking.
-    """
+    """Precomputed noise model to use: preprocessing fits, or the mapmaking white-noise estimate."""
 
 
 @dataclass
 class MapMakingConfig:
+    """Top-level configuration for a mapmaking run."""
+
     method: Methods = Methods.BINNED
+    """Mapmaking algorithm to use."""
+
     scanning_mask: bool = False
+    """Drop samples outside each observation's scanning intervals."""
+
     sample_mask: bool = False
+    """Zero out TOD samples flagged invalid (glitches/cuts)."""
+
     hits_cut: float = 1e-2
+    """Drop pixels whose hit count is below this threshold times the 95th-percentile hit count."""
+
     cond_cut: float = 1e-2
+    """Drop pixels whose weight matrix rcond is smaller than this threshold."""
+
     double_precision: bool = True
+    """Run the pipeline in float64 (`True`) or float32 (`False`); see [`dtype`][]."""
+
     pointing: PointingConfig = field(default_factory=PointingConfig)
+    """Pointing computation options."""
+
     weighting: WeightingConfig = field(default_factory=WeightingConfig)
+    """Inverse-noise weighting / noise model options."""
+
     debug: bool = True
+    """Run mapmaking solve twice to determine JIT time, and compute the reprojected map."""
+
     solver: SolverConfig = field(default_factory=SolverConfig)
+    """Iterative (conjugate gradient) solver options."""
+
     gaps: GapsConfig = field(default_factory=GapsConfig)
+    """Treatment of flagged samples in the correlated-noise weighting."""
+
     landscape: LandscapeConfig = field(
         default_factory=lambda: LandscapeConfig(healpix=HealpixConfig())
     )
+    """Output sky map: Stokes components and pixelisation."""
+
     templates: TemplatesConfig | None = None
+    """Template deprojection options. `None` disables all templates."""
+
     atop_tau: int = 0
+    """Length of the `ATOP` interval (in samples)."""
+
     sotodlib: SotodlibConfig | None = None
+    """Options specific to the sotodlib interface. `None` when not using sotodlib data."""
 
     @classmethod
     def for_method(cls, method: 'Methods | str') -> 'MapMakingConfig':
@@ -604,16 +754,20 @@ class MapMakingConfig:
 
     @property
     def binned(self) -> bool:
+        """True when the inverse-noise weighting is diagonal (identity or white)."""
         return self.weighting.diagonal_matrix
 
     @property
     def demodulated(self) -> bool:
+        """True when using demodulated TODs (sotodlib-specific)."""
         return self.sotodlib.demodulated if self.sotodlib is not None else False
 
     @property
     def use_templates(self) -> bool:
+        """True when at least one template is enabled."""
         return (self.templates is not None) and (not self.templates.empty)
 
     @property
     def dtype(self) -> DTypeLike:
+        """The floating-point dtype used throughout the pipeline, per `double_precision`."""
         return jnp.float64 if self.double_precision else jnp.float32  # type: ignore[no-any-return]

--- a/src/furax/mapmaking/config.py
+++ b/src/furax/mapmaking/config.py
@@ -116,7 +116,15 @@ class GapTreatment(Enum):
 
 @dataclass
 class SolverConfig:
-    """Options for the iterative (conjugate gradient) solver."""
+    """Options for the iterative (conjugate gradient) solver.
+
+    Examples:
+        YAML config section
+
+            solver:
+                rtol: 1.0e-6  # needs the decimal point, else PyYAML reads it as a string
+                max_steps: 1000
+    """
 
     rtol: float = 1e-6
     """Relative tolerance."""
@@ -176,7 +184,21 @@ class NoiseFitConfig:
 
 @dataclass
 class WeightingConfig:
-    """Configuration for the inverse-noise / weighting matrix used in mapmaking."""
+    """Configuration for the inverse-noise / weighting matrix used in mapmaking.
+
+    Examples:
+        Diagonal (white noise) weighting using precomputed noise parameters
+
+            weighting:
+                mode: diagonal
+                source: precomputed
+
+        Toeplitz ($1/f$) weighting
+
+            weighting:
+                mode: toeplitz
+                correlation_length: 1000
+    """
 
     mode: WeightingMode = WeightingMode.DIAGONAL
     """Matrix structure."""
@@ -198,14 +220,7 @@ class WeightingConfig:
 
 @dataclass
 class HealpixConfig:
-    """Configuration for a HEALPix output map.
-
-    Examples:
-        YAML config section
-
-            healpix:
-                nside: 512
-    """
+    """Configuration for a HEALPix output map."""
 
     nside: int = 512
     """HEALPix resolution parameter."""
@@ -220,16 +235,7 @@ class HealpixConfig:
 
 @dataclass
 class SkyPatch:
-    """Explicit rectangular sky patch for WCS map construction.
-
-    Examples:
-        YAML config section
-
-            patch:
-                center: [30.0, -10.0]  # ra, dec in degrees
-                width: 20.0
-                height: 10.0
-    """
+    """Explicit rectangular sky patch for WCS map construction."""
 
     center: tuple[float, float]
     """Center ``(ra, dec)`` in degrees."""
@@ -253,26 +259,6 @@ class WCSConfig:
         at `resolution`.
 
     `projection` applies to the `patch`/auto modes only.
-
-    Examples:
-        Auto footprint at 4 arcmin resolution
-
-            car:
-                resolution: 4.0
-
-        Explicit patch
-
-            car:
-                resolution: 4.0
-                patch:
-                    center: [30.0, -10.0]
-                    width: 20.0
-                    height: 10.0
-
-        Geometry from file
-
-            car:
-                geometry_file: /path/to/map.fits
     """
 
     projection: ProjectionType = ProjectionType.CAR
@@ -299,7 +285,43 @@ class WCSConfig:
 
 @dataclass
 class LandscapeConfig:
-    """Configuration of the output sky map: its Stokes components and pixelisation."""
+    """Configuration of the output sky map: its Stokes components and pixelisation.
+
+    Exactly one of `healpix` or `wcs` must be set.
+
+    Examples:
+        HEALPix output
+
+            landscape:
+                stokes: IQU
+                healpix:
+                    nside: 512
+
+        WCS output, automatic footprint detection at 4 arcmin resolution
+
+            landscape:
+                stokes: IQU
+                wcs:
+                    resolution: 4.0
+
+        WCS output, explicit patch
+
+            landscape:
+                stokes: IQU
+                wcs:
+                    resolution: 4.0
+                    patch:
+                        center: [30.0, -10.0]  # ra, dec in degrees
+                        width: 20.0
+                        height: 10.0
+
+        WCS output, geometry read from a file
+
+            landscape:
+                stokes: IQU
+                wcs:
+                    geometry_file: /path/to/map.fits
+    """
 
     stokes: ValidStokesLiteral = 'IQU'
     """Which Stokes components (`'I'`, `'QU'`, `'IQU'`, or `'IQUV'`) the output map holds."""
@@ -462,6 +484,17 @@ class TemplatesConfig:
 
     Each field is `None` by default, meaning that template is disabled; setting it to an instance
     of its config class enables the corresponding template with those options.
+
+    Examples:
+        YAML config section (enables the polynomial and ground templates)
+
+            templates:
+                polynomial:
+                    legendre:
+                        min_order: 0
+                        max_order: 3
+                ground:
+                    azimuth_resolution: 0.05
     """
 
     polynomial: PolynomialConfig | None = None
@@ -553,7 +586,28 @@ class NestedConfig:
 
 @dataclass
 class GapsConfig:
-    """Configuration options related to the treatment of gaps."""
+    """Configuration options related to the treatment of gaps.
+
+    Examples:
+        Cheap, suboptimal inner-mask weighting (default correlated-noise fallback)
+
+            gaps:
+                treatment: inner_mask
+
+        Gap-fill the RHS with a constrained noise realization
+
+            gaps:
+                treatment: fill
+                fill_options:
+                    seed: 42
+
+        Unbiased, minimum-variance nested-inverse weighting
+
+            gaps:
+                treatment: nested
+                nested:
+                    inner_steps: 20
+    """
 
     treatment: GapTreatment = GapTreatment.FILL
     """How flagged samples enter the weighting."""
@@ -567,7 +621,23 @@ class GapsConfig:
 
 @dataclass
 class PointingConfig:
-    """Configuration options for pointing computation."""
+    """Configuration options for pointing computation.
+
+    `interpolation: 'bilinear'` requires `on_the_fly: true`: pre-computed pointing only stores
+    a single pixel index per sample, so it cannot carry interpolation weights.
+
+    Examples:
+        On-the-fly pointing with bilinear sampling
+
+            pointing:
+                on_the_fly: true
+                interpolation: bilinear
+
+        Pre-computed pointing, nearest-neighbor sampling (default, fastest)
+
+            pointing:
+                on_the_fly: false
+    """
 
     on_the_fly: bool = True
     """Compute pointing on the fly instead of pre-computing pixel indices."""
@@ -578,14 +648,28 @@ class PointingConfig:
     interpolation: Literal['nearest', 'bilinear'] = 'nearest'
     """Pixel interpolation scheme used when sampling the sky map.
 
+    ``'bilinear'`` requires `on_the_fly`.
+
     - ``'nearest'``: nearest-neighbor (default, fastest).
     - ``'bilinear'``: bilinear interpolation using the four nearest pixels.
     """
 
+    def __post_init__(self) -> None:
+        if self.interpolation == 'bilinear' and not self.on_the_fly:
+            raise ValueError("interpolation='bilinear' requires on_the_fly=True")
+
 
 @dataclass
 class SotodlibConfig:
-    """Configuration options specific to the sotodlib interface."""
+    """Configuration options specific to the sotodlib interface.
+
+    Examples:
+        YAML config section
+
+            sotodlib:
+                site: so_sat1
+                demodulated: true
+    """
 
     # see https://github.com/simonsobs/so3g/blob/master/python/proj/coords.py#L45
     site: Literal['so', 'so_sat1', 'so_sat2', 'so_sat3', 'so_lat'] = 'so'

--- a/tests/mapmaking/test_config.py
+++ b/tests/mapmaking/test_config.py
@@ -1,0 +1,58 @@
+import inspect
+
+import pytest
+import yaml
+from apischema import deserialize
+
+from furax.mapmaking import config as config_module
+
+# Every config class whose docstring carries an `Examples:` block.
+EXAMPLE_CLASSES = [
+    cls
+    for _, cls in inspect.getmembers(config_module, inspect.isclass)
+    if cls.__module__ == config_module.__name__ and 'Examples:' in (inspect.getdoc(cls) or '')
+]
+
+
+def _extract_yaml_blocks(cls: type) -> list[str]:
+    """Pull every indented YAML snippet out of a class's Google-style `Examples:` section.
+
+    Docstring layout (after `inspect.getdoc` dedents it): the `Examples:` header sits at
+    column 0, each example's one-line description is indented 4 spaces, and the YAML snippet
+    itself is indented 8 spaces. Blank lines only separate examples, never occur inside a
+    snippet here, so any non-blank line indented less than 8 spaces closes the current block.
+    """
+    doc = inspect.getdoc(cls)
+    assert doc is not None and 'Examples:' in doc, f'{cls.__name__} has no Examples section'
+    after = doc.split('Examples:', 1)[1]
+
+    blocks = []
+    current: list[str] = []
+    for line in after.split('\n'):
+        if line.strip() == '':
+            continue
+        if line.startswith(' ' * 8):
+            current.append(line[8:])
+        elif current:
+            blocks.append('\n'.join(current))
+            current = []
+    if current:
+        blocks.append('\n'.join(current))
+    return blocks
+
+
+EXAMPLE_CASES = [
+    pytest.param(cls, block, id=f'{cls.__name__}[{i}]')
+    for cls in EXAMPLE_CLASSES
+    for i, block in enumerate(_extract_yaml_blocks(cls))
+]
+
+
+@pytest.mark.parametrize('cls,yaml_block', EXAMPLE_CASES)
+def test_docstring_example_parses_and_deserializes(cls: type, yaml_block: str):
+    parsed = yaml.safe_load(yaml_block)
+    assert isinstance(parsed, dict) and len(parsed) == 1, (
+        f'expected a single top-level key, got: {parsed!r}'
+    )
+    (value,) = parsed.values()
+    deserialize(cls, value)

--- a/zensical.toml
+++ b/zensical.toml
@@ -22,16 +22,37 @@ nav = [
   ] },
   { "API reference" = [
       "api/furax.md",
-      "api/core.md",
-      "api/obs.md",
-      "api/mapmaking.md",
-      "api/math.md",
-      "api/linalg.md",
-      "api/io.md",
-      "api/interfaces.md",
-      "api/tree.md",
-      "api/distributed.md",
-      "api/exceptions.md",
+      { "furax.core" = [
+          "api/core/algebra.md",
+          "api/core/composite.md",
+          "api/core/structural.md",
+          "api/core/special.md",
+      ] },
+      { "furax.obs" = [
+          "api/obs/pointing.md",
+          "api/obs/polarization.md",
+          "api/obs/beam.md",
+          "api/obs/seds.md",
+          "api/obs/likelihoods.md",
+          "api/obs/landscapes.md",
+          "api/obs/stokes.md",
+          "api/obs/atmosphere.md",
+      ] },
+      { "furax.mapmaking" = [
+          "api/mapmaking/observation.md",
+          "api/mapmaking/mapmaker.md",
+          "api/mapmaking/config.md",
+          "api/mapmaking/preconditioner.md",
+      ] },
+      { "Other subpackages" = [
+          "api/math.md",
+          "api/linalg.md",
+          "api/io.md",
+          "api/interfaces.md",
+          "api/tree.md",
+          "api/distributed.md",
+          "api/exceptions.md",
+      ] },
   ] },
   { "Development" = [
       "development/contributing.md",
@@ -60,8 +81,7 @@ paths = ["src"]
 # Parse docstrings as Google style, rendering sections as lists (not tables).
 docstring_style = "google"
 docstring_section_style = "list"
-# Prefix members with their full path on package/module pages; keep source order.
-show_root_members_full_path = true
+# Keep source order.
 members_order = "source"
 # Cross-references: resolve [`Name`][] by scope, by dotted relative path, and in signatures.
 relative_crossrefs = true
@@ -69,6 +89,8 @@ scoped_crossrefs = true
 signature_crossrefs = true
 # Show the real type inside Annotated[...] annotations.
 unwrap_annotated = true
+# Render a heading for the symbol requested directly by a `:::` block.
+show_root_heading = true
 # Render symbols with no docstring; document only public (non-_) names.
 show_if_no_docstring = true
 filters = "public"


### PR DESCRIPTION
## Summary

What it says in the title.

The mapmaking configuration docs now have example YAML sections.

## Checklist

- [x] Tests added/updated for new or changed behavior
- [x] `uvx prek run -a` passes (ruff, mypy, etc.)
- [x] Added a changelog entry under `[Unreleased]` in `docs/development/changelog.md`, or this PR doesn't need one (e.g. internal refactor, CI-only change)
- [x] Updated docs for user-facing changes (docstrings, `docs/`)
