### PR TITLE
Implement `LocalStokesLandscape`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,8 +23,11 @@ repos:
     - id: nbqa-ruff
       name: nbqa ruff linting
       args: [--fix]
+      # pin to match ruff-pre-commit rev above; nbQA installs latest ruff otherwise
+      additional_dependencies: [ruff==0.15.21]
     - id: nbqa-ruff-format
       name: nbqa ruff formatting
+      additional_dependencies: [ruff==0.15.21]
 
 - repo: https://github.com/pre-commit/pre-commit-hooks
   rev: v6.0.0

--- a/docs/api/obs/landscapes.md
+++ b/docs/api/obs/landscapes.md
@@ -4,6 +4,7 @@ Stokes-aware sky pixelisation: HEALPix, WCS, and horizon/tangential projections.
 
 ::: furax.obs.landscapes.Landscape
 ::: furax.obs.landscapes.StokesLandscape
+::: furax.obs.landscapes.LocalStokesLandscape
 ::: furax.obs.landscapes.ProjectionType
 ::: furax.obs.landscapes.WCSProjection
 ::: furax.obs.landscapes.WCSLandscape

--- a/docs/development/changelog.md
+++ b/docs/development/changelog.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Introduce `XSamplingOperator` to support precomputed bilinear pointing (#181)
+- Implement `LocalStokesLandscape` (#186)
 
 ### Changed
 

--- a/src/furax/obs/_projections.py
+++ b/src/furax/obs/_projections.py
@@ -7,7 +7,6 @@ from furax.obs import QURotationOperator
 from furax.obs._detectors import DetectorArray
 from furax.obs._samplings import Sampling
 from furax.obs.landscapes import HealpixLandscape
-from furax.obs.stokes import Stokes
 
 
 def create_projection_operator(
@@ -30,7 +29,7 @@ def create_projection_operator(
         # remove the number of directions per pixels if there is only one.
         indices = indices.reshape(indices.shape[0], indices.shape[2])
 
-    tod_structure = Stokes.class_for(landscape.stokes).structure_for(indices.shape, landscape.dtype)
+    tod_structure = landscape.structure_for(indices.shape)
 
     rotation = QURotationOperator(samplings.pa, in_structure=tod_structure)
     # Stokes maps carry the components on the leading axis: ravel only the spatial axes (1..-1) and

--- a/src/furax/obs/landscapes.py
+++ b/src/furax/obs/landscapes.py
@@ -880,6 +880,23 @@ class LocalStokesLandscape(StokesLandscape):
         """Convert quaternions to local pixel indices (sink for unmapped)."""
         return self.global2local(self.parent.quat2index(quat))
 
+    def world2interp(
+        self, theta: Float[Array, ' *dims'], phi: Float[Array, ' *dims']
+    ) -> tuple[Integer[Array, '...'], Float[Array, '...']]:
+        r"""Returns (local indices, weights) for interpolation on the parent's grid.
+
+        Neighbors outside the subset map to the sink with their weight zeroed, following the
+        parent's out-of-bounds convention. Consumers that renormalize the weights then
+        interpolate over the covered neighbors only.
+
+        Note:
+            Calling this method entails an additional $O(\log n_\mathrm{local})$ binary search
+            per neighbor, compared to the parent landscape's method.
+        """
+        indices, weights = self.parent.world2interp(theta, phi)
+        local = self.global2local(indices)
+        return local, jnp.where(local == self.sink, 0, weights)
+
     def world2pixel(
         self, theta: Float[Array, ' *dims'], phi: Float[Array, ' *dims']
     ) -> tuple[Float[Array, ' *dims'], ...]:

--- a/src/furax/obs/landscapes.py
+++ b/src/furax/obs/landscapes.py
@@ -12,7 +12,7 @@ import numpy as np
 from astropy.coordinates import SkyCoord
 from astropy.wcs import WCS
 from jax.tree_util import register_static
-from jaxtyping import Array, DTypeLike, Float, Integer, Key, PyTree, ScalarLike, Shaped
+from jaxtyping import Array, Bool, DTypeLike, Float, Integer, Key, PyTree, ScalarLike, Shaped
 
 from furax.math.quaternion import qrot_zaxis, to_iso_angles
 from furax.obs._samplings import Sampling
@@ -846,8 +846,13 @@ class LocalStokesLandscape(StokesLandscape):
         parent: StokesLandscape,
         global_indices: Integer[np.ndarray | Array, '...'],
     ) -> None:
+        gi = jnp.asarray(global_indices)
+        if gi.dtype == jnp.bool_:
+            raise TypeError('global_indices is boolean; use from_boolean_mask for masks.')
+        if not jnp.issubdtype(gi.dtype, jnp.integer):
+            raise TypeError(f'global_indices must be an integer array, got dtype {gi.dtype}.')
         # Deduplicate and drop negative entries to respect sorted-unique invariant.
-        gi = jnp.unique(jnp.asarray(global_indices).reshape(-1))
+        gi = jnp.unique(gi.reshape(-1))
         gi = gi[gi >= 0]
         npix = math.prod(parent.shape)
         if gi.size > 0 and int(gi[-1]) >= npix:
@@ -963,10 +968,10 @@ class LocalStokesLandscape(StokesLandscape):
 
     @classmethod
     def from_boolean_mask(
-        cls, parent: StokesLandscape, mask: Integer[Array, ' *shape']
+        cls, parent: StokesLandscape, mask: Bool[np.ndarray | Array, '...']
     ) -> 'LocalStokesLandscape':
-        """Build from a boolean mask over parent pixels (any shape; raveled in C order)."""
-        global_indices = jnp.flatnonzero(jnp.asarray(mask).reshape(-1))
+        """Build from a boolean mask over parent pixels."""
+        global_indices = jnp.flatnonzero(mask)
         return cls(parent, global_indices)
 
     @classmethod

--- a/src/furax/obs/landscapes.py
+++ b/src/furax/obs/landscapes.py
@@ -3,6 +3,7 @@ import warnings
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from enum import IntEnum
+from typing import TypeVar
 
 import jax
 import jax.numpy as jnp
@@ -16,6 +17,8 @@ from jaxtyping import Array, DTypeLike, Float, Integer, Key, PyTree, ScalarLike,
 from furax.math.quaternion import qrot_zaxis, to_iso_angles
 from furax.obs._samplings import Sampling
 from furax.obs.stokes import Stokes, ValidStokesLiteral
+
+_StokesT = TypeVar('_StokesT', bound=Stokes)
 
 
 @register_static
@@ -782,3 +785,153 @@ class TangentialLandscape(StokesLandscape):
         xs, ys, weights = _2d_bilinear_interp(pix_x, pix_y)
         indices = self.pixel2index(xs, ys)
         return indices, weights
+
+
+@register_static
+class LocalStokesLandscape(StokesLandscape):
+    r"""A landscape over a subset of a parent landscape's pixels.
+
+    Wraps a ``parent`` [`StokesLandscape`][] and an array of *global* (parent) flat pixel indices,
+    defining a reduced pixel domain of ``nlocal`` real pixels. The indices are normalized on
+    construction: any shape is flattened, duplicates are removed, negative entries (the
+    out-of-bounds marker of ``world2index``) are dropped, and the result is sorted. Index-producing
+    methods (``world2index`` / ``quat2index``) return **local** indices into the subset, so it is a
+    drop-in landscape wherever a full-sky one is used.
+
+    The pixel axis carries an extra trailing *sink* slot: ``shape == (nlocal + 1,)`` and the sink is
+    index ``nlocal``. Coordinates outside the subset (and out-of-bounds inputs) map to the sink
+    rather than ``-1``, so a plain gather from the length ``nlocal + 1`` buffer lands them on the
+    dedicated discardable slot instead of wrapping onto a real pixel (as ``-1`` would). The map
+    product space is the ``nlocal`` real pixels (no sink): [`restrict`][] and [`promote`][] move
+    between the parent sky and that space.
+
+    Attributes:
+        parent: The parent landscape.
+        global_indices: Sorted 1-D array of unique global (parent) flat pixel indices, length
+            ``nlocal``.
+
+    Examples:
+        Restrict a 12-pixel HEALPix sky to two pixels (the shape gains a trailing sink slot):
+
+        >>> parent = HealpixLandscape(1, stokes='I')
+        >>> local = LocalStokesLandscape(parent, jnp.array([3, 7]))
+        >>> local.nlocal, local.sink, local.shape
+        (2, 2, (3,))
+
+        Global indices map to local ones; unselected and out-of-bounds pixels fall in the sink:
+
+        >>> local.global2local(jnp.array([3, 7, 5, -1]))
+        Array([0, 1, 2, 2], dtype=int32)
+
+        [`restrict`][] and [`promote`][] move between the parent sky and the real (sink-less)
+        subset:
+
+        >>> sky = parent.ones()
+        >>> local.restrict(sky).shape
+        (2,)
+        >>> local.promote(local.restrict(sky)).shape
+        (12,)
+    """
+
+    def __init__(
+        self,
+        parent: StokesLandscape,
+        global_indices: Integer[np.ndarray | Array, '...'],
+    ) -> None:
+        # Deduplicate and drop negative entries to respect sorted-unique invariant.
+        gi = jnp.unique(jnp.asarray(global_indices).reshape(-1))
+        gi = gi[gi >= 0]
+        npix = math.prod(parent.shape)
+        if gi.size > 0 and int(gi[-1]) >= npix:
+            raise ValueError(
+                f'global_indices contains {int(gi[-1])}, out of range for a parent '
+                f'with {npix} pixels.'
+            )
+        nlocal = int(gi.size)
+        # The sink occupies index `nlocal`, so the buffer has shape `(nlocal + 1,)`.
+        super().__init__(shape=(nlocal + 1,), stokes=parent.stokes, dtype=parent.dtype)
+        self.parent = parent
+        self.global_indices = gi
+        # lut[global_flat_index] -> local index in [0, nlocal); unmapped pixels -> sink.
+        lut = jnp.full(npix, nlocal, dtype=jnp.int32)
+        lut = lut.at[gi].set(jnp.arange(nlocal, dtype=jnp.int32))
+        self._global2local_lut = lut
+
+    @property
+    def nlocal(self) -> int:
+        return len(self.global_indices)
+
+    @property
+    def sink(self) -> int:
+        """The sink index that unmapped/out-of-bounds samples map to."""
+        return len(self.global_indices)
+
+    def world2index(
+        self, theta: Float[Array, ' *dims'], phi: Float[Array, ' *dims']
+    ) -> Integer[Array, ' *dims']:
+        """Convert world coordinates to local pixel indices (sink for unmapped)."""
+        return self.global2local(self.parent.world2index(theta, phi))
+
+    def quat2index(self, quat: Float[Array, '*dims 4']) -> Integer[Array, ' *dims']:
+        """Convert quaternions to local pixel indices (sink for unmapped)."""
+        return self.global2local(self.parent.quat2index(quat))
+
+    def world2pixel(
+        self, theta: Float[Array, ' *dims'], phi: Float[Array, ' *dims']
+    ) -> tuple[Float[Array, ' *dims'], ...]:
+        raise NotImplementedError('LocalStokesLandscape does not support world2pixel.')
+
+    def global2local(self, indices: Integer[Array, ' *dims']) -> Integer[Array, ' *dims']:
+        """Map global (parent) flat indices to local indices, sending unmapped ones to the sink.
+
+        Out-of-bounds inputs (negative, e.g. ``-1`` from a missed sample) also map to the sink.
+        """
+        safe = jnp.where(indices >= 0, indices, 0)
+        local: Integer[Array, ' *dims'] = jnp.where(
+            indices >= 0, self._global2local_lut[safe], self.sink
+        )
+        return local
+
+    def local2global(self, indices: Integer[Array, ' *dims']) -> Integer[Array, ' *dims']:
+        """Map local indices to global (parent) flat indices, ``-1`` for out-of-range inputs."""
+        valid = (indices >= 0) & (indices < self.nlocal)
+        safe = jnp.where(valid, indices, 0)
+        return jnp.where(valid, self.global_indices[safe], -1)
+
+    def restrict(self, sky: _StokesT) -> _StokesT:
+        """Extract the local subset from a parent-shaped Stokes map (``nlocal``-sized, no sink)."""
+        flat = sky.data.reshape(sky.data.shape[0], -1)
+        return type(sky).from_array(flat[:, self.global_indices])
+
+    def promote(self, sky: _StokesT, fill_value: ScalarLike = 0) -> _StokesT:
+        """Scatter a local (``nlocal``-sized) Stokes map back into a parent-shaped one.
+
+        Pixels outside the local subset are set to ``fill_value``.
+        """
+        ncomp = sky.data.shape[0]
+        npix = math.prod(self.parent.shape)
+        flat = jnp.full((ncomp, npix), fill_value, dtype=sky.dtype)
+        flat = flat.at[:, self.global_indices].set(sky.data)
+        return type(sky).from_array(flat.reshape(ncomp, *self.parent.shape))
+
+    def get_coverage(self, arg: Sampling) -> Integer[Array, ' nlocal']:
+        """Per-pixel hit counts in local index space (samples outside the subset are ignored)."""
+        local = self.world2index(arg.theta, arg.phi)
+        valid = local < self.nlocal  # drop the sink
+        safe = jnp.where(valid, local, 0)
+        coverage = jnp.zeros(self.nlocal, dtype=np.int64)
+        coverage = coverage.at[safe].add(valid.astype(np.int64))
+        return coverage
+
+    @classmethod
+    def from_boolean_mask(
+        cls, parent: StokesLandscape, mask: Integer[Array, ' *shape']
+    ) -> 'LocalStokesLandscape':
+        """Build from a boolean mask over parent pixels (any shape; raveled in C order)."""
+        global_indices = jnp.flatnonzero(jnp.asarray(mask).reshape(-1))
+        return cls(parent, global_indices)
+
+    @classmethod
+    def from_sampling(cls, parent: StokesLandscape, sampling: Sampling) -> 'LocalStokesLandscape':
+        """Build from the pixels a [`Sampling`][furax.obs._samplings.Sampling] observes."""
+        return cls(parent, parent.world2index(sampling.theta, sampling.phi))

--- a/src/furax/obs/landscapes.py
+++ b/src/furax/obs/landscapes.py
@@ -975,6 +975,11 @@ class LocalStokesLandscape(StokesLandscape):
         return cls(parent, global_indices)
 
     @classmethod
-    def from_sampling(cls, parent: StokesLandscape, sampling: Sampling) -> 'LocalStokesLandscape':
+    def from_sampling(
+        cls, parent: StokesLandscape, sampling: Sampling, interpolate: bool = False
+    ) -> 'LocalStokesLandscape':
         """Build from the pixels a [`Sampling`][furax.obs._samplings.Sampling] observes."""
+        if interpolate:
+            # bilinear reads the full 4-pixel stencil, so the subset must contain it
+            return cls(parent, parent.world2interp(sampling.theta, sampling.phi)[0])
         return cls(parent, parent.world2index(sampling.theta, sampling.phi))

--- a/src/furax/obs/landscapes.py
+++ b/src/furax/obs/landscapes.py
@@ -800,7 +800,10 @@ class LocalStokesLandscape(StokesLandscape):
     construction: any shape is flattened, duplicates are removed, negative entries (the
     out-of-bounds marker of ``world2index``) are dropped, and the result is sorted. Index-producing
     methods (``world2index`` / ``quat2index``) return **local** indices into the subset, so it is a
-    drop-in landscape wherever a full-sky one is used.
+    drop-in landscape wherever a full-sky one is used. Pixel coordinates, however, do not make
+    sense here: local indices are positions in the sorted subset, not points on the parent's pixel
+    grid, so the pixel-coordinate methods (``world2pixel``, ``quat2pixel``, ``pixel2index``) raise
+    ``NotImplementedError``.
 
     The pixel axis carries an extra trailing *sink* slot: ``shape == (nlocal + 1,)`` and the sink is
     index ``nlocal``. Coordinates outside the subset (and out-of-bounds inputs) map to the sink

--- a/src/furax/obs/landscapes.py
+++ b/src/furax/obs/landscapes.py
@@ -805,9 +805,10 @@ class LocalStokesLandscape(StokesLandscape):
     The pixel axis carries an extra trailing *sink* slot: ``shape == (nlocal + 1,)`` and the sink is
     index ``nlocal``. Coordinates outside the subset (and out-of-bounds inputs) map to the sink
     rather than ``-1``, so a plain gather from the length ``nlocal + 1`` buffer lands them on the
-    dedicated discardable slot instead of wrapping onto a real pixel (as ``-1`` would). The map
-    product space is the ``nlocal`` real pixels (no sink): [`restrict`][] and [`promote`][] move
-    between the parent sky and that space.
+    dedicated discardable slot instead of wrapping onto a real pixel (as ``-1`` would). Maps live
+    in that ``nlocal + 1`` space throughout: [`restrict`][] pads a zero sink slot and [`promote`][]
+    discards it when moving between the parent sky and the local one. [`with_sink`][] and
+    [`drop_sink`][] convert between that space and sink-less ``nlocal``-sized maps.
 
     Attributes:
         parent: The parent landscape.
@@ -827,12 +828,12 @@ class LocalStokesLandscape(StokesLandscape):
         >>> local.global2local(jnp.array([3, 7, 5, -1]))
         Array([0, 1, 2, 2], dtype=int32)
 
-        [`restrict`][] and [`promote`][] move between the parent sky and the real (sink-less)
-        subset:
+        [`restrict`][] and [`promote`][] move between the parent sky and the local map space
+        (sink slot included):
 
         >>> sky = parent.ones()
         >>> local.restrict(sky).shape
-        (2,)
+        (3,)
         >>> local.promote(local.restrict(sky)).shape
         (12,)
     """
@@ -856,10 +857,6 @@ class LocalStokesLandscape(StokesLandscape):
         super().__init__(shape=(nlocal + 1,), stokes=parent.stokes, dtype=parent.dtype)
         self.parent = parent
         self.global_indices = gi
-        # lut[global_flat_index] -> local index in [0, nlocal); unmapped pixels -> sink.
-        lut = jnp.full(npix, nlocal, dtype=jnp.int32)
-        lut = lut.at[gi].set(jnp.arange(nlocal, dtype=jnp.int32))
-        self._global2local_lut = lut
 
     @property
     def nlocal(self) -> int:
@@ -868,7 +865,7 @@ class LocalStokesLandscape(StokesLandscape):
     @property
     def sink(self) -> int:
         """The sink index that unmapped/out-of-bounds samples map to."""
-        return len(self.global_indices)
+        return self.nlocal
 
     def world2index(
         self, theta: Float[Array, ' *dims'], phi: Float[Array, ' *dims']
@@ -885,15 +882,26 @@ class LocalStokesLandscape(StokesLandscape):
     ) -> tuple[Float[Array, ' *dims'], ...]:
         raise NotImplementedError('LocalStokesLandscape does not support world2pixel.')
 
+    def quat2pixel(self, quat: Float[Array, '*dims 4']) -> tuple[Float[Array, ' *dims'], ...]:
+        raise NotImplementedError('LocalStokesLandscape does not support quat2pixel.')
+
+    def pixel2index(self, *coords: Float[Array, ' *dims']) -> Integer[Array, ' *ndims']:
+        raise NotImplementedError('LocalStokesLandscape does not support pixel2index.')
+
     def global2local(self, indices: Integer[Array, ' *dims']) -> Integer[Array, ' *dims']:
         """Map global (parent) flat indices to local indices, sending unmapped ones to the sink.
 
         Out-of-bounds inputs (negative, e.g. ``-1`` from a missed sample) also map to the sink.
         """
-        safe = jnp.where(indices >= 0, indices, 0)
-        local: Integer[Array, ' *dims'] = jnp.where(
-            indices >= 0, self._global2local_lut[safe], self.sink
-        )
+        if self.nlocal == 0:
+            return jnp.full(jnp.shape(indices), self.sink, dtype=jnp.int32)
+        # global_indices is sorted-unique: binary search + equality check gives an O(log nlocal)
+        # inverse lookup without materializing an npix-sized LUT. Negative inputs (oob markers)
+        # miss the equality check (global_indices is non-negative) and fall in the sink.
+        pos = jnp.searchsorted(self.global_indices, indices).astype(jnp.int32)
+        safe = jnp.minimum(pos, self.nlocal - 1)
+        hit = self.global_indices[safe] == indices
+        local: Integer[Array, ' *dims'] = jnp.where(hit, safe, self.sink)
         return local
 
     def local2global(self, indices: Integer[Array, ' *dims']) -> Integer[Array, ' *dims']:
@@ -902,30 +910,36 @@ class LocalStokesLandscape(StokesLandscape):
         safe = jnp.where(valid, indices, 0)
         return jnp.where(valid, self.global_indices[safe], -1)
 
+    def with_sink(self, sky: _StokesT, fill_value: ScalarLike = 0) -> _StokesT:
+        """Append a sink slot filled with ``fill_value`` (``nlocal`` -> ``nlocal + 1`` pixels)."""
+        pad_width = [(0, 0)] * (sky.data.ndim - 1) + [(0, 1)]
+        return type(sky).from_array(jnp.pad(sky.data, pad_width, constant_values=fill_value))
+
+    def drop_sink(self, sky: _StokesT) -> _StokesT:
+        """Return the map without its trailing sink slot (``nlocal + 1`` -> ``nlocal`` pixels)."""
+        return type(sky).from_array(sky.data[..., :-1])
+
     def restrict(self, sky: _StokesT) -> _StokesT:
-        """Extract the local subset from a parent-shaped Stokes map (``nlocal``-sized, no sink)."""
-        flat = sky.data.reshape(sky.data.shape[0], -1)
-        return type(sky).from_array(flat[:, self.global_indices])
+        """Extract the local subset from a parent-shaped Stokes map (shape ``self.shape``).
+
+        The trailing sink slot is padded with zeros. Leading (batch) axes are preserved; only the
+        trailing ``parent.ndim`` axes are interpreted as the pixel axes.
+        """
+        batch = sky.data.shape[: sky.data.ndim - len(self.parent.shape)]
+        flat = sky.data.reshape(*batch, -1)
+        return self.with_sink(type(sky).from_array(flat[..., self.global_indices]))
 
     def promote(self, sky: _StokesT, fill_value: ScalarLike = 0) -> _StokesT:
-        """Scatter a local (``nlocal``-sized) Stokes map back into a parent-shaped one.
+        """Scatter a local (``self.shape``-sized) Stokes map back into a parent-shaped one.
 
-        Pixels outside the local subset are set to ``fill_value``.
+        The trailing sink slot is discarded. Pixels outside the local subset are set to
+        ``fill_value``. Leading (batch) axes are preserved.
         """
-        ncomp = sky.data.shape[0]
+        batch = sky.data.shape[:-1]
         npix = math.prod(self.parent.shape)
-        flat = jnp.full((ncomp, npix), fill_value, dtype=sky.dtype)
-        flat = flat.at[:, self.global_indices].set(sky.data)
-        return type(sky).from_array(flat.reshape(ncomp, *self.parent.shape))
-
-    def get_coverage(self, arg: Sampling) -> Integer[Array, ' nlocal']:
-        """Per-pixel hit counts in local index space (samples outside the subset are ignored)."""
-        local = self.world2index(arg.theta, arg.phi)
-        valid = local < self.nlocal  # drop the sink
-        safe = jnp.where(valid, local, 0)
-        coverage = jnp.zeros(self.nlocal, dtype=np.int64)
-        coverage = coverage.at[safe].add(valid.astype(np.int64))
-        return coverage
+        flat = jnp.full((*batch, npix), fill_value, dtype=sky.dtype)
+        flat = flat.at[..., self.global_indices].set(sky.data[..., : self.nlocal])
+        return type(sky).from_array(flat.reshape(*batch, *self.parent.shape))
 
     @classmethod
     def from_boolean_mask(

--- a/src/furax/obs/landscapes.py
+++ b/src/furax/obs/landscapes.py
@@ -92,8 +92,12 @@ class StokesLandscape(Landscape):
 
     @property
     def structure(self) -> PyTree[jax.ShapeDtypeStruct]:
+        return self.structure_for(self.shape)
+
+    def structure_for(self, shape: tuple[int, ...]) -> PyTree[jax.ShapeDtypeStruct]:
+        """Structure of a Stokes map with this landscape's Stokes components and dtype."""
         cls = Stokes.class_for(self.stokes)
-        return cls.structure_for(self.shape, self.dtype)
+        return cls.structure_for(shape, self.dtype)
 
     def full(self, fill_value: ScalarLike) -> PyTree[Shaped[Array, ' {self.npixel}']]:
         cls = Stokes.class_for(self.stokes)

--- a/src/furax/obs/pointing.py
+++ b/src/furax/obs/pointing.py
@@ -68,9 +68,7 @@ class PointingOperator(AbstractLinearOperator):
         # Explicitly determine the output structure
         ndet = detector_quaternions.shape[0]
         nsamp = boresight_quaternions.shape[0]
-        out_structure = Stokes.class_for(landscape.stokes).structure_for(
-            (ndet, nsamp), dtype=landscape.dtype
-        )
+        out_structure = landscape.structure_for((ndet, nsamp))
 
         # In boresight frame, strip the z-rotation (gamma) from each detector quaternion.
         # This absorbs the frame correction into qdet so that _get_cos_sin_angles always
@@ -350,9 +348,7 @@ class XSamplingOperator(AbstractLinearOperator):
         # The map is raveled along its spatial axes (see PointingOperator.as_expanded_operator),
         # leaving a single pixel axis that this operator indexes.
         ravel_op = RavelOperator(1, -1, in_structure=landscape.structure)
-        out_structure = Stokes.class_for(landscape.stokes).structure_for(
-            theta.shape, dtype=landscape.dtype
-        )
+        out_structure = landscape.structure_for(theta.shape)
         return cls(
             landscape,
             theta=theta,

--- a/tests/obs/test_landscapes.py
+++ b/tests/obs/test_landscapes.py
@@ -394,7 +394,7 @@ class TestLocalStokesLandscape:
     def test_restrict_promote_roundtrip(self, parent: CARLandscape) -> None:
         local = LocalStokesLandscape(parent, jnp.array([0, 10, 29]))
         sky = Stokes.class_for('QU').from_array(
-            jnp.arange(2 * parent.size // 2, dtype=jnp.float64).reshape(2, *parent.shape)
+            jnp.arange(2 * len(parent), dtype=jnp.float64).reshape(2, *parent.shape)
         )
         restricted = local.restrict(sky)
         # restrict lands in the map space `self.shape` (sink slot included, zero-padded)
@@ -405,9 +405,7 @@ class TestLocalStokesLandscape:
         gi = local.global_indices
         # selected pixels survive the roundtrip; everything else is zeroed
         assert_array_equal(promoted.data.reshape(2, -1)[:, gi], sky.data.reshape(2, -1)[:, gi])
-        assert_array_equal(
-            promoted.data.reshape(2, -1).at[:, gi].set(0.0), jnp.zeros((2, parent.size // 2))
-        )
+        assert_array_equal(promoted.data.reshape(2, -1).at[:, gi].set(0.0), 0.0)
 
     def test_with_drop_sink_roundtrip(self, parent: CARLandscape) -> None:
         local = LocalStokesLandscape(parent, jnp.array([0, 10, 29]))
@@ -435,12 +433,10 @@ class TestLocalStokesLandscape:
         local = LocalStokesLandscape(parent, jnp.array([3, 7, 15, 19]))
         nfreq = 2
         sky = Stokes.class_for('QU').from_array(
-            jnp.arange(2 * nfreq * parent.size // 2, dtype=jnp.float64).reshape(
-                2, nfreq, *parent.shape
-            )
+            jnp.arange(2 * nfreq * len(parent), dtype=jnp.float64).reshape(2, nfreq, *parent.shape)
         )
         restricted = local.restrict(sky)
-        assert restricted.shape == (nfreq, local.nlocal + 1)
+        assert restricted.shape == (nfreq, *local.shape)
         gi = local.global_indices
         assert_array_equal(restricted.data[..., :-1], sky.data.reshape(2, nfreq, -1)[..., gi])
         promoted = local.promote(restricted)
@@ -479,7 +475,7 @@ class TestLocalStokesLandscape:
 
     def test_rejects_out_of_range(self, parent: CARLandscape) -> None:
         with pytest.raises(ValueError, match='out of range'):
-            LocalStokesLandscape(parent, jnp.array([0, parent.size // 2]))
+            LocalStokesLandscape(parent, jnp.array([0, len(parent)]))
 
     def test_delegates_stokes_and_dtype(self, parent: CARLandscape) -> None:
         local = LocalStokesLandscape(parent, jnp.array([0, 2, 4]))

--- a/tests/obs/test_landscapes.py
+++ b/tests/obs/test_landscapes.py
@@ -11,6 +11,7 @@ from furax.obs.landscapes import (
     CARLandscape,
     FrequencyLandscape,
     HealpixLandscape,
+    LocalStokesLandscape,
     ProjectionType,
     StokesLandscape,
     WCSLandscape,
@@ -364,3 +365,66 @@ class TestWCSConventions:
         x2, y2 = landscape2.world2pixel(theta, phi)
         assert_array_almost_equal(x1, x2, decimal=12)
         assert_array_almost_equal(y1, y2, decimal=12)
+
+
+class TestLocalStokesLandscape:
+    @pytest.fixture
+    def parent(self) -> CARLandscape:
+        proj = WCSProjection(crpix=(6.5, 5.5), crval=(180.0, 0.0), cdelt=(-2.0, 2.0))
+        return CARLandscape((10, 12), proj, stokes='QU')
+
+    def test_from_boolean_mask(self, parent: CARLandscape) -> None:
+        mask = np.zeros(parent.shape, bool)
+        mask[0, 0] = mask[1, 2] = mask[3, 5] = True
+        local = LocalStokesLandscape.from_boolean_mask(parent, mask)
+        # global_indices are the sorted flat positions; shape carries the extra sink slot
+        assert_array_equal(local.global_indices, [0, 1 * 12 + 2, 3 * 12 + 5])
+        assert local.nlocal == 3
+        assert local.sink == 3
+        assert local.shape == (4,)  # nlocal + 1 (sink)
+
+    def test_global2local_roundtrip_and_sink(self, parent: CARLandscape) -> None:
+        local = LocalStokesLandscape(parent, jnp.array([0, 10, 29]))
+        assert_array_equal(local.global2local(local.global_indices), [0, 1, 2])
+        # unmapped and out-of-bounds (-1) both fall in the sink
+        assert_array_equal(local.global2local(jnp.array([7, -1, 40])), [3, 3, 3])
+        # local2global inverts, out-of-range -> -1
+        assert_array_equal(local.local2global(jnp.array([0, 1, 2, 3])), [0, 10, 29, -1])
+
+    def test_restrict_promote_roundtrip(self, parent: CARLandscape) -> None:
+        local = LocalStokesLandscape(parent, jnp.array([0, 10, 29]))
+        sky = Stokes.class_for('QU').from_array(
+            jnp.arange(2 * parent.size // 2, dtype=jnp.float64).reshape(2, *parent.shape)
+        )
+        restricted = local.restrict(sky)
+        assert restricted.shape == (3,)
+        promoted = local.promote(restricted)
+        assert promoted.shape == parent.shape
+        gi = local.global_indices
+        # selected pixels survive the roundtrip; everything else is zeroed
+        assert_array_equal(promoted.data.reshape(2, -1)[:, gi], sky.data.reshape(2, -1)[:, gi])
+        assert_array_equal(
+            promoted.data.reshape(2, -1).at[:, gi].set(0.0), jnp.zeros((2, parent.size // 2))
+        )
+
+    @pytest.mark.parametrize(
+        'indices',
+        [
+            [3, 1, 5],  # unsorted
+            [1, 3, 3, 5, 1],  # duplicates
+            [[5, 3], [1, -1]],  # any shape; negatives (oob markers) dropped
+            [-1, 1, 3, 5],  # negatives dropped
+        ],
+    )
+    def test_normalizes_indices(self, parent: CARLandscape, indices: list) -> None:
+        local = LocalStokesLandscape(parent, jnp.array(indices))
+        assert_array_equal(local.global_indices, [1, 3, 5])
+
+    def test_rejects_out_of_range(self, parent: CARLandscape) -> None:
+        with pytest.raises(ValueError, match='out of range'):
+            LocalStokesLandscape(parent, jnp.array([0, parent.size // 2]))
+
+    def test_delegates_stokes_and_dtype(self, parent: CARLandscape) -> None:
+        local = LocalStokesLandscape(parent, jnp.array([0, 2, 4]))
+        assert local.stokes == parent.stokes
+        assert local.dtype == parent.dtype

--- a/tests/obs/test_landscapes.py
+++ b/tests/obs/test_landscapes.py
@@ -495,6 +495,14 @@ class TestLocalStokesLandscape:
         with pytest.raises(ValueError, match='out of range'):
             LocalStokesLandscape(parent, jnp.array([0, len(parent)]))
 
+    def test_rejects_non_integer_indices(self, parent: CARLandscape) -> None:
+        with pytest.raises(TypeError, match='integer'):
+            LocalStokesLandscape(parent, jnp.array([0.0, 1.0]))
+
+    def test_rejects_boolean_indices(self, parent: CARLandscape) -> None:
+        with pytest.raises(TypeError, match='from_boolean_mask'):
+            LocalStokesLandscape(parent, jnp.array([True, False]))
+
     def test_delegates_stokes_and_dtype(self, parent: CARLandscape) -> None:
         local = LocalStokesLandscape(parent, jnp.array([0, 2, 4]))
         assert local.stokes == parent.stokes

--- a/tests/obs/test_landscapes.py
+++ b/tests/obs/test_landscapes.py
@@ -445,6 +445,24 @@ class TestLocalStokesLandscape:
             promoted.data.reshape(2, nfreq, -1)[..., gi], sky.data.reshape(2, nfreq, -1)[..., gi]
         )
 
+    def test_world2interp_localizes_indices_and_masks_weights(self) -> None:
+        parent = HealpixLandscape(2, stokes='I')
+        theta, phi = jnp.array([1.2]), jnp.array([0.7])
+        gidx, gweights = parent.world2interp(theta, phi)
+        # subset containing all 4 neighbors: indices are localized, weights unchanged
+        local = LocalStokesLandscape(parent, gidx)
+        lidx, lweights = local.world2interp(theta, phi)
+        assert_array_equal(local.local2global(lidx), gidx)
+        assert_array_equal(lweights, gweights)
+        # drop one neighbor: it maps to the sink and its weight is zeroed
+        dropped = gidx.ravel()[0]
+        local = LocalStokesLandscape(parent, gidx.ravel()[1:])
+        lidx, lweights = local.world2interp(theta, phi)
+        mask = gidx == dropped
+        assert_array_equal(lidx[mask], local.sink)
+        assert_array_equal(lweights[mask], 0.0)
+        assert_array_equal(lweights[~mask], gweights[~mask])
+
     def test_get_coverage_matches_shape(self) -> None:
         # base-class contract: coverage has shape self.shape; the sink slot counts the
         # samples falling outside the subset

--- a/tests/obs/test_landscapes.py
+++ b/tests/obs/test_landscapes.py
@@ -463,6 +463,27 @@ class TestLocalStokesLandscape:
         assert_array_equal(lweights[mask], 0.0)
         assert_array_equal(lweights[~mask], gweights[~mask])
 
+    def test_from_sampling(self) -> None:
+        parent = HealpixLandscape(2, stokes='I')
+        theta = jnp.array([1.2, 0.9, 2.0])
+        phi = jnp.array([0.7, 3.1, 5.0])
+        sampling = Sampling(theta, phi, jnp.zeros_like(theta))
+
+        # nearest: subset is exactly the observed (sorted-unique) pixels
+        nearest = LocalStokesLandscape.from_sampling(parent, sampling)
+        expected = jnp.unique(parent.world2index(theta, phi))
+        assert_array_equal(nearest.global_indices, expected)
+
+        # interpolate: subset is the full 4-pixel bilinear stencil
+        interp = LocalStokesLandscape.from_sampling(parent, sampling, interpolate=True)
+        gidx, _ = parent.world2interp(theta, phi)
+        assert_array_equal(interp.global_indices, jnp.unique(gidx))
+        # every stencil neighbor is local (nothing falls in the sink) -> weights preserved
+        lidx, lweights = interp.world2interp(theta, phi)
+        assert not jnp.any(lidx == interp.sink)
+        _, gweights = parent.world2interp(theta, phi)
+        assert_array_equal(lweights, gweights)
+
     def test_get_coverage_matches_shape(self) -> None:
         # base-class contract: coverage has shape self.shape; the sink slot counts the
         # samples falling outside the subset

--- a/tests/obs/test_landscapes.py
+++ b/tests/obs/test_landscapes.py
@@ -397,7 +397,9 @@ class TestLocalStokesLandscape:
             jnp.arange(2 * parent.size // 2, dtype=jnp.float64).reshape(2, *parent.shape)
         )
         restricted = local.restrict(sky)
-        assert restricted.shape == (3,)
+        # restrict lands in the map space `self.shape` (sink slot included, zero-padded)
+        assert restricted.shape == local.shape == (4,)
+        assert_array_equal(restricted.data[:, -1], 0.0)
         promoted = local.promote(restricted)
         assert promoted.shape == parent.shape
         gi = local.global_indices
@@ -406,6 +408,61 @@ class TestLocalStokesLandscape:
         assert_array_equal(
             promoted.data.reshape(2, -1).at[:, gi].set(0.0), jnp.zeros((2, parent.size // 2))
         )
+
+    def test_with_drop_sink_roundtrip(self, parent: CARLandscape) -> None:
+        local = LocalStokesLandscape(parent, jnp.array([0, 10, 29]))
+        compact = Stokes.class_for('QU').from_array(
+            jnp.arange(2 * local.nlocal, dtype=jnp.float64).reshape(2, local.nlocal)
+        )
+        padded = local.with_sink(compact, fill_value=-1.0)
+        assert padded.shape == local.shape
+        assert_array_equal(padded.data[:, -1], -1.0)
+        assert_array_equal(padded.data[:, :-1], compact.data)
+        roundtripped = local.drop_sink(padded)
+        assert roundtripped.shape == (local.nlocal,)
+        assert_array_equal(roundtripped.data, compact.data)
+
+    def test_promote_accepts_landscape_maps(self, parent: CARLandscape) -> None:
+        # zeros()/structure and restrict/promote all live in the same (nlocal + 1) space
+        local = LocalStokesLandscape(parent, jnp.array([0, 10, 29]))
+        promoted = local.promote(local.zeros())
+        assert promoted.shape == parent.shape
+        assert_array_equal(promoted.data, 0.0)
+
+    def test_restrict_promote_batch_axes(self, parent: CARLandscape) -> None:
+        # extra leading axes (e.g. frequency) are preserved; only the trailing
+        # parent.ndim axes are pixel axes
+        local = LocalStokesLandscape(parent, jnp.array([3, 7, 15, 19]))
+        nfreq = 2
+        sky = Stokes.class_for('QU').from_array(
+            jnp.arange(2 * nfreq * parent.size // 2, dtype=jnp.float64).reshape(
+                2, nfreq, *parent.shape
+            )
+        )
+        restricted = local.restrict(sky)
+        assert restricted.shape == (nfreq, local.nlocal + 1)
+        gi = local.global_indices
+        assert_array_equal(restricted.data[..., :-1], sky.data.reshape(2, nfreq, -1)[..., gi])
+        promoted = local.promote(restricted)
+        assert promoted.shape == (nfreq, *parent.shape)
+        assert_array_equal(
+            promoted.data.reshape(2, nfreq, -1)[..., gi], sky.data.reshape(2, nfreq, -1)[..., gi]
+        )
+
+    def test_get_coverage_matches_shape(self) -> None:
+        # base-class contract: coverage has shape self.shape; the sink slot counts the
+        # samples falling outside the subset
+        class _IdentityLandscape(StokesLandscape):
+            def world2pixel(self, theta, phi):
+                return theta, phi
+
+        parent = _IdentityLandscape((5, 2), 'I')
+        local = LocalStokesLandscape(parent, jnp.array([0, 3]))
+        # samples hit flat parent pixels [0, 3, 3, 1]; pixel 1 is outside the subset -> sink
+        samplings = Sampling(jnp.array([0.0, 1, 1, 1]), jnp.array([0.0, 1, 1, 0]), jnp.array(0.0))
+        coverage = local.get_coverage(samplings)
+        assert coverage.shape == local.shape
+        assert_array_equal(coverage, [1, 2, 1])
 
     @pytest.mark.parametrize(
         'indices',

--- a/tests/obs/test_pointing.py
+++ b/tests/obs/test_pointing.py
@@ -178,38 +178,50 @@ class TestLocalLandscape:
     """A PointingOperator on a LocalStokesLandscape matches the full-sky one."""
 
     @pytest.fixture
-    def setup(self):
+    def keys(self) -> jax.Array:
+        return jax.random.split(jax.random.key(11), 4)
+
+    @pytest.fixture
+    def p_full(self, keys: jax.Array) -> PointingOperator:
         parent = HealpixLandscape(NSIDE, 'IQU')
-        k1, k2, k3, k4 = jax.random.split(jax.random.PRNGKey(11), 4)
-        qbore = _random_unit_quats(k1, (NSAMP,))
-        qdet = _random_unit_quats(k2, (NDET,))
-        p_full = PointingOperator.create(parent, qbore, qdet)
-        sky = parent.normal(k3)
-        tod = jax.tree.map(lambda s: jax.random.normal(k4, s.shape, s.dtype), p_full.out_structure)
+        qbore = _random_unit_quats(keys[0], (NSAMP,))
+        qdet = _random_unit_quats(keys[1], (NDET,))
+        return PointingOperator.create(parent, qbore, qdet)
+
+    @pytest.fixture
+    def sky(self, p_full: PointingOperator, keys: jax.Array):
+        return p_full.landscape.normal(keys[2])
+
+    @pytest.fixture
+    def tod(self, p_full: PointingOperator, keys: jax.Array):
+        return ftree.normal_like(p_full.out_structure, keys[3])
+
+    @pytest.fixture
+    def covered(self, p_full: PointingOperator) -> jax.Array:
         # global pixels hit by the pointing: bin a ones-TOD (I accumulates 1 per hit)
         hits = p_full.T(ftree.ones_like(p_full.out_structure))
-        covered = jnp.flatnonzero(hits.i)
-        return parent, qbore, qdet, p_full, sky, tod, covered
+        return jnp.flatnonzero(hits.i)
 
-    def test_mv_matches_full_sky(self, setup) -> None:
-        parent, qbore, qdet, p_full, sky, tod, covered = setup
-        local = LocalStokesLandscape(parent, covered)
-        p_local = PointingOperator.create(local, qbore, qdet)
+    @staticmethod
+    def _local_operator(
+        p_full: PointingOperator, indices: jax.Array
+    ) -> tuple[LocalStokesLandscape, PointingOperator]:
+        local = LocalStokesLandscape(p_full.landscape, indices)
+        return local, PointingOperator.create(local, p_full.qbore, p_full.qdet)
+
+    def test_mv_matches_full_sky(self, p_full, sky, covered) -> None:
+        local, p_local = self._local_operator(p_full, covered)
         assert tree_equal(p_local(local.restrict(sky)), p_full(sky), rtol=1e-13)
 
-    def test_transpose_matches_full_sky(self, setup) -> None:
-        parent, qbore, qdet, p_full, sky, tod, covered = setup
-        local = LocalStokesLandscape(parent, covered)
-        p_local = PointingOperator.create(local, qbore, qdet)
+    def test_transpose_matches_full_sky(self, p_full, tod, covered) -> None:
+        local, p_local = self._local_operator(p_full, covered)
         # uncovered pixels are zero in both the full binning and the promoted local one
         assert tree_equal(local.promote(p_local.T(tod)), p_full.T(tod), rtol=1e-13)
 
-    def test_partial_coverage_sinks_missing_pixels(self, setup) -> None:
-        parent, qbore, qdet, p_full, sky, tod, covered = setup
+    def test_partial_coverage_sinks_missing_pixels(self, p_full, tod, covered) -> None:
         # keep only half the covered pixels: samples on dropped pixels land in the sink
         subset = covered[::2]
-        local = LocalStokesLandscape(parent, subset)
-        p_local = PointingOperator.create(local, qbore, qdet)
+        local, p_local = self._local_operator(p_full, subset)
         binned_local = local.promote(p_local.T(tod)).data
         binned_full = p_full.T(tod).data
         # transposes agree on the subset pixels; the sink contributions are discarded

--- a/tests/obs/test_pointing.py
+++ b/tests/obs/test_pointing.py
@@ -177,28 +177,29 @@ def test_expanded_interpolate_preserves_rotation_fusion() -> None:
 class TestLocalLandscape:
     """A PointingOperator on a LocalStokesLandscape matches the full-sky one."""
 
-    @pytest.fixture
+    @pytest.fixture(scope='class')
     def keys(self) -> jax.Array:
         return jax.random.split(jax.random.key(11), 4)
 
-    @pytest.fixture
-    def p_full(self, keys: jax.Array) -> PointingOperator:
+    @pytest.fixture(scope='class', params=[False, True], ids=['nearest', 'bilinear'])
+    def p_full(self, request: pytest.FixtureRequest, keys: jax.Array) -> PointingOperator:
         parent = HealpixLandscape(NSIDE, 'IQU')
         qbore = _random_unit_quats(keys[0], (NSAMP,))
         qdet = _random_unit_quats(keys[1], (NDET,))
-        return PointingOperator.create(parent, qbore, qdet)
+        return PointingOperator.create(parent, qbore, qdet, interpolate=request.param)
 
-    @pytest.fixture
+    @pytest.fixture(scope='class')
     def sky(self, p_full: PointingOperator, keys: jax.Array):
         return p_full.landscape.normal(keys[2])
 
-    @pytest.fixture
+    @pytest.fixture(scope='class')
     def tod(self, p_full: PointingOperator, keys: jax.Array):
         return ftree.normal_like(p_full.out_structure, keys[3])
 
-    @pytest.fixture
+    @pytest.fixture(scope='class')
     def covered(self, p_full: PointingOperator) -> jax.Array:
-        # global pixels hit by the pointing: bin a ones-TOD (I accumulates 1 per hit)
+        # global pixels hit by the pointing: bin a ones-TOD (I accumulates 1 per hit for
+        # nearest, the interpolation weights for bilinear)
         hits = p_full.T(ftree.ones_like(p_full.out_structure))
         return jnp.flatnonzero(hits.i)
 
@@ -207,23 +208,41 @@ class TestLocalLandscape:
         p_full: PointingOperator, indices: jax.Array
     ) -> tuple[LocalStokesLandscape, PointingOperator]:
         local = LocalStokesLandscape(p_full.landscape, indices)
-        return local, PointingOperator.create(local, p_full.qbore, p_full.qdet)
+        p_local = PointingOperator.create(
+            local, p_full.qbore, p_full.qdet, interpolate=p_full.interpolate
+        )
+        return local, p_local
 
-    def test_mv_matches_full_sky(self, p_full, sky, covered) -> None:
-        local, p_local = self._local_operator(p_full, covered)
+    @pytest.fixture(scope='class')
+    def full_coverage(
+        self, p_full: PointingOperator, covered: jax.Array
+    ) -> tuple[LocalStokesLandscape, PointingOperator]:
+        return self._local_operator(p_full, covered)
+
+    @pytest.fixture(scope='class')
+    def half_coverage(
+        self, p_full: PointingOperator, covered: jax.Array
+    ) -> tuple[LocalStokesLandscape, PointingOperator]:
+        # samples on the dropped pixels land in the sink
+        return self._local_operator(p_full, covered[::2])
+
+    def test_mv_matches_full_sky(self, p_full, sky, full_coverage) -> None:
+        local, p_local = full_coverage
         assert tree_equal(p_local(local.restrict(sky)), p_full(sky), rtol=1e-13)
 
-    def test_transpose_matches_full_sky(self, p_full, tod, covered) -> None:
-        local, p_local = self._local_operator(p_full, covered)
+    def test_transpose_matches_full_sky(self, p_full, tod, full_coverage) -> None:
+        local, p_local = full_coverage
         # uncovered pixels are zero in both the full binning and the promoted local one
         assert tree_equal(local.promote(p_local.T(tod)), p_full.T(tod), rtol=1e-13)
 
-    def test_partial_coverage_sinks_missing_pixels(self, p_full, tod, covered) -> None:
-        # keep only half the covered pixels: samples on dropped pixels land in the sink
-        subset = covered[::2]
-        local, p_local = self._local_operator(p_full, subset)
+    def test_partial_coverage_sinks_missing_pixels(self, p_full, tod, half_coverage) -> None:
+        local, p_local = half_coverage
+        subset = local.global_indices
         binned_local = local.promote(p_local.T(tod)).data
-        binned_full = p_full.T(tod).data
-        # transposes agree on the subset pixels; the sink contributions are discarded
-        assert_array_almost_equal(binned_local[:, subset], binned_full[:, subset], decimal=13)
+        if not p_full.interpolate:
+            # nearest: contributions to kept pixels are identical, sink ones are discarded
+            # (bilinear renormalizes the weights over covered neighbors, so values differ)
+            binned_full = p_full.T(tod).data
+            assert_array_almost_equal(binned_local[:, subset], binned_full[:, subset], decimal=13)
+        # nothing lands outside the subset
         assert_array_equal(binned_local.at[:, subset].set(0.0), 0.0)

--- a/tests/obs/test_pointing.py
+++ b/tests/obs/test_pointing.py
@@ -2,11 +2,17 @@ import jax
 import jax.numpy as jnp
 import pytest
 from equinox import tree_equal
-from numpy.testing import assert_array_almost_equal
+from numpy.testing import assert_array_almost_equal, assert_array_equal
 
 import furax.tree as ftree
 from furax.core import AbstractLinearOperator, CompositionOperator
-from furax.obs.landscapes import CARLandscape, HealpixLandscape, StokesLandscape, WCSProjection
+from furax.obs.landscapes import (
+    CARLandscape,
+    HealpixLandscape,
+    LocalStokesLandscape,
+    StokesLandscape,
+    WCSProjection,
+)
 from furax.obs.operators import QURotationOperator
 from furax.obs.pointing import PointingOperator
 from furax.obs.stokes import ValidStokesLiteral
@@ -166,3 +172,46 @@ def test_expanded_interpolate_preserves_rotation_fusion() -> None:
 
     tod = jax.tree.map(lambda s: jax.random.normal(key4, s.shape, s.dtype), expanded.out_structure)
     assert tree_equal((outer @ expanded)(op.T(tod)), reduced(op.T(tod)), rtol=1e-10)
+
+
+class TestLocalLandscape:
+    """A PointingOperator on a LocalStokesLandscape matches the full-sky one."""
+
+    @pytest.fixture
+    def setup(self):
+        parent = HealpixLandscape(NSIDE, 'IQU')
+        k1, k2, k3, k4 = jax.random.split(jax.random.PRNGKey(11), 4)
+        qbore = _random_unit_quats(k1, (NSAMP,))
+        qdet = _random_unit_quats(k2, (NDET,))
+        p_full = PointingOperator.create(parent, qbore, qdet)
+        sky = parent.normal(k3)
+        tod = jax.tree.map(lambda s: jax.random.normal(k4, s.shape, s.dtype), p_full.out_structure)
+        # global pixels hit by the pointing: bin a ones-TOD (I accumulates 1 per hit)
+        hits = p_full.T(ftree.ones_like(p_full.out_structure))
+        covered = jnp.flatnonzero(hits.i)
+        return parent, qbore, qdet, p_full, sky, tod, covered
+
+    def test_mv_matches_full_sky(self, setup) -> None:
+        parent, qbore, qdet, p_full, sky, tod, covered = setup
+        local = LocalStokesLandscape(parent, covered)
+        p_local = PointingOperator.create(local, qbore, qdet)
+        assert tree_equal(p_local(local.restrict(sky)), p_full(sky), rtol=1e-13)
+
+    def test_transpose_matches_full_sky(self, setup) -> None:
+        parent, qbore, qdet, p_full, sky, tod, covered = setup
+        local = LocalStokesLandscape(parent, covered)
+        p_local = PointingOperator.create(local, qbore, qdet)
+        # uncovered pixels are zero in both the full binning and the promoted local one
+        assert tree_equal(local.promote(p_local.T(tod)), p_full.T(tod), rtol=1e-13)
+
+    def test_partial_coverage_sinks_missing_pixels(self, setup) -> None:
+        parent, qbore, qdet, p_full, sky, tod, covered = setup
+        # keep only half the covered pixels: samples on dropped pixels land in the sink
+        subset = covered[::2]
+        local = LocalStokesLandscape(parent, subset)
+        p_local = PointingOperator.create(local, qbore, qdet)
+        binned_local = local.promote(p_local.T(tod)).data
+        binned_full = p_full.T(tod).data
+        # transposes agree on the subset pixels; the sink contributions are discarded
+        assert_array_almost_equal(binned_local[:, subset], binned_full[:, subset], decimal=13)
+        assert_array_equal(binned_local.at[:, subset].set(0.0), 0.0)


### PR DESCRIPTION
## Summary

Revival of #66.

The mapmaker still uses the full landscape for now. Migration will be done in a follow-up.

## Checklist

- [x] Tests added/updated for new or changed behavior
- [x] `uvx prek run -a` passes (ruff, mypy, etc.)
- [x] Added a changelog entry under `[Unreleased]` in `docs/development/changelog.md`, or this PR doesn't need one (e.g. internal refactor, CI-only change)
- [x] Updated docs for user-facing changes (docstrings, `docs/`)
