### PR TITLE
Add `XSamplingOperator` for precomputed coordinate pointing

### DIFF
--- a/docs/development/changelog.md
+++ b/docs/development/changelog.md
@@ -14,6 +14,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Migrate multi-observation mapmaker to furax CG and support verbose mode (#176)
 - Split long API documentation pages (#179)
 - Improve `MapMakingConfig` documentation and add examples (#179)
+- Revert change to `lax.map` in forward on-the-fly pointing (#180)
+- Introduce `XSamplingOperator` to support precomputed bilinear pointing (#181)
 
 ## [0.11.3] - 2026-07-14
 

--- a/src/furax/mapmaking/config.py
+++ b/src/furax/mapmaking/config.py
@@ -623,24 +623,25 @@ class GapsConfig:
 class PointingConfig:
     """Configuration options for pointing computation.
 
-    `interpolation: 'bilinear'` requires `on_the_fly: true`: pre-computed pointing only stores
-    a single pixel index per sample, so it cannot carry interpolation weights.
+    Pre-computed (`on_the_fly: false`) pointing with `interpolation: bilinear` caches the projected
+    pixel coordinates and recovers interpolation weights on each apply; it requires a WCS/CAR
+    landscape (HEALPix is not supported and raises at build time).
 
     Examples:
-        On-the-fly pointing with bilinear sampling
+        Pre-computed pointing with bilinear sampling (WCS/CAR)
 
             pointing:
-                on_the_fly: true
+                on_the_fly: false
                 interpolation: bilinear
 
-        Pre-computed pointing, nearest-neighbor sampling (default, fastest)
+        Pre-computed pointing, nearest-neighbor sampling (fastest)
 
             pointing:
                 on_the_fly: false
     """
 
     on_the_fly: bool = True
-    """Compute pointing on the fly instead of pre-computing pixel indices."""
+    """Compute pointing on the fly instead of pre-computing pixel indices/coordinates."""
 
     batch_size: int = 32
     """Detector batch size for on-the-fly pointing (set to 0 to use a full batch)."""
@@ -648,15 +649,11 @@ class PointingConfig:
     interpolation: Literal['nearest', 'bilinear'] = 'nearest'
     """Pixel interpolation scheme used when sampling the sky map.
 
-    ``'bilinear'`` requires `on_the_fly`.
+    Pre-computed `'bilinear'` (`on_the_fly: false`) requires a WCS/CAR landscape.
 
     - ``'nearest'``: nearest-neighbor (default, fastest).
     - ``'bilinear'``: bilinear interpolation using the four nearest pixels.
     """
-
-    def __post_init__(self) -> None:
-        if self.interpolation == 'bilinear' and not self.on_the_fly:
-            raise ValueError("interpolation='bilinear' requires on_the_fly=True")
 
 
 @dataclass

--- a/src/furax/mapmaking/mapmaker.py
+++ b/src/furax/mapmaking/mapmaker.py
@@ -37,7 +37,6 @@ from furax import (
 from furax.core import (
     BlockDiagonalOperator,
     BlockRowOperator,
-    CompositionOperator,
     IndexOperator,
 )
 from furax.interfaces.lineax import as_lineax_operator
@@ -347,17 +346,18 @@ class MultiObservationMapMaker(Generic[T]):
                 # Padding/failed observations contribute nothing
                 obs.M = obs.M.restrict(real & valid)
 
-                # Hit map contribution.
-                assert isinstance(obs.H, CompositionOperator)  # mypy
-                pointing = obs.H.operands[-1]
-                assert isinstance(pointing, PointingOperator)  # mypy
-                pointing_i = pointing.as_stokes_i(interpolate=False)
+                # Hit map = nearest-neighbour coverage of the sample mask
+                hit_pointing = PointingOperator.create(
+                    landscape,
+                    data[ReaderField.BORESIGHT_QUATERNIONS],
+                    data[ReaderField.DETECTOR_QUATERNIONS],
+                ).as_stokes_i(interpolate=False)
                 ones = furax.tree.ones_like(obs.M.in_structure)
                 masked_tod = obs.M(ones)
                 # The sample mask is per-detector (identical across Stokes legs); take one leg so
-                # StokesI wraps a (ndet, nsamp) array rather than a whole demodulated Stokes backing.
+                # `masked` is a (ndet, nsamp) array rather than a whole demodulated Stokes backing.
                 masked = masked_tod.data[0] if isinstance(masked_tod, Stokes) else masked_tod
-                hits_i = jnp.int64(pointing_i.T(StokesI(masked)).i)
+                hits_i = jnp.int64(hit_pointing.T(StokesI(masked)).i)
 
                 # RHS contribution (optionally gap-filled).
                 def func_gapfill(tod):  # type: ignore[no-untyped-def]

--- a/src/furax/mapmaking/mapmaker.py
+++ b/src/furax/mapmaking/mapmaker.py
@@ -352,11 +352,10 @@ class MultiObservationMapMaker(Generic[T]):
                     data[ReaderField.BORESIGHT_QUATERNIONS],
                     data[ReaderField.DETECTOR_QUATERNIONS],
                 ).as_stokes_i(interpolate=False)
-                ones = furax.tree.ones_like(obs.M.in_structure)
-                masked_tod = obs.M(ones)
-                # The sample mask is per-detector (identical across Stokes legs); take one leg so
-                # `masked` is a (ndet, nsamp) array rather than a whole demodulated Stokes backing.
-                masked = masked_tod.data[0] if isinstance(masked_tod, Stokes) else masked_tod
+                # Read the mask directly: M(ones) = M.to_boolean_mask()
+                masked_tod = obs.M.to_boolean_mask()
+                # The mask is (ndet, nsamp) even in the demodulated case (all legs share the same)
+                masked = masked_tod.data if isinstance(masked_tod, Stokes) else masked_tod
                 hits_i = jnp.int64(hit_pointing.T(StokesI(masked)).i)
 
                 # RHS contribution (optionally gap-filled).

--- a/src/furax/obs/__init__.py
+++ b/src/furax/obs/__init__.py
@@ -16,10 +16,11 @@ from .operators import (
     QURotationOperator,
     SynchrotronOperator,
 )
-from .pointing import PointingOperator
+from .pointing import PointingOperator, XSamplingOperator
 
 __all__ = [
     'PointingOperator',
+    'XSamplingOperator',
     'HWPOperator',
     'LinearPolarizerOperator',
     'QURotationOperator',

--- a/src/furax/obs/landscapes.py
+++ b/src/furax/obs/landscapes.py
@@ -193,7 +193,8 @@ class StokesLandscape(Landscape):
     ) -> tuple[Integer[Array, '...'], Float[Array, '...']]:
         """Returns (indices, weights) with a trailing neighbor dimension for interpolation.
 
-        Subclasses must override this to support interpolated pointing.
+        Subclasses support interpolation by overriding [`pixel2interp`][] (2-D pixel grid, see
+        [`WCSLandscape`][]) or this method directly (e.g. HEALPix via ``get_interp_weights``).
         """
         raise NotImplementedError(f'{type(self).__name__} does not support interpolation')
 
@@ -202,9 +203,9 @@ class StokesLandscape(Landscape):
     ) -> tuple[Integer[Array, '...'], Float[Array, '...']]:
         """Returns (indices, weights) for interpolation from float pixel coordinates.
 
-        The pixel-space entry point to interpolation (see [`XSamplingOperator`][]). Subclasses with a
-        2-D pixel grid (WCS/CAR) override this; landscapes without 2-D pixel coordinates (e.g.
-        HEALPix) do not support it.
+        The pixel-space entry point to interpolation, so cached coordinates can be reused across
+        applies (see [`XSamplingOperator`][]). Subclasses with a 2-D pixel grid (WCS/CAR) override
+        this.
         """
         raise NotImplementedError(
             f'{type(self).__name__} does not support pixel-space interpolation'
@@ -284,6 +285,20 @@ class WCSLandscape(StokesLandscape):
     @property
     def cdelt(self) -> tuple[float, float]:
         return self.projection.cdelt
+
+    def world2interp(
+        self, theta: Float[Array, ' *dims'], phi: Float[Array, ' *dims']
+    ) -> tuple[Integer[Array, '*dims 4'], Float[Array, '*dims 4']]:
+        """Returns (indices, weights) for bilinear interpolation (n=4)."""
+        return self.pixel2interp(*self.world2pixel(theta, phi))
+
+    def pixel2interp(
+        self, pix_x: Float[Array, ' *dims'], pix_y: Float[Array, ' *dims']
+    ) -> tuple[Integer[Array, '*dims 4'], Float[Array, '*dims 4']]:
+        """Bilinear (indices, weights) from float pixel coordinates (grid-agnostic)."""
+        xs, ys, weights = _2d_bilinear_interp(pix_x, pix_y)
+        indices = self.pixel2index(xs, ys)
+        return indices, weights
 
     def to_wcs(self) -> WCS:
         """Reconstruct an astropy WCS object from the stored projection parameters."""
@@ -372,25 +387,6 @@ class CARLandscape(WCSLandscape):
         pix_x = lon_diff / self.cdelt[0] + (self.crpix[0] - 1)
         pix_y = lat_deg / self.cdelt[1] + (self.crpix[1] - 1)
         return pix_x, pix_y
-
-    def world2interp(
-        self, theta: Float[Array, ' *dims'], phi: Float[Array, ' *dims']
-    ) -> tuple[Integer[Array, '*dims 4'], Float[Array, '*dims 4']]:
-        """Returns (indices, weights) for bilinear interpolation (n=4)."""
-        return self.pixel2interp(*self.world2pixel(theta, phi))
-
-    def pixel2interp(
-        self, pix_x: Float[Array, ' *dims'], pix_y: Float[Array, ' *dims']
-    ) -> tuple[Integer[Array, '*dims 4'], Float[Array, '*dims 4']]:
-        """Returns (indices, weights) for bilinear interpolation (n=4) from float pixel coords.
-
-        The pixel-space entry point to bilinear interpolation, letting callers cache the projected
-        coordinates (see [`XSamplingOperator`][]) and skip the quaternion-to-sky projection on every
-        apply. [`world2interp`][] is `pixel2interp(*world2pixel(theta, phi))`.
-        """
-        xs, ys, weights = _2d_bilinear_interp(pix_x, pix_y)
-        indices = self.pixel2index(xs, ys)
-        return indices, weights
 
 
 def _2d_bilinear_interp(

--- a/src/furax/obs/landscapes.py
+++ b/src/furax/obs/landscapes.py
@@ -201,12 +201,7 @@ class StokesLandscape(Landscape):
     def pixel2interp(
         self, pix_x: Float[Array, ' *dims'], pix_y: Float[Array, ' *dims']
     ) -> tuple[Integer[Array, '...'], Float[Array, '...']]:
-        """Returns (indices, weights) for interpolation from float pixel coordinates.
-
-        The pixel-space entry point to interpolation, so cached coordinates can be reused across
-        applies (see [`XSamplingOperator`][]). Subclasses with a 2-D pixel grid (WCS/CAR) override
-        this.
-        """
+        """Returns (indices, weights) for interpolation from float pixel coordinates."""
         raise NotImplementedError(
             f'{type(self).__name__} does not support pixel-space interpolation'
         )

--- a/src/furax/obs/landscapes.py
+++ b/src/furax/obs/landscapes.py
@@ -197,6 +197,19 @@ class StokesLandscape(Landscape):
         """
         raise NotImplementedError(f'{type(self).__name__} does not support interpolation')
 
+    def pixel2interp(
+        self, pix_x: Float[Array, ' *dims'], pix_y: Float[Array, ' *dims']
+    ) -> tuple[Integer[Array, '...'], Float[Array, '...']]:
+        """Returns (indices, weights) for interpolation from float pixel coordinates.
+
+        The pixel-space entry point to interpolation (see [`XSamplingOperator`][]). Subclasses with a
+        2-D pixel grid (WCS/CAR) override this; landscapes without 2-D pixel coordinates (e.g.
+        HEALPix) do not support it.
+        """
+        raise NotImplementedError(
+            f'{type(self).__name__} does not support pixel-space interpolation'
+        )
+
     def quat2interp(
         self, quat: Float[Array, '*dims 4']
     ) -> tuple[Integer[Array, '...'], Float[Array, '...']]:
@@ -364,7 +377,17 @@ class CARLandscape(WCSLandscape):
         self, theta: Float[Array, ' *dims'], phi: Float[Array, ' *dims']
     ) -> tuple[Integer[Array, '*dims 4'], Float[Array, '*dims 4']]:
         """Returns (indices, weights) for bilinear interpolation (n=4)."""
-        pix_x, pix_y = self.world2pixel(theta, phi)
+        return self.pixel2interp(*self.world2pixel(theta, phi))
+
+    def pixel2interp(
+        self, pix_x: Float[Array, ' *dims'], pix_y: Float[Array, ' *dims']
+    ) -> tuple[Integer[Array, '*dims 4'], Float[Array, '*dims 4']]:
+        """Returns (indices, weights) for bilinear interpolation (n=4) from float pixel coords.
+
+        The pixel-space entry point to bilinear interpolation, letting callers cache the projected
+        coordinates (see [`XSamplingOperator`][]) and skip the quaternion-to-sky projection on every
+        apply. [`world2interp`][] is `pixel2interp(*world2pixel(theta, phi))`.
+        """
         xs, ys, weights = _2d_bilinear_interp(pix_x, pix_y)
         indices = self.pixel2index(xs, ys)
         return indices, weights

--- a/src/furax/obs/pointing.py
+++ b/src/furax/obs/pointing.py
@@ -17,7 +17,7 @@ from furax.math.quaternion import (
     to_polarization_angle,
     to_polarization_angle_cos_sin,
 )
-from furax.obs.landscapes import StokesLandscape
+from furax.obs.landscapes import StokesLandscape, WCSLandscape
 from furax.obs.operators._qu_rotations import QURotationOperator, rotate_qu_cs
 from furax.obs.stokes import Stokes, StokesI
 
@@ -176,11 +176,6 @@ class PointingOperator(AbstractLinearOperator):
         ravel_op = RavelOperator(1, -1, in_structure=self.landscape.structure)
         sampler: AbstractLinearOperator
         if self.interpolate:
-            if not _supports_pixel_interp(self.landscape):
-                raise NotImplementedError(
-                    f'{type(self.landscape).__name__} does not support cached bilinear '
-                    'interpolation (no pixel2interp); a WCS/CAR landscape is required.'
-                )
             pix_x, pix_y = self.landscape.quat2pixel(qdet_full)
             sampler = XSamplingOperator.create(self.landscape, pix_x, pix_y, interpolate=True)
         else:
@@ -315,11 +310,6 @@ def _batch_plan(batch_size: int, n: int) -> tuple[int, int]:
     return batch_size, n_batches
 
 
-def _supports_pixel_interp(landscape: StokesLandscape) -> bool:
-    """Whether the landscape provides a real `pixel2interp` (WCS/CAR), not the base fallback."""
-    return type(landscape).pixel2interp is not StokesLandscape.pixel2interp
-
-
 class XSamplingOperator(AbstractLinearOperator):
     r"""Precomputed pixel-sampling operator from cached float pixel coordinates.
 
@@ -356,10 +346,10 @@ class XSamplingOperator(AbstractLinearOperator):
         *,
         interpolate: bool = False,
     ) -> 'XSamplingOperator':
-        if interpolate and not _supports_pixel_interp(landscape):
+        if interpolate and not isinstance(landscape, WCSLandscape):
             raise NotImplementedError(
-                f'{type(landscape).__name__} does not support cached bilinear interpolation '
-                '(no pixel2interp); a WCS/CAR landscape is required.'
+                f'{type(landscape).__name__} does not support cached bilinear interpolation; '
+                'a WCSLandscape is required.'
             )
         # The map is raveled along its spatial axes (see PointingOperator.as_expanded_operator),
         # leaving a single pixel axis that this operator indexes.

--- a/src/furax/obs/pointing.py
+++ b/src/furax/obs/pointing.py
@@ -23,6 +23,7 @@ from furax.obs.stokes import Stokes, StokesI
 
 __all__ = [
     'PointingOperator',
+    'XSamplingOperator',
 ]
 
 _StokesT = TypeVar('_StokesT', bound=Stokes)
@@ -158,21 +159,36 @@ class PointingOperator(AbstractLinearOperator):
         )
 
     def as_expanded_operator(self) -> AbstractLinearOperator:
-        """Return the equivalent QURotationOperator @ IndexOperator @ RavelOperator.
+        """Return the equivalent QURotation @ (Index or XSampling) @ Ravel composition.
 
-        Equivalent to mv() but as an explicit composition, useful for testing.
+        Materialises the pointing once (pixel indices / coordinates and polarisation angles) so the
+        expensive quaternion-to-sky transcendentals are hoisted out of repeated applies (e.g. every
+        CG iteration). The polarisation rotation stays a [`QURotationOperator`][] so it still fuses
+        with the acquisition chain via operator algebra.
+
+        Nearest-neighbour uses a plain precomputed [`IndexOperator`][]. Bilinear interpolation uses
+        an [`XSamplingOperator`][] that caches the float pixel coordinates and recovers the four
+        interpolation weights cheaply on each apply (requires a WCS/CAR landscape).
         """
-        if self.interpolate:
-            raise NotImplementedError('as_expanded_operator does not support interpolate=True')
         qdet_full = qmul(self.qbore, self.qdet[:, None, :])
-        indices = self._quat2index(qdet_full)
         # Ravel the spatial axes only; the Stokes container's backing array carries a leading
         # Stokes axis (axis 0) that must survive, so ravel axes 1..-1 and index the pixel axis last.
         ravel_op = RavelOperator(1, -1, in_structure=self.landscape.structure)
-        index_op = IndexOperator((..., indices), in_structure=ravel_op.out_structure)
+        sampler: AbstractLinearOperator
+        if self.interpolate:
+            if not _supports_pixel_interp(self.landscape):
+                raise NotImplementedError(
+                    f'{type(self.landscape).__name__} does not support cached bilinear '
+                    'interpolation (no pixel2interp); a WCS/CAR landscape is required.'
+                )
+            pix_x, pix_y = self.landscape.quat2pixel(qdet_full)
+            sampler = XSamplingOperator.create(self.landscape, pix_x, pix_y, interpolate=True)
+        else:
+            indices = self._quat2index(qdet_full)
+            sampler = IndexOperator((..., indices), in_structure=ravel_op.out_structure)
         pa = to_polarization_angle(qdet_full)
-        qu_rot_op = QURotationOperator(angles=pa, in_structure=index_op.out_structure)
-        return qu_rot_op @ index_op @ ravel_op
+        qu_rot_op = QURotationOperator(angles=pa, in_structure=sampler.out_structure)
+        return qu_rot_op @ sampler @ ravel_op
 
     @property
     def out_structure(self) -> PyTree[jax.ShapeDtypeStruct]:
@@ -297,3 +313,86 @@ def _batch_plan(batch_size: int, n: int) -> tuple[int, int]:
     batch_size = min(batch_size, n) if batch_size > 0 else n
     n_batches = (n + batch_size - 1) // batch_size
     return batch_size, n_batches
+
+
+def _supports_pixel_interp(landscape: StokesLandscape) -> bool:
+    """Whether the landscape provides a real `pixel2interp` (WCS/CAR), not the base fallback."""
+    return type(landscape).pixel2interp is not StokesLandscape.pixel2interp
+
+
+class XSamplingOperator(AbstractLinearOperator):
+    r"""Precomputed pixel-sampling operator from cached float pixel coordinates.
+
+    The "expanded pointing" sampler. It stores the per-sample projected pixel coordinates
+    ``(pix_x, pix_y)`` -- computed once from the quaternion pointing -- and on every apply gathers a
+    raveled sky map at those coordinates, nearest-neighbour or bilinear. It replaces the plain
+    [`IndexOperator`][] in [`PointingOperator.as_expanded_operator`][] so the expensive
+    quaternion-to-sky transcendentals are hoisted out of repeated applies (e.g. every CG iteration);
+    the four bilinear weights are recovered cheaply from the cached coordinates each apply.
+
+    Requires a landscape exposing `pixel2index` / `pixel2interp` (WCS/CAR); HEALPix has no 2-D pixel
+    coordinates and is not supported. The transpose (map binning) is the automatic linear transpose
+    of the gather -- a weighted scatter-add -- so it is adjoint-exact by construction.
+
+    Attributes:
+        landscape: The WCS/CAR sky pixelization providing `pixel2index` / `pixel2interp`.
+        pix_x: Cached pixel x-coordinates, shape ``(ndet, nsamp)``.
+        pix_y: Cached pixel y-coordinates, shape ``(ndet, nsamp)``.
+        interpolate: If True, bilinear interpolation over the four nearest pixels; else nearest.
+    """
+
+    landscape: StokesLandscape
+    pix_x: Float[Array, 'det samp']
+    pix_y: Float[Array, 'det samp']
+    interpolate: bool = field(metadata={'static': True})
+    _out_structure: PyTree[jax.ShapeDtypeStruct] = field(metadata={'static': True})
+
+    @classmethod
+    def create(
+        cls,
+        landscape: StokesLandscape,
+        pix_x: Float[Array, 'det samp'],
+        pix_y: Float[Array, 'det samp'],
+        *,
+        interpolate: bool = False,
+    ) -> 'XSamplingOperator':
+        if interpolate and not _supports_pixel_interp(landscape):
+            raise NotImplementedError(
+                f'{type(landscape).__name__} does not support cached bilinear interpolation '
+                '(no pixel2interp); a WCS/CAR landscape is required.'
+            )
+        # The map is raveled along its spatial axes (see PointingOperator.as_expanded_operator),
+        # leaving a single pixel axis that this operator indexes.
+        ravel_op = RavelOperator(1, -1, in_structure=landscape.structure)
+        out_structure = Stokes.class_for(landscape.stokes).structure_for(
+            pix_x.shape, dtype=landscape.dtype
+        )
+        return cls(
+            landscape,
+            pix_x=pix_x,
+            pix_y=pix_y,
+            interpolate=interpolate,
+            in_structure=ravel_op.out_structure,
+            _out_structure=out_structure,
+        )
+
+    @property
+    def out_structure(self) -> PyTree[jax.ShapeDtypeStruct]:
+        return self._out_structure
+
+    def mv(self, x: _StokesT) -> _StokesT:
+        # `x` is a raveled sky map: its single backing array is (n_stokes, n_pixels). Index the pixel
+        # (last) axis with the cached per-sample coordinates to produce the (n_stokes, ndet, nsamp) TOD.
+        if not self.interpolate:
+            indices = self.landscape.pixel2index(self.pix_x, self.pix_y)
+            return type(x).from_array(x.data[..., indices])
+
+        indices, weights = self.landscape.pixel2interp(self.pix_x, self.pix_y)
+        # Zero contributions from out-of-bounds pixels (index == -1 -> pixel 0, weight 0) and
+        # renormalise so partially-covered samples stay unbiased -- matches PointingOperator._sample.
+        valid = indices >= 0
+        indices = jnp.where(valid, indices, 0)
+        weights = jnp.where(valid, weights, 0.0)
+        weight_sum = weights.sum(axis=-1, keepdims=True)
+        unit_weights = weights / jnp.where(weight_sum > 0, weight_sum, 1.0)
+        return type(x).from_array(jnp.sum(x.data[..., indices] * unit_weights, axis=-1))

--- a/src/furax/obs/pointing.py
+++ b/src/furax/obs/pointing.py
@@ -176,8 +176,7 @@ class PointingOperator(AbstractLinearOperator):
         ravel_op = RavelOperator(1, -1, in_structure=self.landscape.structure)
         sampler: AbstractLinearOperator
         if self.interpolate:
-            pix_x, pix_y = self.landscape.quat2pixel(qdet_full)
-            sampler = XSamplingOperator.create(self.landscape, pix_x, pix_y, interpolate=True)
+            sampler = XSamplingOperator.create(self.landscape, qdet_full, interpolate=True)
         else:
             indices = self._quat2index(qdet_full)
             sampler = IndexOperator((..., indices), in_structure=ravel_op.out_structure)
@@ -337,8 +336,7 @@ class XSamplingOperator(AbstractLinearOperator):
     def create(
         cls,
         landscape: StokesLandscape,
-        pix_x: Float[Array, 'det samp'],
-        pix_y: Float[Array, 'det samp'],
+        quaternions: Float[Array, 'det samp 4'],
         *,
         interpolate: bool = False,
     ) -> 'XSamplingOperator':
@@ -347,6 +345,7 @@ class XSamplingOperator(AbstractLinearOperator):
                 f'{type(landscape).__name__} does not support cached bilinear interpolation; '
                 'a WCSLandscape is required.'
             )
+        pix_x, pix_y = landscape.quat2pixel(quaternions)
         # The map is raveled along its spatial axes (see PointingOperator.as_expanded_operator),
         # leaving a single pixel axis that this operator indexes.
         ravel_op = RavelOperator(1, -1, in_structure=landscape.structure)

--- a/src/furax/obs/pointing.py
+++ b/src/furax/obs/pointing.py
@@ -314,15 +314,11 @@ class XSamplingOperator(AbstractLinearOperator):
     r"""Precomputed pixel-sampling operator from cached float pixel coordinates.
 
     The "expanded pointing" sampler. It stores the per-sample projected pixel coordinates
-    ``(pix_x, pix_y)`` -- computed once from the quaternion pointing -- and on every apply gathers a
-    raveled sky map at those coordinates, nearest-neighbour or bilinear. It replaces the plain
-    [`IndexOperator`][] in [`PointingOperator.as_expanded_operator`][] so the expensive
-    quaternion-to-sky transcendentals are hoisted out of repeated applies (e.g. every CG iteration);
-    the four bilinear weights are recovered cheaply from the cached coordinates each apply.
+    `(pix_x, pix_y)` (computed once from the quaternion pointing) and on every apply gathers a
+    raveled sky map at those coordinates, nearest-neighbour or bilinear.
 
-    Requires a landscape exposing `pixel2index` / `pixel2interp` (WCS/CAR); HEALPix has no 2-D pixel
-    coordinates and is not supported. The transpose (map binning) is the automatic linear transpose
-    of the gather -- a weighted scatter-add -- so it is adjoint-exact by construction.
+    Requires a landscape exposing `pixel2index` / `pixel2interp` (WCS/CAR).
+    HEALPix has no 2-D pixel coordinates and is not supported.
 
     Attributes:
         landscape: The WCS/CAR sky pixelization providing `pixel2index` / `pixel2interp`.

--- a/tests/obs/test_pointing.py
+++ b/tests/obs/test_pointing.py
@@ -5,7 +5,9 @@ from equinox import tree_equal
 from numpy.testing import assert_array_almost_equal
 
 import furax.tree as ftree
+from furax.core import AbstractLinearOperator, CompositionOperator
 from furax.obs.landscapes import CARLandscape, HealpixLandscape, StokesLandscape, WCSProjection
+from furax.obs.operators import QURotationOperator
 from furax.obs.pointing import PointingOperator
 from furax.obs.stokes import ValidStokesLiteral
 
@@ -66,6 +68,58 @@ class TestAsExpandedOperator:
 
         assert tree_equal(sky_direct, sky_expanded, rtol=1e-10, atol=0)
 
+    def test_mv_interpolate(self, stokes, frame, landscape_type) -> None:
+        """Interpolated PointingOperator.mv equals as_expanded_operator().mv (WCS/CAR only)."""
+        if landscape_type == 'healpix':
+            pytest.skip('cached bilinear interpolation requires a WCS/CAR landscape')
+        landscape = _make_landscape(landscape_type, stokes)
+
+        key = jax.random.PRNGKey(42)
+        key1, key2, key3 = jax.random.split(key, 3)
+        qbore = _random_unit_quats(key1, (NSAMP,))
+        qdet = _random_unit_quats(key2, (NDET,))
+
+        pointing_op = PointingOperator.create(
+            landscape, qbore, qdet, frame=frame, batch_size=2, interpolate=True
+        )
+        sky = landscape.normal(key3)
+
+        assert tree_equal(pointing_op(sky), pointing_op.as_expanded_operator()(sky), rtol=1e-10)
+
+    def test_transpose_mv_interpolate(self, stokes, frame, landscape_type) -> None:
+        """Interpolated PointingOperator.T.mv equals as_expanded_operator().T.mv (WCS/CAR only)."""
+        if landscape_type == 'healpix':
+            pytest.skip('cached bilinear interpolation requires a WCS/CAR landscape')
+        landscape = _make_landscape(landscape_type, stokes)
+
+        key = jax.random.PRNGKey(42)
+        key1, key2, key3 = jax.random.split(key, 3)
+        qbore = _random_unit_quats(key1, (NSAMP,))
+        qdet = _random_unit_quats(key2, (NDET,))
+
+        pointing_op = PointingOperator.create(
+            landscape, qbore, qdet, frame=frame, batch_size=2, interpolate=True
+        )
+        tod = jax.tree.map(
+            lambda s: jax.random.normal(key3, s.shape, s.dtype), pointing_op.out_structure
+        )
+
+        sky_direct = pointing_op.T(tod)
+        sky_expanded = pointing_op.as_expanded_operator().T(tod)
+
+        assert tree_equal(sky_direct, sky_expanded, rtol=1e-10)
+
+    def test_healpix_interpolate_raises(self, stokes, frame, landscape_type) -> None:
+        """Cached bilinear interpolation is unsupported for HEALPix landscapes."""
+        if landscape_type != 'healpix':
+            pytest.skip('guard is HEALPix-specific')
+        landscape = _make_landscape(landscape_type, stokes)
+        qbore = _random_unit_quats(jax.random.PRNGKey(1), (NSAMP,))
+        qdet = _random_unit_quats(jax.random.PRNGKey(2), (NDET,))
+        op = PointingOperator.create(landscape, qbore, qdet, frame=frame, interpolate=True)
+        with pytest.raises(NotImplementedError, match='pixel2interp'):
+            op.as_expanded_operator()
+
 
 @pytest.mark.parametrize('landscape_type', ['healpix', 'car'])
 class TestInterpolate:
@@ -98,3 +152,32 @@ class TestInterpolate:
         op = PointingOperator.create(landscape, qbore, qdet, interpolate=True)
         tod = op(landscape.full(3.14))
         assert_array_almost_equal(tod.i, 3.14, decimal=10)
+
+
+def test_expanded_interpolate_preserves_rotation_fusion() -> None:
+    """The expanded interpolated operator keeps QURotation exposed so it fuses via algebra.
+
+    An outer QURotation composed with `QURot(pa) @ XSampling @ Ravel` must reduce to a single
+    QURotation (angles added), leaving one rotation in the chain rather than two.
+    """
+    landscape = _make_landscape('car', 'IQU')
+    key1, key2, key3, key4 = jax.random.split(jax.random.PRNGKey(3), 4)
+    qbore = _random_unit_quats(key1, (NSAMP,))
+    qdet = _random_unit_quats(key2, (NDET,))
+
+    op = PointingOperator.create(landscape, qbore, qdet, interpolate=True)
+    expanded = op.as_expanded_operator()
+    gamma = jax.random.normal(key3, (NDET, NSAMP))
+    outer = QURotationOperator(angles=gamma, in_structure=expanded.out_structure)
+
+    reduced = (outer @ expanded).reduce()
+
+    assert isinstance(reduced, CompositionOperator)
+    leaves = jax.tree.leaves(
+        reduced.operands, is_leaf=lambda x: isinstance(x, AbstractLinearOperator)
+    )
+    n_rotations = sum(isinstance(o, QURotationOperator) for o in leaves)
+    assert n_rotations == 1
+
+    tod = jax.tree.map(lambda s: jax.random.normal(key4, s.shape, s.dtype), expanded.out_structure)
+    assert tree_equal((outer @ expanded)(op.T(tod)), reduced(op.T(tod)), rtol=1e-10)

--- a/tests/obs/test_pointing.py
+++ b/tests/obs/test_pointing.py
@@ -117,7 +117,7 @@ class TestAsExpandedOperator:
         qbore = _random_unit_quats(jax.random.PRNGKey(1), (NSAMP,))
         qdet = _random_unit_quats(jax.random.PRNGKey(2), (NDET,))
         op = PointingOperator.create(landscape, qbore, qdet, frame=frame, interpolate=True)
-        with pytest.raises(NotImplementedError, match='pixel2interp'):
+        with pytest.raises(NotImplementedError, match='WCSLandscape'):
             op.as_expanded_operator()
 
 


### PR DESCRIPTION
## Summary

The current `PointingOperator.as_expanded_operator()` method does not support bilinear interpolation, because it uses an `IndexOperator` that stores a single pixel index.

In order to enable precomputed pointing for both nearest-neighbour and bilinear options, this PR introduces `XSamplingOperator` that stores projected floating pixel coordinates and recovers nearest/bilinear indices and weights cheaply.

List of changes:
- implement `XSamplingOperator` and support `as_expanded_operator(interpolate=True)`
- relax corresponding config restriction
- add `pixel2interp` method to Stokes landscapes
- build hit map from raw pointing geometry instead of trying to retrieve the pointing operator in the composed acquisition operator
- save transient memory by reading the sample mask directly instead of applying it to a vector of ones

Notes and follow-ups:
- QU rotation by polarisation angle stays a separate operator so it can still fuse with other components of the acquisition chain.
- HEALPix bilinear interpolation is not supported yet because it does not have simple 2D pixel coordinates.
- Precomputed path stores the polarisation angle and recomputes sincos per apply; on-the-fly path avoids this via quaternion algebra. A special rotation operator that stores the sincos can lift this limitation later.

## Checklist

- [x] Tests added/updated for new or changed behavior
- [x] `uvx prek run -a` passes (ruff, mypy, etc.)
- [x] Added a changelog entry under `[Unreleased]` in `docs/development/changelog.md`, or this PR doesn't need one (e.g. internal refactor, CI-only change)
- [x] Updated docs for user-facing changes (docstrings, `docs/`)
