### PR TITLE
Supported precomputed bilinear pointing for HEALPix landscapes

### DIFF
--- a/docs/api/obs/pointing.md
+++ b/docs/api/obs/pointing.md
@@ -4,3 +4,4 @@ Boresight + detector quaternions to sky pixels, on-the-fly.
 
 ::: furax.obs.pointing.PointingOperator
 ::: furax.obs.pointing.PointingTransposeOperator
+::: furax.obs.pointing.XSamplingOperator

--- a/docs/development/changelog.md
+++ b/docs/development/changelog.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Migrate multi-observation mapmaker to furax CG and support verbose mode (#176)
 - Split long API documentation pages (#179)
 - Improve `MapMakingConfig` documentation and add examples (#179)
+- Generalise `XSamplingOperator` to cache world angles, enabling precomputed bilinear pointing for HEALPix (#183)
 
 ### Fixed
 

--- a/src/furax/obs/landscapes.py
+++ b/src/furax/obs/landscapes.py
@@ -188,6 +188,13 @@ class StokesLandscape(Landscape):
         """Converts quaternion to 1-dimensional pixel indices."""
         return self.pixel2index(*self.quat2pixel(quat))
 
+    def quat2world(
+        self, quat: Float[Array, '*dims 4']
+    ) -> tuple[Float[Array, ' *dims'], Float[Array, ' *dims']]:
+        """Converts quaternion to spherical world angles ``(theta, phi)``."""
+        theta, phi, _ = to_iso_angles(quat)  # psi not needed
+        return theta, phi
+
     def world2interp(
         self, theta: Float[Array, ' *dims'], phi: Float[Array, ' *dims']
     ) -> tuple[Integer[Array, '...'], Float[Array, '...']]:

--- a/src/furax/obs/pointing.py
+++ b/src/furax/obs/pointing.py
@@ -17,7 +17,7 @@ from furax.math.quaternion import (
     to_polarization_angle,
     to_polarization_angle_cos_sin,
 )
-from furax.obs.landscapes import StokesLandscape, WCSLandscape
+from furax.obs.landscapes import StokesLandscape
 from furax.obs.operators._qu_rotations import QURotationOperator, rotate_qu_cs
 from furax.obs.stokes import Stokes, StokesI
 
@@ -167,8 +167,8 @@ class PointingOperator(AbstractLinearOperator):
         with the acquisition chain via operator algebra.
 
         Nearest-neighbour uses a precomputed [`IndexOperator`][]. Bilinear interpolation uses an
-        [`XSamplingOperator`][] that caches the float pixel coordinates and recovers the four
-        interpolation weights cheaply on each apply (requires a WCS/CAR landscape).
+        [`XSamplingOperator`][] that caches the world angles ``(theta, phi)`` and recovers the four
+        interpolation weights on each apply (works for HEALPix and WCS/CAR landscapes).
         """
         qdet_full = qmul(self.qbore, self.qdet[:, None, :])
         # Ravel the spatial axes only; the Stokes container's backing array carries a leading
@@ -316,25 +316,25 @@ def _batch_plan(batch_size: int, n: int) -> tuple[int, int]:
 
 
 class XSamplingOperator(AbstractLinearOperator):
-    r"""Precomputed pixel-sampling operator from cached float pixel coordinates.
+    r"""Precomputed sky-sampling operator from cached world angles.
 
-    The "expanded pointing" sampler. It stores the per-sample projected pixel coordinates
-    `(pix_x, pix_y)` (computed once from the quaternion pointing) and on every apply gathers a
-    raveled sky map at those coordinates, nearest-neighbour or bilinear.
+    The "expanded pointing" sampler. It stores the per-sample world angles `(theta, phi)`
+    (computed once from the quaternion pointing, so the expensive quaternion-to-angle
+    transcendentals are hoisted out of repeated applies) and on every apply gathers a raveled
+    sky map at those angles, nearest-neighbour or bilinear.
 
-    Requires a landscape exposing `pixel2index` / `pixel2interp` (WCS/CAR).
-    HEALPix has no 2-D pixel coordinates and is not supported.
+    Works for any landscape exposing `world2index` / `world2interp` (HEALPix and WCS/CAR).
 
     Attributes:
-        landscape: The WCS/CAR sky pixelization providing `pixel2index` / `pixel2interp`.
-        pix_x: Cached pixel x-coordinates, shape ``(ndet, nsamp)``.
-        pix_y: Cached pixel y-coordinates, shape ``(ndet, nsamp)``.
+        landscape: The sky pixelization providing `world2index` / `world2interp`.
+        theta: Cached spherical co-latitude angles, shape ``(ndet, nsamp)``.
+        phi: Cached spherical longitude angles, shape ``(ndet, nsamp)``.
         interpolate: If True, bilinear interpolation over the four nearest pixels; else nearest.
     """
 
     landscape: StokesLandscape
-    pix_x: Float[Array, 'det samp']
-    pix_y: Float[Array, 'det samp']
+    theta: Float[Array, 'det samp']
+    phi: Float[Array, 'det samp']
     interpolate: bool = field(metadata={'static': True})
     _out_structure: PyTree[jax.ShapeDtypeStruct] = field(metadata={'static': True})
 
@@ -346,22 +346,17 @@ class XSamplingOperator(AbstractLinearOperator):
         *,
         interpolate: bool = False,
     ) -> 'XSamplingOperator':
-        if interpolate and not isinstance(landscape, WCSLandscape):
-            raise NotImplementedError(
-                f'{type(landscape).__name__} does not support cached bilinear interpolation; '
-                'a WCSLandscape is required.'
-            )
-        pix_x, pix_y = landscape.quat2pixel(quaternions)
+        theta, phi = landscape.quat2world(quaternions)
         # The map is raveled along its spatial axes (see PointingOperator.as_expanded_operator),
         # leaving a single pixel axis that this operator indexes.
         ravel_op = RavelOperator(1, -1, in_structure=landscape.structure)
         out_structure = Stokes.class_for(landscape.stokes).structure_for(
-            pix_x.shape, dtype=landscape.dtype
+            theta.shape, dtype=landscape.dtype
         )
         return cls(
             landscape,
-            pix_x=pix_x,
-            pix_y=pix_y,
+            theta=theta,
+            phi=phi,
             interpolate=interpolate,
             in_structure=ravel_op.out_structure,
             _out_structure=out_structure,
@@ -373,12 +368,12 @@ class XSamplingOperator(AbstractLinearOperator):
 
     def mv(self, x: _StokesT) -> _StokesT:
         # `x` is a raveled sky map: its single backing array is (n_stokes, n_pixels). Index the pixel
-        # (last) axis with the cached per-sample coordinates to produce the (n_stokes, ndet, nsamp) TOD.
+        # (last) axis with the cached per-sample angles to produce the (n_stokes, ndet, nsamp) TOD.
         if not self.interpolate:
-            indices = self.landscape.pixel2index(self.pix_x, self.pix_y)
+            indices = self.landscape.world2index(self.theta, self.phi)
             return type(x).from_array(x.data[..., indices])
 
-        indices, weights = self.landscape.pixel2interp(self.pix_x, self.pix_y)
+        indices, weights = self.landscape.world2interp(self.theta, self.phi)
         # Zero contributions from out-of-bounds pixels (index == -1 -> pixel 0, weight 0) and
         # renormalise so partially-covered samples stay unbiased -- matches PointingOperator._sample.
         valid = indices >= 0

--- a/tests/obs/test_pointing.py
+++ b/tests/obs/test_pointing.py
@@ -69,9 +69,7 @@ class TestAsExpandedOperator:
         assert tree_equal(sky_direct, sky_expanded, rtol=1e-10, atol=0)
 
     def test_mv_interpolate(self, stokes, frame, landscape_type) -> None:
-        """Interpolated PointingOperator.mv equals as_expanded_operator().mv (WCS/CAR only)."""
-        if landscape_type == 'healpix':
-            pytest.skip('cached bilinear interpolation requires a WCS/CAR landscape')
+        """Interpolated PointingOperator.mv equals as_expanded_operator().mv."""
         landscape = _make_landscape(landscape_type, stokes)
 
         key = jax.random.PRNGKey(42)
@@ -87,9 +85,7 @@ class TestAsExpandedOperator:
         assert tree_equal(pointing_op(sky), pointing_op.as_expanded_operator()(sky), rtol=1e-10)
 
     def test_transpose_mv_interpolate(self, stokes, frame, landscape_type) -> None:
-        """Interpolated PointingOperator.T.mv equals as_expanded_operator().T.mv (WCS/CAR only)."""
-        if landscape_type == 'healpix':
-            pytest.skip('cached bilinear interpolation requires a WCS/CAR landscape')
+        """Interpolated PointingOperator.T.mv equals as_expanded_operator().T.mv."""
         landscape = _make_landscape(landscape_type, stokes)
 
         key = jax.random.PRNGKey(42)
@@ -108,17 +104,6 @@ class TestAsExpandedOperator:
         sky_expanded = pointing_op.as_expanded_operator().T(tod)
 
         assert tree_equal(sky_direct, sky_expanded, rtol=1e-10)
-
-    def test_healpix_interpolate_raises(self, stokes, frame, landscape_type) -> None:
-        """Cached bilinear interpolation is unsupported for HEALPix landscapes."""
-        if landscape_type != 'healpix':
-            pytest.skip('guard is HEALPix-specific')
-        landscape = _make_landscape(landscape_type, stokes)
-        qbore = _random_unit_quats(jax.random.PRNGKey(1), (NSAMP,))
-        qdet = _random_unit_quats(jax.random.PRNGKey(2), (NDET,))
-        op = PointingOperator.create(landscape, qbore, qdet, frame=frame, interpolate=True)
-        with pytest.raises(NotImplementedError, match='WCSLandscape'):
-            op.as_expanded_operator()
 
 
 @pytest.mark.parametrize('landscape_type', ['healpix', 'car'])


### PR DESCRIPTION
## Summary

Generalise `XSamplingOperator` to cache world coordinates `(theta, phi)` instead of WCS pixel coordinates, in order to support bilinear precomputed pointing in the HEALPix case with minimal branching.

Changes:
- added `StokesLandscape.quat2world`
- change `pix_x/pix_y` xsampling fields to `theta/phi`; drop the landscape guard

## Checklist

- [x] Tests added/updated for new or changed behavior
- [x] `uvx prek run -a` passes (ruff, mypy, etc.)
- [x] Added a changelog entry under `[Unreleased]` in `docs/development/changelog.md`, or this PR doesn't need one (e.g. internal refactor, CI-only change)
- [x] Updated docs for user-facing changes (docstrings, `docs/`)
