### PR TITLE
Restrict bilinear pointing to the ML solver, and let ML run with any weighting mode

### DIFF
--- a/docs/development/changelog.md
+++ b/docs/development/changelog.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Split long API documentation pages (#179)
 - Improve `MapMakingConfig` documentation and add examples (#179)
 - Generalise `XSamplingOperator` to cache world angles, enabling precomputed bilinear pointing for HEALPix (#183)
+- Allow the ML mapmaker to run with any weighting mode (identity/diagonal/Toeplitz), and restrict bilinear pointing to the ML solver (the direct binned solvers now raise on bilinear)
 
 ### Fixed
 

--- a/docs/development/changelog.md
+++ b/docs/development/changelog.md
@@ -19,7 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Split long API documentation pages (#179)
 - Improve `MapMakingConfig` documentation and add examples (#179)
 - Generalise `XSamplingOperator` to cache world angles, enabling precomputed bilinear pointing for HEALPix (#183)
-- Allow the ML mapmaker to run with any weighting mode (identity/diagonal/Toeplitz), and restrict bilinear pointing to the ML solver (the direct binned solvers now raise on bilinear)
+- Allow the ML mapmaker to run with any weighting mode (identity/diagonal/Toeplitz), and restrict bilinear pointing to the ML solver (the direct binned solvers now raise on bilinear) (#187)
 
 ### Fixed
 

--- a/src/furax/mapmaking/mapmaker.py
+++ b/src/furax/mapmaking/mapmaker.py
@@ -6,7 +6,7 @@ from functools import cached_property
 from logging import Logger
 from math import prod
 from pathlib import Path
-from typing import Any, Generic, TypeVar
+from typing import Any, ClassVar, Generic, TypeVar
 
 import equinox as eqx
 import jax
@@ -604,8 +604,18 @@ class MapMaker:
     config: MapMakingConfig
     logger: Logger = furax_logger
 
+    # Whether this mapmaker solves the map system iteratively (full pixel coupling). Only such
+    # solvers may use bilinear pointing; the direct block-diagonal binners drop the off-diagonal
+    # pixel coupling that interpolation introduces and would return a biased map.
+    supports_bilinear_pointing: ClassVar[bool] = False
+
     def __post_init__(self) -> None:
-        return
+        if self.config.pointing.interpolation == 'bilinear' and not self.supports_bilinear_pointing:
+            raise ValueError(
+                f'{type(self).__name__} does not support bilinear pointing: the direct binned '
+                'solver ignores the off-diagonal pixel coupling that interpolation introduces and '
+                'would return a biased map. Use the ML mapmaker (method=ML) instead.'
+            )
 
     @abstractmethod
     def make_map(self, observation: AbstractGroundObservation[Any]) -> dict[str, Any]: ...
@@ -1086,12 +1096,14 @@ class BinnedMapMaker(MapMaker):
 class MLMapmaker(MapMaker):
     """Class for mapmaking with maximum likelihood (ML) estimator."""
 
+    # The ML estimator solves the full system iteratively, so it accepts any weighting mode
+    # (identity / diagonal / Toeplitz) and is the only mapmaker that may use bilinear pointing.
+    supports_bilinear_pointing: ClassVar[bool] = True
+
     def __post_init__(self) -> None:
         super().__post_init__()
 
         # Validation on config
-        if self.config.binned:
-            raise ValueError('ML Mapmaker is incompatible with binned=True')
         if self.config.demodulated:
             raise ValueError('ML Mapmaker is incompatible with demodulated=True')
 
@@ -1133,14 +1145,15 @@ class MLMapmaker(MapMaker):
         logger_info('Created noise and inverse noise covariance operators')
 
         # Approximate system matrix with diagonal noise covariance and full map pixels
-        if config.weighting.mode == WeightingMode.IDENTITY:
-            diag_inv_noise = inv_noise
-        elif isinstance(inv_noise, SymmetricBandToeplitzOperator):
+        diag_inv_noise: AbstractLinearOperator
+        if isinstance(inv_noise, SymmetricBandToeplitzOperator):
+            # Correlated (Toeplitz) weighting: use the zero-lag (diagonal) band value.
             diag_inv_noise = DiagonalOperator(
                 inv_noise.band_values[..., [0]], in_structure=data_struct
             )
         else:
-            raise NotImplementedError
+            # Identity / diagonal (white) weighting: the inverse-noise operator is already diagonal.
+            diag_inv_noise = inv_noise
         diag_system = BJPreconditioner.create(acquisition.T @ diag_inv_noise @ masker @ acquisition)
         logger_info('Created approximate system matrix')
 

--- a/src/furax/mapmaking/mapmaker.py
+++ b/src/furax/mapmaking/mapmaker.py
@@ -604,10 +604,12 @@ class MapMaker:
     config: MapMakingConfig
     logger: Logger = furax_logger
 
-    # Whether this mapmaker solves the map system iteratively (full pixel coupling). Only such
-    # solvers may use bilinear pointing; the direct block-diagonal binners drop the off-diagonal
-    # pixel coupling that interpolation introduces and would return a biased map.
     supports_bilinear_pointing: ClassVar[bool] = False
+    """Whether this mapmaker solves the map system iteratively (full pixel coupling).
+
+    Only such solvers may use bilinear pointing; the direct block-diagonal binners drop the
+    off-diagonal pixel coupling that interpolation introduces and would return a biased map.
+    """
 
     def __post_init__(self) -> None:
         if self.config.pointing.interpolation == 'bilinear' and not self.supports_bilinear_pointing:
@@ -1096,9 +1098,8 @@ class BinnedMapMaker(MapMaker):
 class MLMapmaker(MapMaker):
     """Class for mapmaking with maximum likelihood (ML) estimator."""
 
-    # The ML estimator solves the full system iteratively, so it accepts any weighting mode
-    # (identity / diagonal / Toeplitz) and is the only mapmaker that may use bilinear pointing.
     supports_bilinear_pointing: ClassVar[bool] = True
+    """The ML solve is iterative, so it accounts for the pixel coupling from interpolation."""
 
     def __post_init__(self) -> None:
         super().__post_init__()
@@ -1151,9 +1152,13 @@ class MLMapmaker(MapMaker):
             diag_inv_noise = DiagonalOperator(
                 inv_noise.band_values[..., [0]], in_structure=data_struct
             )
-        else:
-            # Identity / diagonal (white) weighting: the inverse-noise operator is already diagonal.
+        elif inv_noise.is_diagonal:
+            # Identity / diagonal (white) weighting.
             diag_inv_noise = inv_noise
+        else:
+            raise NotImplementedError(
+                f'Cannot approximate {type(inv_noise).__name__} by a diagonal operator.'
+            )
         diag_system = BJPreconditioner.create(acquisition.T @ diag_inv_noise @ masker @ acquisition)
         logger_info('Created approximate system matrix')
 

--- a/tests/mapmaking/test_mapmaker.py
+++ b/tests/mapmaking/test_mapmaker.py
@@ -29,7 +29,13 @@ from furax.mapmaking.config import (
     WeightingConfig,
     WeightingMode,
 )
-from furax.mapmaking.mapmaker import MLMapmaker, get_obs_distribution_to_process
+from furax.mapmaking.mapmaker import (
+    ATOPMapMaker,
+    BinnedMapMaker,
+    MLMapmaker,
+    TwoStepMapmaker,
+    get_obs_distribution_to_process,
+)
 from furax.mapmaking.noise import WhiteNoiseModel
 from furax.obs.landscapes import ProjectionType
 from furax.obs.stokes import ValidStokesLiteral
@@ -422,6 +428,51 @@ class TestSingleObsTemplates:
         for key, value in res.items():
             if key.startswith('template_') and not key.startswith('template_reg'):
                 assert bool(jnp.all(jnp.isfinite(value))), key
+
+
+class TestSingleObsSolverGuards:
+    """Solver/weighting compatibility on the single-observation ``MapMaker`` path.
+
+    The direct binned solvers invert only the per-pixel (block-Jacobi) system, which is exact for
+    nearest-neighbour pointing but drops the off-diagonal pixel coupling that bilinear interpolation
+    introduces -- so bilinear pointing is restricted to the iterative ML solver. The ML solver in
+    turn accepts any weighting mode (identity / diagonal / Toeplitz), not just Toeplitz.
+    """
+
+    def _config(
+        self,
+        mode: WeightingMode,
+        interpolation: Literal['nearest', 'bilinear'] = 'nearest',
+        method: Methods = Methods.MAXL,
+    ) -> MapMakingConfig:
+        return MapMakingConfig(
+            method=method,
+            pointing=PointingConfig(on_the_fly=True, interpolation=interpolation),
+            landscape=LandscapeConfig(stokes='IQU', healpix=HealpixConfig(nside=8)),
+            # PRECOMPUTED sidesteps fitting a model to the synthetic white TODs (yields NaN).
+            weighting=WeightingConfig(mode=mode, source=NoiseSource.PRECOMPUTED),
+        )
+
+    @pytest.mark.parametrize('mode', [WeightingMode.IDENTITY, WeightingMode.DIAGONAL])
+    def test_ml_mapmaker_accepts_diagonal_weighting(self, mode):
+        """ML runs with identity/diagonal weighting (previously rejected via ``binned=True``)."""
+        obs = FakeGroundObservation(n_dets=4, n_samples=1024, sample_rate=100.0)
+        res = MLMapmaker(config=self._config(mode)).make_map(obs)
+        assert bool(jnp.all(jnp.isfinite(res['map'])))
+
+    def test_ml_mapmaker_accepts_bilinear_pointing(self):
+        """Bilinear pointing runs under the ML solver."""
+        obs = FakeGroundObservation(n_dets=4, n_samples=1024, sample_rate=100.0)
+        cfg = self._config(WeightingMode.IDENTITY, interpolation='bilinear')
+        res = MLMapmaker(config=cfg).make_map(obs)
+        assert bool(jnp.all(jnp.isfinite(res['map'])))
+
+    @pytest.mark.parametrize('maker_cls', [BinnedMapMaker, TwoStepMapmaker, ATOPMapMaker])
+    def test_direct_solvers_reject_bilinear_pointing(self, maker_cls):
+        """The direct binned solvers refuse bilinear pointing at construction time."""
+        cfg = self._config(WeightingMode.DIAGONAL, interpolation='bilinear', method=Methods.BINNED)
+        with pytest.raises(ValueError, match='does not support bilinear pointing'):
+            maker_cls(config=cfg)
 
 
 class TestGapTreatmentMapMaker:

--- a/tests/mapmaking/test_mapmaker.py
+++ b/tests/mapmaking/test_mapmaker.py
@@ -32,6 +32,7 @@ from furax.mapmaking.config import (
 from furax.mapmaking.mapmaker import (
     ATOPMapMaker,
     BinnedMapMaker,
+    MapMaker,
     MLMapmaker,
     TwoStepMapmaker,
     get_obs_distribution_to_process,
@@ -454,13 +455,13 @@ class TestSingleObsSolverGuards:
         )
 
     @pytest.mark.parametrize('mode', [WeightingMode.IDENTITY, WeightingMode.DIAGONAL])
-    def test_ml_mapmaker_accepts_diagonal_weighting(self, mode):
+    def test_ml_mapmaker_accepts_diagonal_weighting(self, mode: WeightingMode) -> None:
         """ML runs with identity/diagonal weighting (previously rejected via ``binned=True``)."""
         obs = FakeGroundObservation(n_dets=4, n_samples=1024, sample_rate=100.0)
         res = MLMapmaker(config=self._config(mode)).make_map(obs)
         assert bool(jnp.all(jnp.isfinite(res['map'])))
 
-    def test_ml_mapmaker_accepts_bilinear_pointing(self):
+    def test_ml_mapmaker_accepts_bilinear_pointing(self) -> None:
         """Bilinear pointing runs under the ML solver."""
         obs = FakeGroundObservation(n_dets=4, n_samples=1024, sample_rate=100.0)
         cfg = self._config(WeightingMode.IDENTITY, interpolation='bilinear')
@@ -468,7 +469,7 @@ class TestSingleObsSolverGuards:
         assert bool(jnp.all(jnp.isfinite(res['map'])))
 
     @pytest.mark.parametrize('maker_cls', [BinnedMapMaker, TwoStepMapmaker, ATOPMapMaker])
-    def test_direct_solvers_reject_bilinear_pointing(self, maker_cls):
+    def test_direct_solvers_reject_bilinear_pointing(self, maker_cls: type[MapMaker]) -> None:
         """The direct binned solvers refuse bilinear pointing at construction time."""
         cfg = self._config(WeightingMode.DIAGONAL, interpolation='bilinear', method=Methods.BINNED)
         with pytest.raises(ValueError, match='does not support bilinear pointing'):


### PR DESCRIPTION
## Motivation

Two coupled problems on the single-observation mapmaking path.

**Bilinear pointing silently produced a biased map under the direct binned solvers.** `BinnedMapMaker.make_map` builds the system as a block-Jacobi preconditioner and inverts it directly (`system.inverse() @ binner`). `BJPreconditioner` forms only the per-pixel Stokes blocks (3x3 for IQU) of `AᵀN⁻¹A` and inverts each independently, which is the exact inverse *only* when `AᵀN⁻¹A` is genuinely block-diagonal in pixel space, i.e. for nearest-neighbour pointing where each sample maps to exactly one pixel. With bilinear interpolation each sample spreads over four neighbouring pixels, so `AᵀN⁻¹A` gains off-diagonal pixel-pixel coupling that block-Jacobi discards. The result was a wrong map with no error and no warning. The ML estimator instead performs a full CG solve of the coupled system and handles this correctly.

**But the ML mapmaker refused to instantiate with identity or diagonal weighting.** `MapMakingConfig.binned` is derived, not independent: it returns `weighting.diagonal_matrix`, which is `mode != WeightingMode.TOEPLITZ`. So `IDENTITY` and `DIAGONAL` both force `config.binned == True`, and `MLMapmaker.__post_init__` raised `ValueError('ML Mapmaker is incompatible with binned=True')`. Net effect: ML only ever instantiated with Toeplitz weighting, so the very solver that bilinear pointing requires was unreachable for the simplest noise models. The single `binned` flag was conflating two orthogonal concerns: whether the inverse-noise weighting is diagonal (which correctly drives the noise-model class), and which solver to use.

## Changes

- **`MapMaker` gains `supports_bilinear_pointing: ClassVar[bool] = False`**, and its `__post_init__` raises `ValueError` when `config.pointing.interpolation == 'bilinear'` and the concrete mapmaker does not support it. `MLMapmaker` sets it `True`; `BinnedMapMaker`, `TwoStepMapmaker` and `ATOPMapMaker` inherit `False`, so bilinear under any direct solver is now a hard error at construction time with a message pointing at `method=ML`.
- **Removed the `binned=True` guard from `MLMapmaker.__post_init__`.** ML now accepts identity, diagonal and Toeplitz weighting. `config.binned` itself is unchanged: it still means "the weighting is diagonal", which is what it is actually used for elsewhere.
- **Extended the ML `diag_inv_noise` branch** used to build the approximate (block-Jacobi) system matrix. It previously special-cased identity, handled `SymmetricBandToeplitzOperator`, and raised `NotImplementedError` otherwise. It now takes the zero-lag band value for Toeplitz weighting, uses the inverse-noise operator directly when it is already diagonal (checked via the operator tag system, `inv_noise.is_diagonal`, which covers both `DiagonalOperator` and `IdentityOperator`), and raises `NotImplementedError` with the offending operator type otherwise. This is what makes `DIAGONAL` work, not just `IDENTITY`, while keeping the failure loud for any future non-diagonal, non-Toeplitz inverse-noise operator — those blocks are not merely a preconditioner, they also drive pixel selection via `get_pixel_selector`.

`MultiObservationMapMaker` is deliberately left untouched. It is not a `MapMaker` subclass and always performs a full iterative PCG solve on the coupled system, with block-Jacobi confined to the preconditioner, so bilinear pointing is already correct there and needs no guard.

## Verification

Verified directly that for a bilinear `PointingOperator` with identity weighting, `A = PᵀP` carries genuine off-diagonal pixel coupling, yet `furax.linalg.cg(A, b, preconditioner=BJ.I)` converges in 30 iterations to a relative residual of about 5e-11 and matches a dense `np.linalg.solve` to about 5e-10 — confirming that the block-Jacobi approximation is harmless in the preconditioner but not as a direct inverse.

New test class `TestSingleObsSolverGuards` in `tests/mapmaking/test_mapmaker.py`: ML runs and returns a finite map with identity and diagonal weighting (parametrized) and with bilinear pointing; `BinnedMapMaker`, `TwoStepMapmaker` and `ATOPMapMaker` each raise on bilinear at construction (parametrized).

Full test suite green: 2152 passed, 11 skipped, 4 xfailed. Ruff check, ruff format and mypy are clean on the touched files.

## Notes 

`config.method` is essentially cosmetic in the multi-observation path — only `Methods.ATOP` changes behaviour there, so `BINNED`, `MAXL` and `TWOSTEP` are indistinguishable to `MultiObservationMapMaker`. That means `method=BINNED` denotes a direct block-diagonal inversion in the single-observation path but a full iterative PCG solve in the multi-observation path. That asymmetry predates this PR and is left as-is; a follow-up could warn on inconsistent method/weighting combinations.
