### PR TITLE
Overhaul streaming module

### DIFF
--- a/docs/api/mapmaking/streaming.md
+++ b/docs/api/mapmaking/streaming.md
@@ -1,0 +1,6 @@
+# Streaming
+
+::: furax.mapmaking.streaming
+    options:
+      show_root_heading: false
+      members_order: source

--- a/docs/development/changelog.md
+++ b/docs/development/changelog.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `StreamOperator` that mixes stacked and shared components in one operator, with `stream_block_row`/`stream_block_column` constructors so a block system spanning both fuses into a single streaming scan (#190)
+
 ## [0.12.0] - 2026-07-24
 
 This version drops support for Python 3.11 following the latest JAX release (0.11.0).

--- a/docs/development/changelog.md
+++ b/docs/development/changelog.md
@@ -15,8 +15,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - **Breaking:** the four stream operator classes collapse into a single `StreamOperator` (#190):
-    - `StreamDiagonalOperator.create(op)` → `StreamOperator.diagonal(op)`, and likewise `.column`, `.row`, `.addition`
-    - `in_stacked`/`out_stacked` say which side carries the stream axis, per component, so one stream can mix shared and per-slice components
+  - `StreamDiagonalOperator.create(op)` → `StreamOperator.diagonal(op)`, and likewise `.column`, `.row`, `.addition`
+  - `in_stacked`/`out_stacked` say which side carries the stream axis, per component, so one stream can mix shared and per-slice components
 - **Breaking:** `AbstractLinearOperator.__call__`, `BJPreconditioner.create`, and the `LBSObservation`/`ToastObservation` pointing helpers now raise `TypeError` (previously `ValueError`/`RuntimeError`) for invalid argument/operator/landscape types (#194)
 - Bumped ruff to 0.16.1 and updated rule selection accordingly (#194)
 

--- a/docs/development/changelog.md
+++ b/docs/development/changelog.md
@@ -7,8 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `StreamOperator.block_row`/`block_column`: fuse several streams into one, evaluating a joint system in a single pass over the data (#190)
+- API reference page for `furax.mapmaking.streaming` (#190)
+
 ### Changed
 
+- **Breaking:** the four stream operator classes collapse into a single `StreamOperator` (#190):
+    - `StreamDiagonalOperator.create(op)` → `StreamOperator.diagonal(op)`, and likewise `.column`, `.row`, `.addition`
+    - `in_stacked`/`out_stacked` say which side carries the stream axis, per component, so one stream can mix shared and per-slice components
 - **Breaking:** `AbstractLinearOperator.__call__`, `BJPreconditioner.create`, and the `LBSObservation`/`ToastObservation` pointing helpers now raise `TypeError` (previously `ValueError`/`RuntimeError`) for invalid argument/operator/landscape types (#194)
 - Bumped ruff to 0.16.1 and updated rule selection accordingly (#194)
 
@@ -285,7 +293,8 @@ Initial tagged release.
 
 - Project classifiers and editable-mode installation instructions
 
-[unreleased]: https://github.com/CMBSciPol/furax/compare/v0.11.4...HEAD
+[unreleased]: https://github.com/CMBSciPol/furax/compare/v0.12.0...HEAD
+[0.12.0]: https://github.com/CMBSciPol/furax/compare/v0.11.4...v0.12.0
 [0.11.4]: https://github.com/CMBSciPol/furax/compare/v0.11.3...v0.11.4
 [0.11.3]: https://github.com/CMBSciPol/furax/compare/v0.11.2...v0.11.3
 [0.11.2]: https://github.com/CMBSciPol/furax/compare/v0.11.1...v0.11.2

--- a/src/furax/mapmaking/mapmaker.py
+++ b/src/furax/mapmaking/mapmaker.py
@@ -70,7 +70,7 @@ from .gap_filling import gap_fill
 from .noise import AtmosphericNoiseModel, NoiseModel, WhiteNoiseModel
 from .preconditioner import BJPreconditioner
 from .results import MapMakingResults
-from .streaming import StreamColumnOperator, StreamDiagonalOperator
+from .streaming import StreamOperator
 from .templates import PerDetectorTemplate
 from .weight import WeightOperator
 
@@ -405,13 +405,13 @@ class MultiObservationMapMaker[T]:
     def get_system_operator(
         self, model: ObservationModel, *, diag: bool = False
     ) -> AbstractLinearOperator:
-        H = StreamColumnOperator.create(model.H)
+        H = StreamOperator.column(model.H)
         # filter_vmap: array leaves mapped, static fields held
         weight = eqx.filter_vmap(ObservationModel.diag_W)(model) if diag else model.W
-        W = StreamDiagonalOperator.create(weight)
+        W = StreamOperator.diagonal(weight)
         # specify leading axis dimension because F can be trivial
         _, n_own, n_pad = self.obs_distribution
-        F = StreamDiagonalOperator.create(model.F, n_lead=n_own + n_pad)
+        F = StreamOperator.diagonal(model.F, n_lead=n_own + n_pad)
         return (H.T @ W @ F @ H).reduce()
 
     def pixel_selection(

--- a/src/furax/mapmaking/streaming.py
+++ b/src/furax/mapmaking/streaming.py
@@ -1,4 +1,4 @@
-"""Operators that stream a per-observation operator across a sharded observation axis."""
+"""Operators that stream a batched operator slice-by-slice across a sharded leading axis."""
 
 import functools
 from abc import ABC
@@ -36,11 +36,14 @@ __all__ = [
 ]
 
 type StackSpec = bool | PyTree[bool]
-"""Obs-stackedness of a structure: a bare bool (uniform) or a prefix pytree of bools."""
+"""Per-component stackedness of a structure: a bare bool (uniform) or a prefix pytree of bools."""
 
 
 class StreamSegment(eqx.Module):
-    """One segment of a stream body."""
+    """One segment of a stream body.
+
+    A *stacked* segment is sliced along the batch axis; a *shared* one is broadcast to all slices.
+    """
 
     operator: AbstractLinearOperator
     stacked: bool = eqx.field(static=True)
@@ -68,41 +71,40 @@ class StreamSegment(eqx.Module):
 class AbstractStreamOperator(AbstractLinearOperator, ABC):
     """Base class for operators that apply a batched pytree operator slice-by-slice via scan.
 
-    The effective per-observation operator is stored as a list of "segments" ([`StreamSegment`][]).
-    Segments are in composition (left-to-right) order: segments[0] is applied last (output side),
-    segments[-1] first (input side). Each segment is tagged obs-*stacked* (sliced per observation)
-    or *shared* (broadcast across observations).
+    "Stacked" appears in two independent roles here:
 
-    `in_stacked`/`out_stacked` say which *components* of the input/output carry the observation
-    axis, as a [`StackSpec`][]: a bare bool applies to the whole structure, a prefix pytree of
-    bools resolves per component. A stacked component is sliced on input and stacked on output; a
-    shared component is broadcast on input and sum-reduced (scan carry, then `psum`) on output.
-    The four uniform combinations are the named subclasses:
+    - *Segments* ([`StreamSegment`][]) are the links of the per-slice operator, held in composition
+      order (segments[0] applied last, segments[-1] first). Each is tagged *stacked* (its arrays
+      carry the batch axis, sliced per scan step) or *shared* (broadcast, applied identically every
+      step). These describe the scan body's interior.
+    - `in_stacked`/`out_stacked` ([`StackSpec`][]) tag the boundary instead: which *components* of
+      the input/output carry the batch axis. A bare bool covers the whole structure, a prefix pytree
+      resolves per component. A stacked component is sliced on input / stacked on output; a shared
+      one is broadcast on input / sum-reduced (scan carry, then `psum`) on output.
 
-    | in_stacked | out_stacked | class                    | signature       |
-    |------------|-------------|--------------------------|-----------------|
+    The two are independent: a stacked segment may sit between shared boundary components (e.g.
+    `StreamAdditionOperator`). The four uniform boundary combinations are the named subclasses;
+    anything mixed is a [`StreamOperator`][]:
+
+    | in_stacked | out_stacked | class                        | signature         |
+    |------------|-------------|------------------------------|-------------------|
     | True       | True        | [`StreamDiagonalOperator`][] | (N,in) -> (N,out) |
     | False      | True        | [`StreamColumnOperator`][]   | (in,)  -> (N,out) |
     | True       | False       | [`StreamRowOperator`][]      | (N,in) -> (out,)  |
     | False      | False       | [`StreamAdditionOperator`][] | (in,)  -> (out,)  |
-
-    Anything mixed is a [`StreamOperator`][], e.g. a joint sky (shared) + per-observation
-    amplitude (stacked) system, whose single scan computes each observation's data once and
-    feeds both legs.
 
     An active mesh context is required when calling `mv`; use `jax.set_mesh` beforehand.
     """
 
     segments: tuple[StreamSegment, ...]
     n_lead: int = field(kw_only=True, metadata={'static': True})
-    # Static like `in_structure`, and holding pytrees just like it: never hashed (operators are
-    # closed over by the solvers, not passed as jit arguments).
     in_stacked: StackSpec = field(kw_only=True, metadata={'static': True})
     out_stacked: StackSpec = field(kw_only=True, metadata={'static': True})
 
-    # Class-canonical uniform specs; None on StreamOperator, which requires explicit specs.
-    _uniform_in: ClassVar[bool | None] = None
-    _uniform_out: ClassVar[bool | None] = None
+    # Default boundary specs `_build` fills in when the caller omits them. Each named subclass
+    # sets its fixed pair; None here (kept on StreamOperator) forces the caller to pass specs.
+    _default_in_stacked: ClassVar[bool | None] = None
+    _default_out_stacked: ClassVar[bool | None] = None
 
     @classmethod
     def create(
@@ -111,8 +113,8 @@ class AbstractStreamOperator(AbstractLinearOperator, ABC):
         """Wrap a freshly stacked operator as a block with a single stacked segment.
 
         Args:
-            operator: The per-observation operator, stacked along a leading (observation) axis.
-            n_lead: The observation-axis size. If not explicitly provided, is inferred from the
+            operator: The per-slice operator, stacked along a leading (batch) axis.
+            n_lead: The batch-axis size. If not explicitly provided, is inferred from the
                 operator leaves. Required if the operator has no array leaves.
         """
         if n_lead is None:
@@ -129,8 +131,8 @@ class AbstractStreamOperator(AbstractLinearOperator, ABC):
         out_stacked: StackSpec | None = None,
     ) -> 'AbstractStreamOperator':
         """Build from segments, defaulting the specs to the class's uniform ones."""
-        in_stacked = cls._uniform_in if in_stacked is None else in_stacked
-        out_stacked = cls._uniform_out if out_stacked is None else out_stacked
+        in_stacked = cls._default_in_stacked if in_stacked is None else in_stacked
+        out_stacked = cls._default_out_stacked if out_stacked is None else out_stacked
         if in_stacked is None or out_stacked is None:
             raise TypeError(f'{cls.__name__} requires explicit in_stacked/out_stacked')
         return _build_stream(
@@ -139,58 +141,62 @@ class AbstractStreamOperator(AbstractLinearOperator, ABC):
 
     @property
     def out_structure(self) -> PyTree[jax.ShapeDtypeStruct]:
-        per_obs_out = self.segments[0].out_structure  # leftmost segment is applied last
-        return _expand_structure(per_obs_out, self.out_stacked, self.n_lead)
+        per_slice_out = self.segments[0].out_structure  # leftmost segment is applied last
+        return _expand_structure(per_slice_out, self.out_stacked, self.n_lead)
 
     @property
     def operator(self) -> AbstractLinearOperator:
-        """Effective per-observation operator (composition of the segments; for introspection)."""
+        """Effective per-slice operator (composition of the segments; for introspection)."""
         # segments is never empty (see _normalize), so _compose needs no fallback structure
         return _compose(tuple(seg.operator for seg in self.segments))
 
     def reduce(self) -> AbstractLinearOperator:
-        segments = tuple(seg.reduce() for seg in self.segments)
         return _build_stream(
-            segments, n_lead=self.n_lead, in_stacked=self.in_stacked, out_stacked=self.out_stacked
+            tuple(seg.reduce() for seg in self.segments),
+            n_lead=self.n_lead,
+            in_stacked=self.in_stacked,
+            out_stacked=self.out_stacked,
         )
 
     def transpose(self) -> AbstractLinearOperator:
-        segments = tuple(seg.transpose() for seg in reversed(self.segments))
-        # Swapping the specs maps each named class to its transpose: Diagonal -> Diagonal,
-        # Column <-> Row, Addition -> Addition.
+        # Swapping the specs maps each named class to its transpose:
+        # Diagonal -> Diagonal, Column <-> Row, Addition -> Addition.
         return _build_stream(
-            segments, n_lead=self.n_lead, in_stacked=self.out_stacked, out_stacked=self.in_stacked
+            segments=tuple(seg.transpose() for seg in reversed(self.segments)),
+            n_lead=self.n_lead,
+            in_stacked=self.out_stacked,
+            out_stacked=self.in_stacked,
         )
 
     def mv(self, x: PyTree[Inexact[Array, '...']]) -> PyTree[Inexact[Array, '...']]:
         mesh = _get_mesh()
         axis = mesh.axis_names[0]
-        per_obs_in = self.segments[-1].in_structure
-        per_obs_out = self.segments[0].out_structure
-        in_spec = _expand_spec(self.in_stacked, per_obs_in)
-        out_spec = _expand_spec(self.out_stacked, per_obs_out)
+        per_slice_in = self.segments[-1].in_structure
+        per_slice_out = self.segments[0].out_structure
+        # Per-leaf boolean masks (True = stacked) over the boundary structures.
+        in_mask = _expand_spec(self.in_stacked, per_slice_in)
+        out_mask = _expand_spec(self.out_stacked, per_slice_out)
         # Stacked inputs ride the scan; shared inputs are closed over and broadcast to every step.
-        x_stacked, x_shared = eqx.partition(x, in_spec)
-        # Shared outputs reduce into the scan carry; stacked outputs are emitted as scan outputs.
-        _, shared_out = eqx.partition(per_obs_out, out_spec)
-        out_specs = jax.tree.map(lambda stacked: P(axis) if stacked else P(), out_spec)
+        x_stacked, x_shared = eqx.partition(x, in_mask)
+        # Shared outputs accumulate in the scan carry; stacked outputs are emitted per step.
+        _, shared_out_structure = eqx.partition(per_slice_out, out_mask)
+        out_pspecs = jax.tree.map(lambda stacked: P(axis) if stacked else P(), out_mask)
         dyn, static = self._partition()
-        # scan infers its length from the scanned leaves' (per-shard) leading axis. Only when the
-        # body has no array leaves at all (e.g. a trivial F) is an explicit length needed; the
-        # per-shard slot count is n_lead over the number of obs shards.
+        # scan infers its length from the scanned leaves' (per-shard) leading axis; only a body with
+        # no array leaves at all (e.g. a trivial F) needs it spelled out, as n_lead per shard.
         has_scanned_leaves = bool(jax.tree.leaves((dyn, x_stacked)))
         length = None if has_scanned_leaves else self.n_lead // mesh.shape[axis]
 
-        @jax.shard_map(out_specs=out_specs, check_vma=False)
+        @jax.shard_map(out_specs=out_pspecs, check_vma=False)
         def kernel(dyn, static, x_stacked, x_shared):  # type: ignore[no-untyped-def]
             def step(carry, args):  # type: ignore[no-untyped-def]
                 dyn_i, xs_i = args
                 y = _apply_chain(dyn_i, static, eqx.combine(xs_i, x_shared))
-                ys_i, y_shared = eqx.partition(y, out_spec)
+                ys_i, y_shared = eqx.partition(y, out_mask)
                 return tree.add(carry, y_shared), ys_i
 
             # pcast makes the replicated zeros match the varying carry type inside shard_map
-            init = jax.lax.pcast(tree.zeros_like(shared_out), axis, to='varying')
+            init = jax.lax.pcast(tree.zeros_like(shared_out_structure), axis, to='varying')
             carry, ys = jax.lax.scan(step, init, (dyn, x_stacked), length=length)
             return eqx.combine(ys, jax.lax.psum(carry, axis_name=axis))
 
@@ -202,7 +208,7 @@ class AbstractStreamOperator(AbstractLinearOperator, ABC):
         """Split each segment's operator into (dynamic, static).
 
         Stacked segments expose their arrays to the scan, shared segments keep everything static
-        (broadcast across observations).
+        (broadcast across all slices).
         """
         dyn: list[AbstractLinearOperator] = []
         stat: list[AbstractLinearOperator] = []
@@ -219,98 +225,99 @@ class AbstractStreamOperator(AbstractLinearOperator, ABC):
 class StreamDiagonalOperator(AbstractStreamOperator):
     """Block-diagonal operator: each block acts independently on its own slice of the input.
 
-    Given a per-observation operator `(*in,) -> (*out,)` with `N` slices, maps
-    `(N, *in) -> (N, *out)`.
+    Given a per-slice operator `(*in,) -> (*out,)` with `N` slices, maps `(N, *in) -> (N, *out)`.
 
-    Example — per-observation noise weighting (square blocks, `*in == *out`):
+    Examples:
+        Per-slice noise weighting (square blocks, `*in == *out`):
 
-        >>> with jax.set_mesh(jax.make_mesh((4,), ('obs',))):
+        >>> with jax.set_mesh(jax.make_mesh((4,), ('batch',))):
         ...     W = StreamDiagonalOperator.create(noise_op)  # leaves: (N, *in)
-        ...     weighted = W(samples)                           # (N, *in) -> (N, *out)
+        ...     weighted = W(samples)                        # (N, *in) -> (N, *out)
     """
 
-    _uniform_in = True
-    _uniform_out = True
+    _default_in_stacked = True
+    _default_out_stacked = True
 
 
 class StreamColumnOperator(AbstractStreamOperator):
     """Column operator: applies all blocks to the same input and stacks the results.
 
-    Given a per-observation operator `(*in,) -> (*out,)` with `N` slices, maps
-    `(*in,) -> (N, *out)`.
+    Given a per-slice operator `(*in,) -> (*out,)` with `N` slices, maps `(*in,) -> (N, *out)`.
 
-    Example — pointing matrix from pixel map to time-ordered data:
+    Examples:
+        Pointing matrix from pixel map to time-ordered data:
 
-        >>> with jax.set_mesh(jax.make_mesh((4,), ('obs',))):
+        >>> with jax.set_mesh(jax.make_mesh((4,), ('batch',))):
         ...     H = StreamColumnOperator.create(pointing_op)  # leaves: (N, *out)
-        ...     tod = H(pixel_map)                               # (*in,) -> (N, *out)
+        ...     tod = H(pixel_map)                            # (*in,) -> (N, *out)
     """
 
-    _uniform_in = False
-    _uniform_out = True
+    _default_in_stacked = False
+    _default_out_stacked = True
 
 
 class StreamRowOperator(AbstractStreamOperator):
     """Row operator: applies each block to its own input slice and sums the results.
 
-    Given a per-observation operator `(*in,) -> (*out,)` with `N` slices, maps
-    `(N, *in) -> (*out,)`.
+    Given a per-slice operator `(*in,) -> (*out,)` with `N` slices, maps `(N, *in) -> (*out,)`.
 
-    Example — co-addition of time-ordered data back to a pixel map:
+    Examples:
+        Co-addition of time-ordered data back to a pixel map:
 
-        >>> with jax.set_mesh(jax.make_mesh((4,), ('obs',))):
+        >>> with jax.set_mesh(jax.make_mesh((4,), ('batch',))):
         ...     HT = StreamRowOperator.create(pointing_op_T)  # leaves: (N, *in)
-        ...     pixel_map = HT(tod)                              # (N, *in) -> (*out,)
+        ...     pixel_map = HT(tod)                           # (N, *in) -> (*out,)
     """
 
-    _uniform_in = True
-    _uniform_out = False
+    _default_in_stacked = True
+    _default_out_stacked = False
 
 
 class StreamAdditionOperator(AbstractStreamOperator):
     """Addition operator: applies all blocks to the same input and sums the results.
 
-    Given a per-observation operator `(*in,) -> (*out,)` with `N` slices, maps
-    `(*in,) -> (*out,)`.
+    Given a per-slice operator `(*in,) -> (*out,)` with `N` slices, maps `(*in,) -> (*out,)`.
 
     Arises naturally as the reduction of `StreamRowOperator @ StreamColumnOperator`,
     e.g. the normal equations operator `H.T @ W @ H` in mapmaking.
 
-    Example — normal equations from a pointing and weighting operator:
+    Examples:
+        Normal equations from a pointing and weighting operator:
 
-        >>> with jax.set_mesh(jax.make_mesh((4,), ('obs',))):
+        >>> with jax.set_mesh(jax.make_mesh((4,), ('batch',))):
         ...     A = (H.T @ W @ H).reduce()  # reduces to StreamAdditionOperator
         ...     rhs = A(pixel_map)          # (*in,) -> (*out,)
     """
 
-    _uniform_in = False
-    _uniform_out = False
+    _default_in_stacked = False
+    _default_out_stacked = False
 
 
 class StreamOperator(AbstractStreamOperator):
-    """General stream with per-component obs-stackedness (mixed reduce+stack scan).
+    """Stream whose input or output mixes stacked and shared components (mixed reduce+stack scan).
 
-    `in_stacked`/`out_stacked` are prefix pytrees of bools over the per-observation input/output
-    structures: True components carry the leading observation axis (sliced on input, stacked on
-    output), False components are shared (broadcast on input, sum-reduced with a `psum` on output).
-    Arises from fusing a system whose unknowns mix shared and per-observation parts, e.g. a joint
-    sky map (shared) and per-observation template amplitudes (stacked): the single scan computes
-    each observation's data once and feeds both legs.
+    Where the four uniform subclasses take a single bool per side, `in_stacked`/`out_stacked` here
+    are prefix pytrees of bools resolved per component: True carries the batch axis (sliced in,
+    stacked out), False is shared (broadcast in, summed out). One scan still computes each slice
+    once, feeding the stacked and shared legs together.
     """
 
-    # _uniform_in/_uniform_out stay None: the specs must be provided explicitly.
+    # _default_in_stacked/_default_out_stacked stay None: the specs must be provided explicitly.
 
 
 class StreamStreamFusionRule(AbstractCompositionRule):
-    """Fuse `left @ right` streams when the junction is entirely obs-stacked.
+    """Fuse `left @ right` streams when the junction is entirely stacked.
+
+    The *junction* is the intermediate structure the two streams meet at: `right`'s output, which
+    `left` consumes as input (in mapmaking, the per-slice TOD between e.g. `Hᵀ` and `H`).
 
     In composition order the segment lists concatenate; the fused specs are the outer ones
     (`in = right.in_stacked`, `out = left.out_stacked`). Fusion is only valid when every junction
     component is stacked on both sides: a *shared* junction component is a psum-reduction only
     available after the full scan, so threading it through a single fused scan would be wrong
     (e.g. `StreamAddition @ StreamAddition`: `(Σᵢaᵢ)(Σⱼbⱼ) ≠ Σᵢ aᵢbᵢ`). Such compositions stay
-    unreduced. The four uniform stream compositions all have stacked TOD junctions, so this one
-    rule subsumes them.
+    unreduced. Every composition among the named uniform subclasses meets at a stacked junction,
+    so this single rule handles them all without per-class special cases.
     """
 
     left_operator_class = AbstractStreamOperator
@@ -351,7 +358,7 @@ class StreamStreamFusionRule(AbstractCompositionRule):
 class HomothetyStreamRule(AbstractCompositionRule):
     """`Homothety @ Stream = Stream` with the scalar attached as a shared segment.
 
-    The scalar becomes a shared (obs-independent) segment on the output side (``Homothety @ block``)
+    The scalar becomes a shared (slice-independent) segment on the output side (``Homothety @ block``)
     or input side (``block @ Homothety``); it is not sliced. A scalar commutes through a linear
     operator, so the surrounding sum still collapses to a single fused stream via the addition-
     fusion rules.
@@ -400,15 +407,17 @@ class HomothetyStreamRule(AbstractCompositionRule):
 class StreamStreamAdditionRule(AbstractAdditionRule):
     """Fuse a sum of two matching stream operators into one stream.
 
-    Each operand is split into ``(pre, core, post)`` around its single stacked segment. When both
-    have trivial (identity) shared maps the cores add directly. Otherwise the shared maps are kept
-    out of the sliced body: the ``pre`` maps fan the input into a ``BlockColumnOperator``, the two
-    cores sit on a ``BlockDiagonalOperator`` (the one stacked segment), and the ``post`` maps
-    recombine through a ``BlockRowOperator``.
+    Applies only when each operand has exactly one stacked segment, so it splits into
+    ``(pre, core, post)`` around that segment (a general stream may hold several stacked segments,
+    e.g. two separated by a shared one; such operands defer). When both operands have trivial
+    (identity) shared maps the cores add directly. Otherwise the shared maps are kept out of the
+    sliced body: the ``pre`` maps fan the input into a ``BlockColumnOperator``, the two cores sit on
+    a ``BlockDiagonalOperator`` (the one stacked segment), and the ``post`` maps recombine through a
+    ``BlockRowOperator``.
 
-    The operands must share n_lead, per-observation in/out structure, and both stack specs (a sum
-    only fuses if both sides map the same layout); otherwise, or if an operand has no single
-    stacked segment, the rule defers to a plain ``AdditionOperator``.
+    The operands must share n_lead, per-slice in/out structure, and both stack specs (a sum
+    only fuses if both sides map the same layout); otherwise, or if an operand does not have exactly
+    one stacked segment, the rule defers to a plain ``AdditionOperator``.
     """
 
     left_operator_class = AbstractStreamOperator
@@ -418,20 +427,20 @@ class StreamStreamAdditionRule(AbstractAdditionRule):
         super().check(left, right)
         assert isinstance(left, AbstractStreamOperator)  # mypy
         assert isinstance(right, AbstractStreamOperator)  # mypy
-        # StreamAddition structures are per-observation, so `__add__`'s structure check does not
+        # StreamAddition structures are per-slice, so `__add__`'s structure check does not
         # force equal n; a mismatched-n sum is legal algebra that must stay unreduced. Mixed specs
         # (previously guaranteed equal by same-class dispatch) must now be checked explicitly too.
         if left.n_lead != right.n_lead:
             raise NoReduction
-        per_obs_in = left.segments[-1].in_structure
-        per_obs_out = left.segments[0].out_structure
-        if not structure_equal(per_obs_in, right.segments[-1].in_structure):
+        per_slice_in = left.segments[-1].in_structure
+        per_slice_out = left.segments[0].out_structure
+        if not structure_equal(per_slice_in, right.segments[-1].in_structure):
             raise NoReduction
-        if not structure_equal(per_obs_out, right.segments[0].out_structure):
+        if not structure_equal(per_slice_out, right.segments[0].out_structure):
             raise NoReduction
-        if not _specs_equal(left.in_stacked, right.in_stacked, per_obs_in):
+        if not _specs_equal(left.in_stacked, right.in_stacked, per_slice_in):
             raise NoReduction
-        if not _specs_equal(left.out_stacked, right.out_stacked, per_obs_out):
+        if not _specs_equal(left.out_stacked, right.out_stacked, per_slice_out):
             raise NoReduction
 
     def apply(
@@ -464,7 +473,7 @@ class StreamStreamAdditionRule(AbstractAdditionRule):
 
 
 def stream_block_row(operands: Sequence[AbstractLinearOperator]) -> AbstractStreamOperator:
-    """Fuse parallel streams ``[S₁ | S₂ | ...]`` sharing one observation axis into one stream.
+    """Fuse parallel streams ``[S₁ | S₂ | ...]`` sharing one batch axis into one stream.
 
     The block-row ``H`` maps a list of per-block inputs to a single shared output:
     ``H([u₁, ...]) = Σᵢ Sᵢ(uᵢ)``. Splitting each operand as ``Sᵢ = postᵢ @ coreᵢ @ preᵢ`` around
@@ -474,7 +483,7 @@ def stream_block_row(operands: Sequence[AbstractLinearOperator]) -> AbstractStre
     pre/post maps as shared segments. The result carries a per-block ``in_stacked`` list and the
     operands' shared ``out_stacked``.
 
-    All operands must be stream operators sharing ``n_lead``, per-observation output structure and
+    All operands must be stream operators sharing ``n_lead``, per-slice output structure and
     output stack spec, and have a single stacked segment. This is an explicit constructor (not a
     deferring reduction): a non-conforming operand raises ``ValueError``.
     """
@@ -486,15 +495,13 @@ def stream_block_row(operands: Sequence[AbstractLinearOperator]) -> AbstractStre
             raise ValueError('stream_block_row operands must be stream operators')
         ops.append(op)
     n_lead = ops[0].n_lead
-    per_obs_out = ops[0].segments[0].out_structure
+    per_slice_out = ops[0].segments[0].out_structure
     for op in ops[1:]:
         if op.n_lead != n_lead:
             raise ValueError('stream_block_row operands must share n_lead')
-        if not structure_equal(op.segments[0].out_structure, per_obs_out):
-            raise ValueError(
-                'stream_block_row operands must share the per-observation out structure'
-            )
-        if not _specs_equal(op.out_stacked, ops[0].out_stacked, per_obs_out):
+        if not structure_equal(op.segments[0].out_structure, per_slice_out):
+            raise ValueError('stream_block_row operands must share the per-slice out structure')
+        if not _specs_equal(op.out_stacked, ops[0].out_stacked, per_slice_out):
             raise ValueError('stream_block_row operands must share out_stacked')
     splits = [_split_core(op) for op in ops]
     conforming = [s for s in splits if s is not None]
@@ -540,7 +547,7 @@ def _get_mesh() -> AbstractMesh:
 
 
 def _leading_size(operator: AbstractLinearOperator) -> int:
-    """Observation-axis size of a *stacked* operator: all (array) leaves share a leading axis.
+    """Batch-axis size of a *stacked* operator: all (array) leaves share a leading axis.
 
     This only returns the leading axis size of the first leaf encountered. It does not check that
     all leaves have consistent dimensions (see [`_check_stacked`][] for that).
@@ -579,7 +586,7 @@ def _uniformity(spec: StackSpec, structure: PyTree[Any]) -> bool | None:
 def _expand_structure(
     structure: PyTree[jax.ShapeDtypeStruct], spec: StackSpec, n_lead: int
 ) -> PyTree[jax.ShapeDtypeStruct]:
-    """Prepend the observation axis on the stacked leaves of ``structure`` only."""
+    """Prepend the batch axis on the stacked leaves of ``structure`` only."""
     return jax.tree.map(
         lambda stacked, s: jax.ShapeDtypeStruct((n_lead, *s.shape), s.dtype) if stacked else s,
         _expand_spec(spec, structure),
@@ -605,10 +612,10 @@ def _build_stream(
     for seg in segments:
         if seg.stacked:
             _check_stacked(seg.operator, n_lead)
-    per_obs_in = segments[-1].in_structure  # rightmost segment is applied first
-    per_obs_out = segments[0].out_structure  # leftmost segment is applied last
-    cls, in_stacked, out_stacked = _class_for(in_stacked, out_stacked, per_obs_in, per_obs_out)
-    in_structure = _expand_structure(per_obs_in, in_stacked, n_lead)
+    per_slice_in = segments[-1].in_structure  # rightmost segment is applied first
+    per_slice_out = segments[0].out_structure  # leftmost segment is applied last
+    cls, in_stacked, out_stacked = _class_for(in_stacked, out_stacked, per_slice_in, per_slice_out)
+    in_structure = _expand_structure(per_slice_in, in_stacked, n_lead)
     return cls(
         segments,
         n_lead=n_lead,
@@ -619,7 +626,7 @@ def _build_stream(
 
 
 # Uniform (in_stacked, out_stacked) -> named class. Anything mixed uses StreamOperator.
-_UNIFORM_CLASS: dict[tuple[bool, bool], type[AbstractStreamOperator]] = {
+_UNIFORM_CLASS = {
     (True, True): StreamDiagonalOperator,
     (False, True): StreamColumnOperator,
     (True, False): StreamRowOperator,
@@ -630,12 +637,12 @@ _UNIFORM_CLASS: dict[tuple[bool, bool], type[AbstractStreamOperator]] = {
 def _class_for(
     in_stacked: StackSpec,
     out_stacked: StackSpec,
-    per_obs_in: PyTree[jax.ShapeDtypeStruct],
-    per_obs_out: PyTree[jax.ShapeDtypeStruct],
+    per_slice_in: PyTree[jax.ShapeDtypeStruct],
+    per_slice_out: PyTree[jax.ShapeDtypeStruct],
 ) -> tuple[type[AbstractStreamOperator], StackSpec, StackSpec]:
     """Pick the concrete class; normalize uniform specs to bare bools so the named classes match."""
-    ui = _uniformity(in_stacked, per_obs_in)
-    uo = _uniformity(out_stacked, per_obs_out)
+    ui = _uniformity(in_stacked, per_slice_in)
+    uo = _uniformity(out_stacked, per_slice_out)
     if ui is not None and uo is not None:
         return _UNIFORM_CLASS[(ui, uo)], ui, uo
     return StreamOperator, in_stacked, out_stacked
@@ -698,7 +705,7 @@ def _apply_chain(
     static: tuple[AbstractLinearOperator, ...],
     x: PyTree[Inexact[Array, '...']],
 ) -> PyTree[Inexact[Array, '...']]:
-    """Apply one observation's segment chain, recombining each segment from its dyn/static split.
+    """Apply one slice's segment chain, recombining each segment from its dyn/static split.
 
     Segments are in composition order, so the last one is applied first (innermost).
     """

--- a/src/furax/mapmaking/streaming.py
+++ b/src/furax/mapmaking/streaming.py
@@ -2,8 +2,9 @@
 
 import functools
 from abc import ABC
+from collections.abc import Sequence
 from dataclasses import field
-from typing import ClassVar, Self
+from typing import Any, ClassVar
 
 import equinox as eqx
 import jax
@@ -21,7 +22,21 @@ from furax.core import (
     HomothetyOperator,
     IdentityOperator,
 )
+from furax.core._base import structure_equal
 from furax.core.rules import AbstractAdditionRule, AbstractCompositionRule, NoReduction
+
+__all__ = [
+    'StreamAdditionOperator',
+    'StreamColumnOperator',
+    'StreamDiagonalOperator',
+    'StreamOperator',
+    'StreamRowOperator',
+    'stream_block_column',
+    'stream_block_row',
+]
+
+type StackSpec = bool | PyTree[bool]
+"""Obs-stackedness of a structure: a bare bool (uniform) or a prefix pytree of bools."""
 
 
 class StreamSegment(eqx.Module):
@@ -58,22 +73,41 @@ class AbstractStreamOperator(AbstractLinearOperator, ABC):
     segments[-1] first (input side). Each segment is tagged obs-*stacked* (sliced per observation)
     or *shared* (broadcast across observations).
 
-    The "block" denomination refers to how each slice appears in the global operator matrix:
-    subclasses arrange the N per-slice operators as blocks of a larger matrix (diagonal, column, or
-    row layout). The `_prepend_in`/`_prepend_out` class flags say whether the block prepends the
-    observation axis to its input/output structure.
+    `in_stacked`/`out_stacked` say which *components* of the input/output carry the observation
+    axis, as a [`StackSpec`][]: a bare bool applies to the whole structure, a prefix pytree of
+    bools resolves per component. A stacked component is sliced on input and stacked on output; a
+    shared component is broadcast on input and sum-reduced (scan carry, then `psum`) on output.
+    The four uniform combinations are the named subclasses:
+
+    | in_stacked | out_stacked | class                    | signature       |
+    |------------|-------------|--------------------------|-----------------|
+    | True       | True        | [`StreamDiagonalOperator`][] | (N,in) -> (N,out) |
+    | False      | True        | [`StreamColumnOperator`][]   | (in,)  -> (N,out) |
+    | True       | False       | [`StreamRowOperator`][]      | (N,in) -> (out,)  |
+    | False      | False       | [`StreamAdditionOperator`][] | (in,)  -> (out,)  |
+
+    Anything mixed is a [`StreamOperator`][], e.g. a joint sky (shared) + per-observation
+    amplitude (stacked) system, whose single scan computes each observation's data once and
+    feeds both legs.
 
     An active mesh context is required when calling `mv`; use `jax.set_mesh` beforehand.
     """
 
     segments: tuple[StreamSegment, ...]
     n_lead: int = field(kw_only=True, metadata={'static': True})
+    # Static like `in_structure`, and holding pytrees just like it: never hashed (operators are
+    # closed over by the solvers, not passed as jit arguments).
+    in_stacked: StackSpec = field(kw_only=True, metadata={'static': True})
+    out_stacked: StackSpec = field(kw_only=True, metadata={'static': True})
 
-    _prepend_in: ClassVar[bool]
-    _prepend_out: ClassVar[bool]
+    # Class-canonical uniform specs; None on StreamOperator, which requires explicit specs.
+    _uniform_in: ClassVar[bool | None] = None
+    _uniform_out: ClassVar[bool | None] = None
 
     @classmethod
-    def create(cls, operator: AbstractLinearOperator, *, n_lead: int | None = None) -> Self:
+    def create(
+        cls, operator: AbstractLinearOperator, *, n_lead: int | None = None
+    ) -> 'AbstractStreamOperator':
         """Wrap a freshly stacked operator as a block with a single stacked segment.
 
         Args:
@@ -86,24 +120,27 @@ class AbstractStreamOperator(AbstractLinearOperator, ABC):
         return cls._build((StreamSegment(operator, True),), n_lead=n_lead)
 
     @classmethod
-    def _build(cls, segments: tuple[StreamSegment, ...], *, n_lead: int) -> Self:
-        segments = _normalize(segments)
-        for seg in segments:
-            if seg.stacked:
-                _check_stacked(seg.operator, n_lead)
-        per_obs_in = segments[-1].in_structure  # rightmost segment is applied first
-        if cls._prepend_in:
-            in_structure = _prepend_axis(per_obs_in, axis_size=n_lead)
-        else:
-            in_structure = per_obs_in
-        return cls(segments, n_lead=n_lead, in_structure=in_structure)
+    def _build(
+        cls,
+        segments: tuple[StreamSegment, ...],
+        *,
+        n_lead: int,
+        in_stacked: StackSpec | None = None,
+        out_stacked: StackSpec | None = None,
+    ) -> 'AbstractStreamOperator':
+        """Build from segments, defaulting the specs to the class's uniform ones."""
+        in_stacked = cls._uniform_in if in_stacked is None else in_stacked
+        out_stacked = cls._uniform_out if out_stacked is None else out_stacked
+        if in_stacked is None or out_stacked is None:
+            raise TypeError(f'{cls.__name__} requires explicit in_stacked/out_stacked')
+        return _build_stream(
+            segments, n_lead=n_lead, in_stacked=in_stacked, out_stacked=out_stacked
+        )
 
     @property
     def out_structure(self) -> PyTree[jax.ShapeDtypeStruct]:
         per_obs_out = self.segments[0].out_structure  # leftmost segment is applied last
-        if self._prepend_out:
-            return _prepend_axis(per_obs_out, axis_size=self.n_lead)
-        return per_obs_out
+        return _expand_structure(per_obs_out, self.out_stacked, self.n_lead)
 
     @property
     def operator(self) -> AbstractLinearOperator:
@@ -113,7 +150,51 @@ class AbstractStreamOperator(AbstractLinearOperator, ABC):
 
     def reduce(self) -> AbstractLinearOperator:
         segments = tuple(seg.reduce() for seg in self.segments)
-        return type(self)._build(segments, n_lead=self.n_lead)
+        return _build_stream(
+            segments, n_lead=self.n_lead, in_stacked=self.in_stacked, out_stacked=self.out_stacked
+        )
+
+    def transpose(self) -> AbstractLinearOperator:
+        segments = tuple(seg.transpose() for seg in reversed(self.segments))
+        # Swapping the specs maps each named class to its transpose: Diagonal -> Diagonal,
+        # Column <-> Row, Addition -> Addition.
+        return _build_stream(
+            segments, n_lead=self.n_lead, in_stacked=self.out_stacked, out_stacked=self.in_stacked
+        )
+
+    def mv(self, x: PyTree[Inexact[Array, '...']]) -> PyTree[Inexact[Array, '...']]:
+        mesh = _get_mesh()
+        axis = mesh.axis_names[0]
+        per_obs_in = self.segments[-1].in_structure
+        per_obs_out = self.segments[0].out_structure
+        in_spec = _expand_spec(self.in_stacked, per_obs_in)
+        out_spec = _expand_spec(self.out_stacked, per_obs_out)
+        # Stacked inputs ride the scan; shared inputs are closed over and broadcast to every step.
+        x_stacked, x_shared = eqx.partition(x, in_spec)
+        # Shared outputs reduce into the scan carry; stacked outputs are emitted as scan outputs.
+        _, shared_out = eqx.partition(per_obs_out, out_spec)
+        out_specs = jax.tree.map(lambda stacked: P(axis) if stacked else P(), out_spec)
+        dyn, static = self._partition()
+        # scan infers its length from the scanned leaves' (per-shard) leading axis. Only when the
+        # body has no array leaves at all (e.g. a trivial F) is an explicit length needed; the
+        # per-shard slot count is n_lead over the number of obs shards.
+        has_scanned_leaves = bool(jax.tree.leaves((dyn, x_stacked)))
+        length = None if has_scanned_leaves else self.n_lead // mesh.shape[axis]
+
+        @jax.shard_map(out_specs=out_specs, check_vma=False)
+        def kernel(dyn, static, x_stacked, x_shared):  # type: ignore[no-untyped-def]
+            def step(carry, args):  # type: ignore[no-untyped-def]
+                dyn_i, xs_i = args
+                y = _apply_chain(dyn_i, static, eqx.combine(xs_i, x_shared))
+                ys_i, y_shared = eqx.partition(y, out_spec)
+                return tree.add(carry, y_shared), ys_i
+
+            # pcast makes the replicated zeros match the varying carry type inside shard_map
+            init = jax.lax.pcast(tree.zeros_like(shared_out), axis, to='varying')
+            carry, ys = jax.lax.scan(step, init, (dyn, x_stacked), length=length)
+            return eqx.combine(ys, jax.lax.psum(carry, axis_name=axis))
+
+        return kernel(dyn, static, x_stacked, x_shared)
 
     def _partition(
         self,
@@ -148,27 +229,8 @@ class StreamDiagonalOperator(AbstractStreamOperator):
         ...     weighted = W(samples)                           # (N, *in) -> (N, *out)
     """
 
-    _prepend_in = True
-    _prepend_out = True
-
-    def mv(self, x: PyTree[Inexact[Array, '...']]) -> PyTree[Inexact[Array, '...']]:
-        axis = _get_mesh().axis_names[0]
-        dyn, static = self._partition()
-
-        @jax.shard_map(out_specs=P(axis), check_vma=False)
-        def kernel(dyn, static, x):  # type: ignore[no-untyped-def]
-            def step(_, args):  # type: ignore[no-untyped-def]
-                dyn_i, x_i = args
-                return None, _apply_chain(dyn_i, static, x_i)
-
-            _, out = jax.lax.scan(step, None, (dyn, x))
-            return out
-
-        return kernel(dyn, static, x)
-
-    def transpose(self) -> AbstractLinearOperator:
-        segments = tuple(seg.transpose() for seg in reversed(self.segments))
-        return StreamDiagonalOperator._build(segments, n_lead=self.n_lead)
+    _uniform_in = True
+    _uniform_out = True
 
 
 class StreamColumnOperator(AbstractStreamOperator):
@@ -184,26 +246,8 @@ class StreamColumnOperator(AbstractStreamOperator):
         ...     tod = H(pixel_map)                               # (*in,) -> (N, *out)
     """
 
-    _prepend_in = False
-    _prepend_out = True
-
-    def mv(self, x: PyTree[Inexact[Array, '...']]) -> PyTree[Inexact[Array, '...']]:
-        axis = _get_mesh().axis_names[0]
-        dyn, static = self._partition()
-
-        @jax.shard_map(out_specs=P(axis), check_vma=False)
-        def kernel(dyn, static, x):  # type: ignore[no-untyped-def]
-            def step(_, dyn_i):  # type: ignore[no-untyped-def]
-                return None, _apply_chain(dyn_i, static, x)
-
-            _, out = jax.lax.scan(step, None, dyn)
-            return out
-
-        return kernel(dyn, static, x)
-
-    def transpose(self) -> AbstractLinearOperator:
-        segments = tuple(seg.transpose() for seg in reversed(self.segments))
-        return StreamRowOperator._build(segments, n_lead=self.n_lead)
+    _uniform_in = False
+    _uniform_out = True
 
 
 class StreamRowOperator(AbstractStreamOperator):
@@ -219,30 +263,8 @@ class StreamRowOperator(AbstractStreamOperator):
         ...     pixel_map = HT(tod)                              # (N, *in) -> (*out,)
     """
 
-    _prepend_in = True
-    _prepend_out = False
-
-    def mv(self, x: PyTree[Inexact[Array, '...']]) -> PyTree[Inexact[Array, '...']]:
-        axis = _get_mesh().axis_names[0]
-        out_structure = self.segments[0].out_structure
-        dyn, static = self._partition()
-
-        @jax.shard_map(out_specs=P(), check_vma=False)
-        def kernel(dyn, static, x):  # type: ignore[no-untyped-def]
-            def step(carry, args):  # type: ignore[no-untyped-def]
-                dyn_i, x_i = args
-                return tree.add(carry, _apply_chain(dyn_i, static, x_i)), None
-
-            # pcast makes the replicated zeros match the varying carry type inside shard_map
-            init = jax.lax.pcast(tree.zeros_like(out_structure), axis, to='varying')
-            out, _ = jax.lax.scan(step, init, (dyn, x))
-            return jax.lax.psum(out, axis_name=axis)
-
-        return kernel(dyn, static, x)
-
-    def transpose(self) -> AbstractLinearOperator:
-        segments = tuple(seg.transpose() for seg in reversed(self.segments))
-        return StreamColumnOperator._build(segments, n_lead=self.n_lead)
+    _uniform_in = True
+    _uniform_out = False
 
 
 class StreamAdditionOperator(AbstractStreamOperator):
@@ -261,40 +283,54 @@ class StreamAdditionOperator(AbstractStreamOperator):
         ...     rhs = A(pixel_map)          # (*in,) -> (*out,)
     """
 
-    _prepend_in = False
-    _prepend_out = False
-
-    def mv(self, x: PyTree[Inexact[Array, '...']]) -> PyTree[Inexact[Array, '...']]:
-        axis = _get_mesh().axis_names[0]
-        out_structure = self.segments[0].out_structure
-        dyn, static = self._partition()
-
-        @jax.shard_map(out_specs=P(), check_vma=False)
-        def kernel(dyn, static, x):  # type: ignore[no-untyped-def]
-            def step(carry, dyn_i):  # type: ignore[no-untyped-def]
-                return tree.add(carry, _apply_chain(dyn_i, static, x)), None
-
-            # pcast makes the replicated zeros match the varying carry type inside shard_map
-            init = jax.lax.pcast(tree.zeros_like(out_structure), axis, to='varying')
-            out, _ = jax.lax.scan(step, init, dyn)
-            return jax.lax.psum(out, axis_name=axis)
-
-        return kernel(dyn, static, x)
-
-    def transpose(self) -> AbstractLinearOperator:
-        segments = tuple(seg.transpose() for seg in reversed(self.segments))
-        return StreamAdditionOperator._build(segments, n_lead=self.n_lead)
+    _uniform_in = False
+    _uniform_out = False
 
 
-class AbstractStreamFusionRule(AbstractCompositionRule):
-    """Fuse a composition of two stream operators into one stream.
+class StreamOperator(AbstractStreamOperator):
+    """General stream with per-component obs-stackedness (mixed reduce+stack scan).
 
-    In composition order the segment lists simply concatenate. The obs-independent maps that meet
-    at the junction ride along as shared segments; a non-scalar junction fuses just like a scalar
-    one. Whatever adjacent segments can genuinely merge do so in the reduced class constructor.
+    `in_stacked`/`out_stacked` are prefix pytrees of bools over the per-observation input/output
+    structures: True components carry the leading observation axis (sliced on input, stacked on
+    output), False components are shared (broadcast on input, sum-reduced with a `psum` on output).
+    Arises from fusing a system whose unknowns mix shared and per-observation parts, e.g. a joint
+    sky map (shared) and per-observation template amplitudes (stacked): the single scan computes
+    each observation's data once and feeds both legs.
     """
 
-    reduced_class: type[AbstractStreamOperator]
+    # _uniform_in/_uniform_out stay None: the specs must be provided explicitly.
+
+
+class StreamStreamFusionRule(AbstractCompositionRule):
+    """Fuse `left @ right` streams when the junction is entirely obs-stacked.
+
+    In composition order the segment lists concatenate; the fused specs are the outer ones
+    (`in = right.in_stacked`, `out = left.out_stacked`). Fusion is only valid when every junction
+    component is stacked on both sides: a *shared* junction component is a psum-reduction only
+    available after the full scan, so threading it through a single fused scan would be wrong
+    (e.g. `StreamAddition @ StreamAddition`: `(Σᵢaᵢ)(Σⱼbⱼ) ≠ Σᵢ aᵢbᵢ`). Such compositions stay
+    unreduced. The four uniform stream compositions all have stacked TOD junctions, so this one
+    rule subsumes them.
+    """
+
+    left_operator_class = AbstractStreamOperator
+    right_operator_class = AbstractStreamOperator
+
+    def check(self, left: AbstractLinearOperator, right: AbstractLinearOperator) -> None:
+        super().check(left, right)
+        assert isinstance(left, AbstractStreamOperator)  # mypy
+        assert isinstance(right, AbstractStreamOperator)  # mypy
+        # n_lead must be checked explicitly: the all-stacked test below is vacuous on a leafless
+        # junction (no leaves to disagree), so it cannot catch a slot-count mismatch on its own.
+        if left.n_lead != right.n_lead:
+            raise NoReduction
+        junction = right.segments[0].out_structure  # == left.segments[-1].in_structure if it fuses
+        if not structure_equal(left.segments[-1].in_structure, junction):
+            raise NoReduction
+        left_in = _expand_spec(left.in_stacked, junction)
+        right_out = _expand_spec(right.out_stacked, junction)
+        if not all(jax.tree.leaves(left_in)) or not all(jax.tree.leaves(right_out)):
+            raise NoReduction
 
     def apply(
         self, left: AbstractLinearOperator, right: AbstractLinearOperator
@@ -302,39 +338,14 @@ class AbstractStreamFusionRule(AbstractCompositionRule):
         assert isinstance(left, AbstractStreamOperator)  # mypy
         assert isinstance(right, AbstractStreamOperator)  # mypy
         segments = left.segments + right.segments
-        return [self.reduced_class._build(segments, n_lead=left.n_lead)]
-
-
-class StreamDiagonalStreamDiagonalRule(AbstractStreamFusionRule):
-    """`StreamDiagonal @ StreamDiagonal = StreamDiagonal`."""
-
-    left_operator_class = StreamDiagonalOperator
-    right_operator_class = StreamDiagonalOperator
-    reduced_class = StreamDiagonalOperator
-
-
-class StreamDiagonalStreamColumnRule(AbstractStreamFusionRule):
-    """`StreamDiagonal @ StreamColumn = StreamColumn`."""
-
-    left_operator_class = StreamDiagonalOperator
-    right_operator_class = StreamColumnOperator
-    reduced_class = StreamColumnOperator
-
-
-class StreamRowStreamDiagonalRule(AbstractStreamFusionRule):
-    """`StreamRow @ StreamDiagonal = StreamRow`."""
-
-    left_operator_class = StreamRowOperator
-    right_operator_class = StreamDiagonalOperator
-    reduced_class = StreamRowOperator
-
-
-class StreamRowStreamColumnRule(AbstractStreamFusionRule):
-    """`StreamRow @ StreamColumn = StreamAddition`."""
-
-    left_operator_class = StreamRowOperator
-    right_operator_class = StreamColumnOperator
-    reduced_class = StreamAdditionOperator
+        return [
+            _build_stream(
+                segments,
+                n_lead=left.n_lead,
+                in_stacked=right.in_stacked,
+                out_stacked=left.out_stacked,
+            )
+        ]
 
 
 class HomothetyStreamRule(AbstractCompositionRule):
@@ -376,11 +387,18 @@ class HomothetyStreamRule(AbstractCompositionRule):
         else:  # block @ homo: trailing shared segment
             scalar = HomothetyOperator(homo.value, in_structure=block.segments[-1].in_structure)
             segments = block.segments + (StreamSegment(scalar, False),)
-        return [type(block)._build(segments, n_lead=block.n_lead)]
+        return [
+            _build_stream(
+                segments,
+                n_lead=block.n_lead,
+                in_stacked=block.in_stacked,
+                out_stacked=block.out_stacked,
+            )
+        ]
 
 
-class AbstractStreamAdditionFusionRule(AbstractAdditionRule):
-    """Fuse a sum of two stream operators of the same kind into one stream.
+class StreamStreamAdditionRule(AbstractAdditionRule):
+    """Fuse a sum of two matching stream operators into one stream.
 
     Each operand is split into ``(pre, core, post)`` around its single stacked segment. When both
     have trivial (identity) shared maps the cores add directly. Otherwise the shared maps are kept
@@ -388,19 +406,32 @@ class AbstractStreamAdditionFusionRule(AbstractAdditionRule):
     cores sit on a ``BlockDiagonalOperator`` (the one stacked segment), and the ``post`` maps
     recombine through a ``BlockRowOperator``.
 
-    An operand without exactly one stacked segment cannot be laid out this way, so the rule defers.
+    The operands must share n_lead, per-observation in/out structure, and both stack specs (a sum
+    only fuses if both sides map the same layout); otherwise, or if an operand has no single
+    stacked segment, the rule defers to a plain ``AdditionOperator``.
     """
 
-    reduced_class: type[AbstractStreamOperator]
+    left_operator_class = AbstractStreamOperator
+    right_operator_class = AbstractStreamOperator
 
     def check(self, left: AbstractLinearOperator, right: AbstractLinearOperator) -> None:
         super().check(left, right)
-        # Diagonal/row/column blocks carry the obs axis in their structures, so `__add__` already
-        # forces equal n there; StreamAddition structures are per-observation, making a mismatched-n
-        # sum legal algebra that must stay unreduced rather than crash in `_build`.
         assert isinstance(left, AbstractStreamOperator)  # mypy
         assert isinstance(right, AbstractStreamOperator)  # mypy
+        # StreamAddition structures are per-observation, so `__add__`'s structure check does not
+        # force equal n; a mismatched-n sum is legal algebra that must stay unreduced. Mixed specs
+        # (previously guaranteed equal by same-class dispatch) must now be checked explicitly too.
         if left.n_lead != right.n_lead:
+            raise NoReduction
+        per_obs_in = left.segments[-1].in_structure
+        per_obs_out = left.segments[0].out_structure
+        if not structure_equal(per_obs_in, right.segments[-1].in_structure):
+            raise NoReduction
+        if not structure_equal(per_obs_out, right.segments[0].out_structure):
+            raise NoReduction
+        if not _specs_equal(left.in_stacked, right.in_stacked, per_obs_in):
+            raise NoReduction
+        if not _specs_equal(left.out_stacked, right.out_stacked, per_obs_out):
             raise NoReduction
 
     def apply(
@@ -414,10 +445,12 @@ class AbstractStreamAdditionFusionRule(AbstractAdditionRule):
             raise NoReduction  # not a single-stacked-core body: defer to a plain AdditionOperator
         pre_l, core_l, post_l = split_left
         pre_r, core_r, post_r = split_right
+        kw = {'in_stacked': left.in_stacked, 'out_stacked': left.out_stacked}
         trivial = all(isinstance(op, IdentityOperator) for op in (pre_l, post_l, pre_r, post_r))
         if trivial:
             core = (core_l + core_r).reduce()
-            return [self.reduced_class._build((StreamSegment(core, True),), n_lead=left.n_lead)]
+            segments: tuple[StreamSegment, ...] = (StreamSegment(core, True),)
+            return [_build_stream(segments, n_lead=left.n_lead, **kw)]
         pre = BlockColumnOperator([pre_l, pre_r])
         core = BlockDiagonalOperator([core_l, core_r])
         post = BlockRowOperator([post_l, post_r])
@@ -427,39 +460,71 @@ class AbstractStreamAdditionFusionRule(AbstractAdditionRule):
             StreamSegment(core, True),
             StreamSegment(pre, False),
         )
-        return [self.reduced_class._build(segments, n_lead=left.n_lead)]
+        return [_build_stream(segments, n_lead=left.n_lead, **kw)]
 
 
-class StreamDiagonalAdditionRule(AbstractStreamAdditionFusionRule):
-    """`StreamDiagonal + StreamDiagonal = StreamDiagonal`."""
+def stream_block_row(operands: Sequence[AbstractLinearOperator]) -> AbstractStreamOperator:
+    """Fuse parallel streams ``[S₁ | S₂ | ...]`` sharing one observation axis into one stream.
 
-    left_operator_class = StreamDiagonalOperator
-    right_operator_class = StreamDiagonalOperator
-    reduced_class = StreamDiagonalOperator
+    The block-row ``H`` maps a list of per-block inputs to a single shared output:
+    ``H([u₁, ...]) = Σᵢ Sᵢ(uᵢ)``. Splitting each operand as ``Sᵢ = postᵢ @ coreᵢ @ preᵢ`` around
+    its single stacked segment, the identity
+    ``BlockRow([Sᵢ]) = BlockRow([postᵢ]) @ BlockDiagonal([coreᵢ]) @ BlockDiagonal([preᵢ])`` lays the
+    fused stream out with one stacked core segment (the ``BlockDiagonal`` of cores) and the shared
+    pre/post maps as shared segments. The result carries a per-block ``in_stacked`` list and the
+    operands' shared ``out_stacked``.
+
+    All operands must be stream operators sharing ``n_lead``, per-observation output structure and
+    output stack spec, and have a single stacked segment. This is an explicit constructor (not a
+    deferring reduction): a non-conforming operand raises ``ValueError``.
+    """
+    if not operands:
+        raise ValueError('stream_block_row requires at least one operand')
+    ops: list[AbstractStreamOperator] = []
+    for op in operands:
+        if not isinstance(op, AbstractStreamOperator):
+            raise ValueError('stream_block_row operands must be stream operators')
+        ops.append(op)
+    n_lead = ops[0].n_lead
+    per_obs_out = ops[0].segments[0].out_structure
+    for op in ops[1:]:
+        if op.n_lead != n_lead:
+            raise ValueError('stream_block_row operands must share n_lead')
+        if not structure_equal(op.segments[0].out_structure, per_obs_out):
+            raise ValueError(
+                'stream_block_row operands must share the per-observation out structure'
+            )
+        if not _specs_equal(op.out_stacked, ops[0].out_stacked, per_obs_out):
+            raise ValueError('stream_block_row operands must share out_stacked')
+    splits = [_split_core(op) for op in ops]
+    conforming = [s for s in splits if s is not None]
+    if len(conforming) != len(ops):
+        raise ValueError('stream_block_row requires operands with a single stacked segment')
+    pres, cores, posts = zip(*conforming, strict=True)
+    segments: list[StreamSegment] = []
+    if all(isinstance(p, IdentityOperator) for p in posts):
+        # Shared posts would not merge into the stacked core (_normalize joins same-tag segments
+        # only), so collapse them into a single stacked BlockRow of cores.
+        segments.append(StreamSegment(BlockRowOperator(list(cores)), True))
+    else:
+        segments.append(StreamSegment(BlockRowOperator(list(posts)), False))
+        segments.append(StreamSegment(BlockDiagonalOperator(list(cores)), True))
+    if not all(isinstance(p, IdentityOperator) for p in pres):
+        segments.append(StreamSegment(BlockDiagonalOperator(list(pres)), False))
+    return _build_stream(
+        tuple(segments),
+        n_lead=n_lead,
+        in_stacked=[op.in_stacked for op in ops],
+        out_stacked=ops[0].out_stacked,
+    )
 
 
-class StreamColumnAdditionRule(AbstractStreamAdditionFusionRule):
-    """`StreamColumn + StreamColumn = StreamColumn`."""
-
-    left_operator_class = StreamColumnOperator
-    right_operator_class = StreamColumnOperator
-    reduced_class = StreamColumnOperator
-
-
-class StreamRowAdditionRule(AbstractStreamAdditionFusionRule):
-    """`StreamRow + StreamRow = StreamRow`."""
-
-    left_operator_class = StreamRowOperator
-    right_operator_class = StreamRowOperator
-    reduced_class = StreamRowOperator
-
-
-class StreamAdditionAdditionRule(AbstractStreamAdditionFusionRule):
-    """`StreamAddition + StreamAddition = StreamAddition`."""
-
-    left_operator_class = StreamAdditionOperator
-    right_operator_class = StreamAdditionOperator
-    reduced_class = StreamAdditionOperator
+def stream_block_column(operands: Sequence[AbstractLinearOperator]) -> AbstractStreamOperator:
+    """Fuse parallel streams into one column block; the transpose of [`stream_block_row`][]."""
+    transposed = stream_block_row([op.T for op in operands])
+    result = transposed.T
+    assert isinstance(result, AbstractStreamOperator)  # mypy
+    return result
 
 
 # ---------------------------------------------------------------------------
@@ -486,10 +551,94 @@ def _leading_size(operator: AbstractLinearOperator) -> int:
     raise RuntimeError('cannot infer leading axis size: no non-scalar array leaf')
 
 
-def _prepend_axis(
-    structure: PyTree[jax.ShapeDtypeStruct], axis_size: int
+def _expand_spec(spec: StackSpec, structure: PyTree[Any]) -> PyTree[bool]:
+    """Broadcast a bare bool or prefix pytree of bools to a per-leaf bool tree over ``structure``."""
+    if isinstance(spec, bool):
+        return jax.tree.map(lambda _: spec, structure)
+    treedef = jax.tree.structure(spec)
+    subtrees = treedef.flatten_up_to(structure)  # type: ignore[attr-defined]  # raises if not a prefix
+    leaves = jax.tree.leaves(spec)
+    return jax.tree.unflatten(
+        treedef,
+        [jax.tree.map(lambda _, s=s: s, sub) for s, sub in zip(leaves, subtrees, strict=True)],
+    )
+
+
+def _uniformity(spec: StackSpec, structure: PyTree[Any]) -> bool | None:
+    """True/False if the expanded spec is uniformly stacked/shared; None if mixed or leafless."""
+    if isinstance(spec, bool):
+        return spec
+    leaves = jax.tree.leaves(_expand_spec(spec, structure))
+    if leaves and all(leaves):
+        return True
+    if leaves and not any(leaves):
+        return False
+    return None
+
+
+def _expand_structure(
+    structure: PyTree[jax.ShapeDtypeStruct], spec: StackSpec, n_lead: int
 ) -> PyTree[jax.ShapeDtypeStruct]:
-    return jax.tree.map(lambda s: jax.ShapeDtypeStruct((axis_size, *s.shape), s.dtype), structure)
+    """Prepend the observation axis on the stacked leaves of ``structure`` only."""
+    return jax.tree.map(
+        lambda stacked, s: jax.ShapeDtypeStruct((n_lead, *s.shape), s.dtype) if stacked else s,
+        _expand_spec(spec, structure),
+        structure,
+    )
+
+
+def _specs_equal(a: StackSpec, b: StackSpec, structure: PyTree[Any]) -> bool:
+    ea = jax.tree.leaves(_expand_spec(a, structure))
+    eb = jax.tree.leaves(_expand_spec(b, structure))
+    return ea == eb
+
+
+def _build_stream(
+    segments: tuple[StreamSegment, ...],
+    *,
+    n_lead: int,
+    in_stacked: StackSpec,
+    out_stacked: StackSpec,
+) -> AbstractStreamOperator:
+    """Normalize segments, pick the concrete class from the specs, and construct the operator."""
+    segments = _normalize(segments)
+    for seg in segments:
+        if seg.stacked:
+            _check_stacked(seg.operator, n_lead)
+    per_obs_in = segments[-1].in_structure  # rightmost segment is applied first
+    per_obs_out = segments[0].out_structure  # leftmost segment is applied last
+    cls, in_stacked, out_stacked = _class_for(in_stacked, out_stacked, per_obs_in, per_obs_out)
+    in_structure = _expand_structure(per_obs_in, in_stacked, n_lead)
+    return cls(
+        segments,
+        n_lead=n_lead,
+        in_stacked=in_stacked,
+        out_stacked=out_stacked,
+        in_structure=in_structure,
+    )
+
+
+# Uniform (in_stacked, out_stacked) -> named class. Anything mixed uses StreamOperator.
+_UNIFORM_CLASS: dict[tuple[bool, bool], type[AbstractStreamOperator]] = {
+    (True, True): StreamDiagonalOperator,
+    (False, True): StreamColumnOperator,
+    (True, False): StreamRowOperator,
+    (False, False): StreamAdditionOperator,
+}
+
+
+def _class_for(
+    in_stacked: StackSpec,
+    out_stacked: StackSpec,
+    per_obs_in: PyTree[jax.ShapeDtypeStruct],
+    per_obs_out: PyTree[jax.ShapeDtypeStruct],
+) -> tuple[type[AbstractStreamOperator], StackSpec, StackSpec]:
+    """Pick the concrete class; normalize uniform specs to bare bools so the named classes match."""
+    ui = _uniformity(in_stacked, per_obs_in)
+    uo = _uniformity(out_stacked, per_obs_out)
+    if ui is not None and uo is not None:
+        return _UNIFORM_CLASS[(ui, uo)], ui, uo
+    return StreamOperator, in_stacked, out_stacked
 
 
 def _check_stacked(operator: AbstractLinearOperator, n_lead: int) -> None:

--- a/src/furax/mapmaking/streaming.py
+++ b/src/furax/mapmaking/streaming.py
@@ -401,7 +401,15 @@ class StreamOperator(AbstractLinearOperator):
     def mv(self, x: PyTree[Inexact[Array, '...']]) -> PyTree[Inexact[Array, '...']]:
         mesh = _get_mesh()
         axis = mesh.axis_names[0]
-        length = self.n_lead // mesh.shape[axis]  # slices per shard
+        # The scan length is declared rather than inferred, so it also asserts the per-shard
+        # leading axis of every sliced leaf. Nothing else would catch an indivisible batch axis: a
+        # body whose sliced segments own no arrays gives `scan` no leaf to disagree with.
+        length, remainder = divmod(self.n_lead, mesh.shape[axis])  # slices per shard
+        if remainder:
+            raise ValueError(
+                f'batch axis {self.n_lead} is not divisible by the {mesh.shape[axis]} shards '
+                f'of mesh axis {axis!r}'
+            )
 
         # Stacked inputs ride the scan, shared ones are closed over. `eqx.partition` broadcasts a
         # prefix spec itself, so the input side needs no per-leaf mask.

--- a/src/furax/mapmaking/streaming.py
+++ b/src/furax/mapmaking/streaming.py
@@ -1,9 +1,8 @@
-"""Operators that stream a per-observation operator across a sharded observation axis."""
+"""Operators that stream a batched operator slice-by-slice across a sharded leading axis."""
 
 import functools
-from abc import ABC
 from dataclasses import field
-from typing import ClassVar, Self
+from typing import Any
 
 import equinox as eqx
 import jax
@@ -21,19 +20,50 @@ from furax.core import (
     HomothetyOperator,
     IdentityOperator,
 )
+from furax.core._base import structure_equal
 from furax.core.rules import AbstractAdditionRule, AbstractCompositionRule, NoReduction
+
+__all__ = [
+    'StackSpec',
+    'StreamOperator',
+    'StreamSegment',
+]
+
+type StackSpec = bool | PyTree[bool]
+"""Per-component stackedness of a structure: a bare bool (uniform) or a prefix pytree of bools."""
 
 
 class StreamSegment(eqx.Module):
-    """One segment of a stream body."""
+    """One link of a stream body, and where its data goes in the scan.
+
+    A *sliced* segment owns data carrying the batch axis, so the scan takes a slice of it each
+    step. A *constant* one owns data that does not, so it is held fixed and applied identically at
+    every step. Being sliced is a claim about the data, checked at construction: every array leaf
+    must lead with `n_lead`.
+
+    A third case cuts across those two. A *pure* segment ([`is_pure`][]) owns no data at all --
+    an identity, or a block operator assembled only to route components around. It has nothing to
+    slice or hold, so it belongs to neither camp and can join whichever neighbour it sits next to.
+    That is what lets the slot alignment emit structural operators freely: `_normalize` folds them
+    away again.
+    """
 
     operator: AbstractLinearOperator
-    stacked: bool = eqx.field(static=True)
+    sliced: bool = eqx.field(static=True)
 
     @property
-    def trivial(self) -> bool:
-        """A trivial segment is a shared IdentityOperator."""
-        return not self.stacked and isinstance(self.operator, IdentityOperator)
+    def is_identity(self) -> bool:
+        """A constant identity: contributes nothing and can be dropped outright, not just folded."""
+        return not self.sliced and isinstance(self.operator, IdentityOperator)
+
+    @property
+    def is_pure(self) -> bool:
+        """Owns no data, so the sliced/constant distinction does not apply to it.
+
+        Any pytree leaf counts as data, not just arrays: a Python float is not an array until
+        something traces it, and a segment's role must not change under `jit`.
+        """
+        return not jax.tree.leaves(self.operator)
 
     @property
     def in_structure(self) -> PyTree[jax.ShapeDtypeStruct]:
@@ -44,89 +74,323 @@ class StreamSegment(eqx.Module):
         return self.operator.out_structure
 
     def transpose(self) -> 'StreamSegment':
-        return StreamSegment(self.operator.T, self.stacked)
+        return StreamSegment(self.operator.T, self.sliced)
 
     def reduce(self) -> 'StreamSegment':
-        return StreamSegment(self.operator.reduce(), self.stacked)
+        return StreamSegment(self.operator.reduce(), self.sliced)
 
 
-class AbstractStreamOperator(AbstractLinearOperator, ABC):
-    """Base class for operators that apply a batched pytree operator slice-by-slice via scan.
+class StreamOperator(AbstractLinearOperator):
+    """Applies a batched pytree operator slice-by-slice via scan, over a sharded leading axis.
 
-    The effective per-observation operator is stored as a list of "segments" ([`StreamSegment`][]).
-    Segments are in composition (left-to-right) order: segments[0] is applied last (output side),
-    segments[-1] first (input side). Each segment is tagged obs-*stacked* (sliced per observation)
-    or *shared* (broadcast across observations).
+    Two independent things carry the batch axis, and they are described separately:
 
-    The "block" denomination refers to how each slice appears in the global operator matrix:
-    subclasses arrange the N per-slice operators as blocks of a larger matrix (diagonal, column, or
-    row layout). The `_prepend_in`/`_prepend_out` class flags say whether the block prepends the
-    observation axis to its input/output structure.
+    - The *interior*: [`StreamSegment`][] links, held in composition order (segments[0] applied
+      last, segments[-1] first), each *sliced* or *constant* according to whether its own data
+      carries the batch axis.
+    - The *boundary*: `in_stacked`/`out_stacked` ([`StackSpec`][]) say which input/output
+      *components* carry it. A bare bool covers the whole structure, a prefix pytree resolves per
+      component. A stacked component is sliced on input and stacked on output; a shared one is
+      broadcast on input and sum-reduced (scan carry, then `psum`) on output.
+
+    Neither constrains the other: a sliced segment may sit between shared boundary components, as
+    in a stream that sums over the batch axis. The boundary is what gives a stream its block
+    layout, and the four uniform combinations have constructors of their own:
+
+    | in_stacked | out_stacked | constructor  | signature         |
+    |------------|-------------|--------------|-------------------|
+    | True       | True        | `diagonal`   | (N,in) -> (N,out) |
+    | False      | True        | `column`     | (in,)  -> (N,out) |
+    | True       | False       | `row`        | (N,in) -> (out,)  |
+    | False      | False       | `addition`   | (in,)  -> (out,)  |
+
+    A boundary need not be uniform: the reduction rules produce mixed streams -- some components
+    stacked, some shared -- which is this same class with prefix pytree specs.
 
     An active mesh context is required when calling `mv`; use `jax.set_mesh` beforehand.
     """
 
     segments: tuple[StreamSegment, ...]
     n_lead: int = field(kw_only=True, metadata={'static': True})
-
-    _prepend_in: ClassVar[bool]
-    _prepend_out: ClassVar[bool]
+    in_stacked: StackSpec = field(kw_only=True, metadata={'static': True})
+    out_stacked: StackSpec = field(kw_only=True, metadata={'static': True})
 
     @classmethod
-    def create(cls, operator: AbstractLinearOperator, *, n_lead: int | None = None) -> Self:
-        """Wrap a freshly stacked operator as a block with a single stacked segment.
+    def diagonal(
+        cls, operator: AbstractLinearOperator, *, n_lead: int | None = None
+    ) -> 'StreamOperator':
+        """Block-diagonal stream: each block acts independently on its own slice of the input.
+
+        Given a per-slice operator `(*in,) -> (*out,)` with `N` slices, maps
+        `(N, *in) -> (N, *out)`.
 
         Args:
-            operator: The per-observation operator, stacked along a leading (observation) axis.
-            n_lead: The observation-axis size. If not explicitly provided, is inferred from the
-                operator leaves. Required if the operator has no array leaves.
+            operator: The per-slice operator, stacked along a leading (batch) axis.
+            n_lead: The batch-axis size. Inferred from the operator leaves if omitted; required if
+                the operator has no array leaves.
+
+        Examples:
+            Per-slice noise weighting (square blocks, `*in == *out`):
+
+            >>> with jax.set_mesh(jax.make_mesh((4,), ('batch',))):
+            ...     W = StreamOperator.diagonal(noise_op)  # leaves: (N, *in)
+            ...     weighted = W(samples)                  # (N, *in) -> (N, *out)
         """
-        if n_lead is None:
-            n_lead = _leading_size(operator)
-        return cls._build((StreamSegment(operator, True),), n_lead=n_lead)
+        return cls._single_segment(operator, n_lead, in_stacked=True, out_stacked=True)
 
     @classmethod
-    def _build(cls, segments: tuple[StreamSegment, ...], *, n_lead: int) -> Self:
-        segments = _normalize(segments)
+    def column(
+        cls, operator: AbstractLinearOperator, *, n_lead: int | None = None
+    ) -> 'StreamOperator':
+        """Column stream: applies all blocks to the same input and stacks the results.
+
+        Given a per-slice operator `(*in,) -> (*out,)` with `N` slices, maps `(*in,) -> (N, *out)`.
+
+        Args:
+            operator: The per-slice operator, stacked along a leading (batch) axis.
+            n_lead: The batch-axis size. Inferred from the operator leaves if omitted; required if
+                the operator has no array leaves.
+
+        Examples:
+            Pointing matrix from pixel map to time-ordered data:
+
+            >>> with jax.set_mesh(jax.make_mesh((4,), ('batch',))):
+            ...     H = StreamOperator.column(pointing_op)  # leaves: (N, *out)
+            ...     tod = H(pixel_map)                      # (*in,) -> (N, *out)
+        """
+        return cls._single_segment(operator, n_lead, in_stacked=False, out_stacked=True)
+
+    @classmethod
+    def row(
+        cls, operator: AbstractLinearOperator, *, n_lead: int | None = None
+    ) -> 'StreamOperator':
+        """Row stream: applies each block to its own input slice and sums the results.
+
+        Given a per-slice operator `(*in,) -> (*out,)` with `N` slices, maps `(N, *in) -> (*out,)`.
+
+        Args:
+            operator: The per-slice operator, stacked along a leading (batch) axis.
+            n_lead: The batch-axis size. Inferred from the operator leaves if omitted; required if
+                the operator has no array leaves.
+
+        Examples:
+            Co-addition of time-ordered data back to a pixel map:
+
+            >>> with jax.set_mesh(jax.make_mesh((4,), ('batch',))):
+            ...     HT = StreamOperator.row(pointing_op_T)  # leaves: (N, *in)
+            ...     pixel_map = HT(tod)                     # (N, *in) -> (*out,)
+        """
+        return cls._single_segment(operator, n_lead, in_stacked=True, out_stacked=False)
+
+    @classmethod
+    def addition(
+        cls, operator: AbstractLinearOperator, *, n_lead: int | None = None
+    ) -> 'StreamOperator':
+        """Addition stream: applies all blocks to the same input and sums the results.
+
+        Given a per-slice operator `(*in,) -> (*out,)` with `N` slices, maps `(*in,) -> (*out,)`.
+
+        Arises naturally as the reduction of a row stream composed with a column one, e.g. the
+        normal equations operator `H.T @ W @ H` in mapmaking.
+
+        Args:
+            operator: The per-slice operator, stacked along a leading (batch) axis.
+            n_lead: The batch-axis size. Inferred from the operator leaves if omitted; required if
+                the operator has no array leaves.
+
+        Examples:
+            Normal equations from a pointing and weighting operator:
+
+            >>> with jax.set_mesh(jax.make_mesh((4,), ('batch',))):
+            ...     A = (H.T @ W @ H).reduce()  # in_stacked and out_stacked both False
+            ...     rhs = A(pixel_map)          # (*in,) -> (*out,)
+        """
+        return cls._single_segment(operator, n_lead, in_stacked=False, out_stacked=False)
+
+    @classmethod
+    def create(
+        cls,
+        segments: tuple[StreamSegment, ...],
+        *,
+        n_lead: int,
+        in_stacked: StackSpec,
+        out_stacked: StackSpec,
+    ) -> 'StreamOperator':
+        """Build a stream from an explicit segment chain; the general constructor.
+
+        Args:
+            segments: The per-slice operator chain, in composition order; at least one.
+            n_lead: The batch-axis size.
+            in_stacked: Which input components carry the batch axis.
+            out_stacked: Which output components carry the batch axis.
+
+        Raises:
+            ValueError: If ``segments`` is empty, if a sliced segment has an array leaf that does
+                not lead with ``n_lead``, or a spec is not a prefix of the structure it applies to.
+        """
+        if not segments:
+            raise ValueError('a stream needs at least one segment')
+        segments = _normalize(segments, n_lead)
         for seg in segments:
-            if seg.stacked:
-                _check_stacked(seg.operator, n_lead)
-        per_obs_in = segments[-1].in_structure  # rightmost segment is applied first
-        if cls._prepend_in:
-            in_structure = _prepend_axis(per_obs_in, axis_size=n_lead)
-        else:
-            in_structure = per_obs_in
-        return cls(segments, n_lead=n_lead, in_structure=in_structure)
+            if seg.sliced:
+                _check_sliceable(seg.operator, n_lead)
+        per_slice_in = segments[-1].in_structure  # rightmost segment is applied first
+        in_stacked = _canonical_spec(in_stacked, per_slice_in)
+        out_stacked = _canonical_spec(out_stacked, segments[0].out_structure)
+        return cls(
+            segments,
+            n_lead=n_lead,
+            in_stacked=in_stacked,
+            out_stacked=out_stacked,
+            in_structure=_expand_structure(per_slice_in, in_stacked, n_lead),
+        )
+
+    @classmethod
+    def _single_segment(
+        cls,
+        operator: AbstractLinearOperator,
+        n_lead: int | None,
+        *,
+        in_stacked: bool,
+        out_stacked: bool,
+    ) -> 'StreamOperator':
+        """Wrap a freshly stacked operator as a stream with a single sliced segment."""
+        if n_lead is None:
+            n_lead = _leading_size(operator)
+        return cls.create(
+            (StreamSegment(operator, True),),
+            n_lead=n_lead,
+            in_stacked=in_stacked,
+            out_stacked=out_stacked,
+        )
+
+    @property
+    def per_slice_in_structure(self) -> PyTree[jax.ShapeDtypeStruct]:
+        """Input structure of one slice, before `in_stacked` adds the batch axis.
+
+        Segments are in composition order, so the *last* one is applied first and owns the input.
+        """
+        return self.segments[-1].in_structure
+
+    @property
+    def per_slice_out_structure(self) -> PyTree[jax.ShapeDtypeStruct]:
+        """Output structure of one slice, before `out_stacked` adds the batch axis.
+
+        Segments are in composition order, so the *first* one is applied last and owns the output.
+        """
+        return self.segments[0].out_structure
 
     @property
     def out_structure(self) -> PyTree[jax.ShapeDtypeStruct]:
-        per_obs_out = self.segments[0].out_structure  # leftmost segment is applied last
-        if self._prepend_out:
-            return _prepend_axis(per_obs_out, axis_size=self.n_lead)
-        return per_obs_out
+        return _expand_structure(self.per_slice_out_structure, self.out_stacked, self.n_lead)
 
     @property
     def operator(self) -> AbstractLinearOperator:
-        """Effective per-observation operator (composition of the segments; for introspection)."""
+        """Effective per-slice operator (composition of the segments; for introspection)."""
         # segments is never empty (see _normalize), so _compose needs no fallback structure
         return _compose(tuple(seg.operator for seg in self.segments))
 
     def reduce(self) -> AbstractLinearOperator:
-        segments = tuple(seg.reduce() for seg in self.segments)
-        return type(self)._build(segments, n_lead=self.n_lead)
+        return type(self).create(
+            tuple(seg.reduce() for seg in self.segments),
+            n_lead=self.n_lead,
+            in_stacked=self.in_stacked,
+            out_stacked=self.out_stacked,
+        )
+
+    def transpose(self) -> AbstractLinearOperator:
+        # Swapping the specs transposes the layout: diagonal and addition map to themselves,
+        # column and row to each other.
+        return type(self).create(
+            segments=tuple(seg.transpose() for seg in reversed(self.segments)),
+            n_lead=self.n_lead,
+            in_stacked=self.out_stacked,
+            out_stacked=self.in_stacked,
+        )
+
+    def mv(self, x: PyTree[Inexact[Array, '...']]) -> PyTree[Inexact[Array, '...']]:
+        mesh = _get_mesh()
+        axis = mesh.axis_names[0]
+        length = self.n_lead // mesh.shape[axis]  # slices per shard
+
+        # Stacked inputs ride the scan, shared ones are closed over. `eqx.partition` broadcasts a
+        # prefix spec itself, so the input side needs no per-leaf mask.
+        x_stacked, x_shared = eqx.partition(x, self.in_stacked)
+        dyn, static = self._partition()
+
+        # Stacked outputs are emitted per step; shared ones accumulate in the carry, then psum.
+        per_slice_out = self.per_slice_out_structure
+        out_mask = jax.tree.broadcast(self.out_stacked, per_slice_out)
+        out_pspecs = jax.tree.map(lambda stacked: P(axis) if stacked else P(), out_mask)
+        _, shared_out_structure = eqx.partition(per_slice_out, out_mask)
+
+        @jax.shard_map(out_specs=out_pspecs, check_vma=False)
+        def kernel(dyn, static, x_stacked, x_shared):  # type: ignore[no-untyped-def]
+            def step(carry, args):  # type: ignore[no-untyped-def]
+                dyn_i, xs_i = args
+                y = _apply_chain(dyn_i, static, eqx.combine(xs_i, x_shared))
+                ys_i, y_shared = eqx.partition(y, out_mask)
+                return tree.add(carry, y_shared), ys_i
+
+            # pcast makes the replicated zeros match the varying carry type inside shard_map
+            init = jax.lax.pcast(tree.zeros_like(shared_out_structure), axis, to='varying')
+            carry, ys = jax.lax.scan(step, init, (dyn, x_stacked), length=length)
+            return eqx.combine(ys, jax.lax.psum(carry, axis_name=axis))
+
+        return kernel(dyn, static, x_stacked, x_shared)
+
+    @property
+    def sliced_count(self) -> int:
+        """How many segments carry the batch axis, i.e. how many sliced passes the body makes."""
+        return sum(seg.sliced for seg in self.segments)
+
+    def _aligned_segments(self, n_sliced: int) -> tuple[StreamSegment, ...]:
+        """Pad this body onto the canonical slot pattern ``[constant, sliced, ..., constant]``.
+
+        Laying several bodies side by side needs them to agree slot for slot, which they do not:
+        one may be ``[sliced]`` and another ``[sliced, constant, sliced]``. Padding with identities
+        makes them agree without changing what any of them computes.
+
+        Alignment is cheap because `_normalize` merges adjacent segments of the same kind, so every
+        body's kinds strictly alternate and the pattern follows from the sliced count alone: send
+        the j-th sliced segment to slot ``2j + 1`` and the constant segments to the even slots
+        around them. A sliced identity in an unused odd slot is legal -- `_check_sliceable` is
+        vacuous on an operator with no array leaves -- and a slot left identity across *all* the
+        bodies folds back into its neighbour, since the block operator built from it is pure.
+        """
+        slots: list[StreamSegment | None] = [None] * (2 * n_sliced + 1)
+        seen = 0
+        for seg in self.segments:
+            if seg.sliced:
+                slots[2 * seen + 1] = seg
+                seen += 1
+            else:
+                slots[2 * seen] = seg  # the constant slot just left of the next sliced one
+        # walk right to left, the direction values flow, so each identity gets its slot's structure
+        filled: list[StreamSegment] = []
+        structure = self.per_slice_in_structure
+        for position, slot in reversed(list(enumerate(slots))):
+            if slot is None:
+                filled.append(
+                    StreamSegment(IdentityOperator(in_structure=structure), position % 2 == 1)
+                )
+            else:
+                structure = slot.out_structure
+                filled.append(slot)
+        return tuple(reversed(filled))
 
     def _partition(
         self,
     ) -> tuple[tuple[AbstractLinearOperator, ...], tuple[AbstractLinearOperator, ...]]:
         """Split each segment's operator into (dynamic, static).
 
-        Stacked segments expose their arrays to the scan, shared segments keep everything static
-        (broadcast across observations).
+        A sliced segment exposes its arrays to the scan, which takes a slice each step; a constant
+        one keeps everything static, so the same operator is applied at every step.
         """
         dyn: list[AbstractLinearOperator] = []
         stat: list[AbstractLinearOperator] = []
         for seg in self.segments:
-            if seg.stacked:
+            if seg.sliced:
                 dyn_i, stat_i = eqx.partition(seg.operator, eqx.is_array)
             else:
                 dyn_i, stat_i = eqx.partition(seg.operator, lambda _: False)
@@ -135,215 +399,67 @@ class AbstractStreamOperator(AbstractLinearOperator, ABC):
         return tuple(dyn), tuple(stat)
 
 
-class StreamDiagonalOperator(AbstractStreamOperator):
-    """Block-diagonal operator: each block acts independently on its own slice of the input.
+class StreamStreamFusionRule(AbstractCompositionRule):
+    """Fuse `left @ right` streams when the junction is entirely stacked.
 
-    Given a per-observation operator `(*in,) -> (*out,)` with `N` slices, maps
-    `(N, *in) -> (N, *out)`.
+    The *junction* is the intermediate structure the two streams meet at: `right`'s output, which
+    `left` consumes as input (in mapmaking, the per-slice TOD between e.g. `Hᵀ` and `H`).
 
-    Example — per-observation noise weighting (square blocks, `*in == *out`):
-
-        >>> with jax.set_mesh(jax.make_mesh((4,), ('obs',))):
-        ...     W = StreamDiagonalOperator.create(noise_op)  # leaves: (N, *in)
-        ...     weighted = W(samples)                           # (N, *in) -> (N, *out)
+    In composition order the segment lists concatenate; the fused specs are the outer ones
+    (`in = right.in_stacked`, `out = left.out_stacked`). Fusion is only valid when every junction
+    component is stacked on both sides: a *shared* junction component is a psum-reduction only
+    available after the full scan, so threading it through a single fused scan would be wrong
+    (e.g. addition @ addition: `(Σᵢaᵢ)(Σⱼbⱼ) ≠ Σᵢ aᵢbᵢ`). Such compositions stay unreduced. Every
+    composition among the four uniform layouts meets at a stacked junction, so this single rule
+    handles them all without per-layout special cases.
     """
 
-    _prepend_in = True
-    _prepend_out = True
+    left_operator_class = StreamOperator
+    right_operator_class = StreamOperator
 
-    def mv(self, x: PyTree[Inexact[Array, '...']]) -> PyTree[Inexact[Array, '...']]:
-        axis = _get_mesh().axis_names[0]
-        dyn, static = self._partition()
-
-        @jax.shard_map(out_specs=P(axis), check_vma=False)
-        def kernel(dyn, static, x):  # type: ignore[no-untyped-def]
-            def step(_, args):  # type: ignore[no-untyped-def]
-                dyn_i, x_i = args
-                return None, _apply_chain(dyn_i, static, x_i)
-
-            _, out = jax.lax.scan(step, None, (dyn, x))
-            return out
-
-        return kernel(dyn, static, x)
-
-    def transpose(self) -> AbstractLinearOperator:
-        segments = tuple(seg.transpose() for seg in reversed(self.segments))
-        return StreamDiagonalOperator._build(segments, n_lead=self.n_lead)
-
-
-class StreamColumnOperator(AbstractStreamOperator):
-    """Column operator: applies all blocks to the same input and stacks the results.
-
-    Given a per-observation operator `(*in,) -> (*out,)` with `N` slices, maps
-    `(*in,) -> (N, *out)`.
-
-    Example — pointing matrix from pixel map to time-ordered data:
-
-        >>> with jax.set_mesh(jax.make_mesh((4,), ('obs',))):
-        ...     H = StreamColumnOperator.create(pointing_op)  # leaves: (N, *out)
-        ...     tod = H(pixel_map)                               # (*in,) -> (N, *out)
-    """
-
-    _prepend_in = False
-    _prepend_out = True
-
-    def mv(self, x: PyTree[Inexact[Array, '...']]) -> PyTree[Inexact[Array, '...']]:
-        axis = _get_mesh().axis_names[0]
-        dyn, static = self._partition()
-
-        @jax.shard_map(out_specs=P(axis), check_vma=False)
-        def kernel(dyn, static, x):  # type: ignore[no-untyped-def]
-            def step(_, dyn_i):  # type: ignore[no-untyped-def]
-                return None, _apply_chain(dyn_i, static, x)
-
-            _, out = jax.lax.scan(step, None, dyn)
-            return out
-
-        return kernel(dyn, static, x)
-
-    def transpose(self) -> AbstractLinearOperator:
-        segments = tuple(seg.transpose() for seg in reversed(self.segments))
-        return StreamRowOperator._build(segments, n_lead=self.n_lead)
-
-
-class StreamRowOperator(AbstractStreamOperator):
-    """Row operator: applies each block to its own input slice and sums the results.
-
-    Given a per-observation operator `(*in,) -> (*out,)` with `N` slices, maps
-    `(N, *in) -> (*out,)`.
-
-    Example — co-addition of time-ordered data back to a pixel map:
-
-        >>> with jax.set_mesh(jax.make_mesh((4,), ('obs',))):
-        ...     HT = StreamRowOperator.create(pointing_op_T)  # leaves: (N, *in)
-        ...     pixel_map = HT(tod)                              # (N, *in) -> (*out,)
-    """
-
-    _prepend_in = True
-    _prepend_out = False
-
-    def mv(self, x: PyTree[Inexact[Array, '...']]) -> PyTree[Inexact[Array, '...']]:
-        axis = _get_mesh().axis_names[0]
-        out_structure = self.segments[0].out_structure
-        dyn, static = self._partition()
-
-        @jax.shard_map(out_specs=P(), check_vma=False)
-        def kernel(dyn, static, x):  # type: ignore[no-untyped-def]
-            def step(carry, args):  # type: ignore[no-untyped-def]
-                dyn_i, x_i = args
-                return tree.add(carry, _apply_chain(dyn_i, static, x_i)), None
-
-            # pcast makes the replicated zeros match the varying carry type inside shard_map
-            init = jax.lax.pcast(tree.zeros_like(out_structure), axis, to='varying')
-            out, _ = jax.lax.scan(step, init, (dyn, x))
-            return jax.lax.psum(out, axis_name=axis)
-
-        return kernel(dyn, static, x)
-
-    def transpose(self) -> AbstractLinearOperator:
-        segments = tuple(seg.transpose() for seg in reversed(self.segments))
-        return StreamColumnOperator._build(segments, n_lead=self.n_lead)
-
-
-class StreamAdditionOperator(AbstractStreamOperator):
-    """Addition operator: applies all blocks to the same input and sums the results.
-
-    Given a per-observation operator `(*in,) -> (*out,)` with `N` slices, maps
-    `(*in,) -> (*out,)`.
-
-    Arises naturally as the reduction of `StreamRowOperator @ StreamColumnOperator`,
-    e.g. the normal equations operator `H.T @ W @ H` in mapmaking.
-
-    Example — normal equations from a pointing and weighting operator:
-
-        >>> with jax.set_mesh(jax.make_mesh((4,), ('obs',))):
-        ...     A = (H.T @ W @ H).reduce()  # reduces to StreamAdditionOperator
-        ...     rhs = A(pixel_map)          # (*in,) -> (*out,)
-    """
-
-    _prepend_in = False
-    _prepend_out = False
-
-    def mv(self, x: PyTree[Inexact[Array, '...']]) -> PyTree[Inexact[Array, '...']]:
-        axis = _get_mesh().axis_names[0]
-        out_structure = self.segments[0].out_structure
-        dyn, static = self._partition()
-
-        @jax.shard_map(out_specs=P(), check_vma=False)
-        def kernel(dyn, static, x):  # type: ignore[no-untyped-def]
-            def step(carry, dyn_i):  # type: ignore[no-untyped-def]
-                return tree.add(carry, _apply_chain(dyn_i, static, x)), None
-
-            # pcast makes the replicated zeros match the varying carry type inside shard_map
-            init = jax.lax.pcast(tree.zeros_like(out_structure), axis, to='varying')
-            out, _ = jax.lax.scan(step, init, dyn)
-            return jax.lax.psum(out, axis_name=axis)
-
-        return kernel(dyn, static, x)
-
-    def transpose(self) -> AbstractLinearOperator:
-        segments = tuple(seg.transpose() for seg in reversed(self.segments))
-        return StreamAdditionOperator._build(segments, n_lead=self.n_lead)
-
-
-class AbstractStreamFusionRule(AbstractCompositionRule):
-    """Fuse a composition of two stream operators into one stream.
-
-    In composition order the segment lists simply concatenate. The obs-independent maps that meet
-    at the junction ride along as shared segments; a non-scalar junction fuses just like a scalar
-    one. Whatever adjacent segments can genuinely merge do so in the reduced class constructor.
-    """
-
-    reduced_class: type[AbstractStreamOperator]
+    def check(self, left: AbstractLinearOperator, right: AbstractLinearOperator) -> None:
+        super().check(left, right)
+        assert isinstance(left, StreamOperator)  # mypy
+        assert isinstance(right, StreamOperator)  # mypy
+        # n_lead must be checked explicitly: the all-stacked test below is vacuous on a leafless
+        # junction (no leaves to disagree), so it cannot catch a slot-count mismatch on its own.
+        if left.n_lead != right.n_lead:
+            raise NoReduction
+        junction = right.per_slice_out_structure  # == left.per_slice_in_structure if it fuses
+        if not structure_equal(left.per_slice_in_structure, junction):
+            raise NoReduction
+        left_in = jax.tree.broadcast(left.in_stacked, junction)
+        right_out = jax.tree.broadcast(right.out_stacked, junction)
+        if not jax.tree.all(left_in) or not jax.tree.all(right_out):
+            raise NoReduction
 
     def apply(
         self, left: AbstractLinearOperator, right: AbstractLinearOperator
     ) -> list[AbstractLinearOperator]:
-        assert isinstance(left, AbstractStreamOperator)  # mypy
-        assert isinstance(right, AbstractStreamOperator)  # mypy
+        assert isinstance(left, StreamOperator)  # mypy
+        assert isinstance(right, StreamOperator)  # mypy
         segments = left.segments + right.segments
-        return [self.reduced_class._build(segments, n_lead=left.n_lead)]
-
-
-class StreamDiagonalStreamDiagonalRule(AbstractStreamFusionRule):
-    """`StreamDiagonal @ StreamDiagonal = StreamDiagonal`."""
-
-    left_operator_class = StreamDiagonalOperator
-    right_operator_class = StreamDiagonalOperator
-    reduced_class = StreamDiagonalOperator
-
-
-class StreamDiagonalStreamColumnRule(AbstractStreamFusionRule):
-    """`StreamDiagonal @ StreamColumn = StreamColumn`."""
-
-    left_operator_class = StreamDiagonalOperator
-    right_operator_class = StreamColumnOperator
-    reduced_class = StreamColumnOperator
-
-
-class StreamRowStreamDiagonalRule(AbstractStreamFusionRule):
-    """`StreamRow @ StreamDiagonal = StreamRow`."""
-
-    left_operator_class = StreamRowOperator
-    right_operator_class = StreamDiagonalOperator
-    reduced_class = StreamRowOperator
-
-
-class StreamRowStreamColumnRule(AbstractStreamFusionRule):
-    """`StreamRow @ StreamColumn = StreamAddition`."""
-
-    left_operator_class = StreamRowOperator
-    right_operator_class = StreamColumnOperator
-    reduced_class = StreamAdditionOperator
+        return [
+            StreamOperator.create(
+                segments,
+                n_lead=left.n_lead,
+                in_stacked=right.in_stacked,
+                out_stacked=left.out_stacked,
+            )
+        ]
 
 
 class HomothetyStreamRule(AbstractCompositionRule):
-    """`Homothety @ Stream = Stream` with the scalar attached as a shared segment.
+    """`Homothety @ Stream = Stream` with the scalar attached as a constant segment.
 
-    The scalar becomes a shared (obs-independent) segment on the output side (``Homothety @ block``)
-    or input side (``block @ Homothety``); it is not sliced. A scalar commutes through a linear
-    operator, so the surrounding sum still collapses to a single fused stream via the addition-
-    fusion rules.
+    The scalar becomes a constant segment -- never sliced -- leading for ``Homothety @ block`` and
+    trailing for ``block @ Homothety``.
+
+    Which of those the rule actually sees is not up to the caller: a scalar commutes through a
+    linear operator, and the algebra relocates it to whichever side has the smaller structure
+    before this rule fires. So ``c * block`` can land on either end depending only on the block
+    shape. Both spellings compute the same thing, and either way the scalar stays out of the sliced
+    body, so the surrounding sum still collapses to a single fused stream via the addition rule.
     """
 
     operator_class = HomothetyOperator
@@ -351,11 +467,11 @@ class HomothetyStreamRule(AbstractCompositionRule):
     @staticmethod
     def _split(
         left: AbstractLinearOperator, right: AbstractLinearOperator
-    ) -> tuple[HomothetyOperator, AbstractStreamOperator, bool] | None:
+    ) -> tuple[HomothetyOperator, StreamOperator, bool] | None:
         """Returns `(homothety, block, on_output_side)` or `None` if the rule does not apply."""
-        if isinstance(left, HomothetyOperator) and isinstance(right, AbstractStreamOperator):
+        if isinstance(left, HomothetyOperator) and isinstance(right, StreamOperator):
             return left, right, True
-        if isinstance(right, HomothetyOperator) and isinstance(left, AbstractStreamOperator):
+        if isinstance(right, HomothetyOperator) and isinstance(left, StreamOperator):
             return right, left, False
         return None
 
@@ -369,97 +485,92 @@ class HomothetyStreamRule(AbstractCompositionRule):
         split = self._split(left, right)
         assert split is not None  # mypy
         homo, block, on_output_side = split
-        if on_output_side:  # homo @ block: leading shared segment
+        if on_output_side:  # homo @ block: leading constant segment
             # we need the per-block structure here, not the public one with the leading axis
-            scalar = HomothetyOperator(homo.value, in_structure=block.segments[0].out_structure)
+            scalar = HomothetyOperator(homo.value, in_structure=block.per_slice_out_structure)
             segments = (StreamSegment(scalar, False),) + block.segments
-        else:  # block @ homo: trailing shared segment
-            scalar = HomothetyOperator(homo.value, in_structure=block.segments[-1].in_structure)
+        else:  # block @ homo: trailing constant segment
+            scalar = HomothetyOperator(homo.value, in_structure=block.per_slice_in_structure)
             segments = block.segments + (StreamSegment(scalar, False),)
-        return [type(block)._build(segments, n_lead=block.n_lead)]
+        return [
+            StreamOperator.create(
+                segments,
+                n_lead=block.n_lead,
+                in_stacked=block.in_stacked,
+                out_stacked=block.out_stacked,
+            )
+        ]
 
 
-class AbstractStreamAdditionFusionRule(AbstractAdditionRule):
-    """Fuse a sum of two stream operators of the same kind into one stream.
+class StreamStreamAdditionRule(AbstractAdditionRule):
+    """Fuse a sum of two matching stream operators into one stream.
 
-    Each operand is split into ``(pre, core, post)`` around its single stacked segment. When both
-    have trivial (identity) shared maps the cores add directly. Otherwise the shared maps are kept
-    out of the sliced body: the ``pre`` maps fan the input into a ``BlockColumnOperator``, the two
-    cores sit on a ``BlockDiagonalOperator`` (the one stacked segment), and the ``post`` maps
-    recombine through a ``BlockRowOperator``.
+    The two bodies are padded onto a common slot pattern (see `_aligned_segments`) and blocked
+    up slot by slot, each slot keeping its own tag: the rightmost fans the shared input across the
+    two legs through a ``BlockColumnOperator``, the leftmost sums them back through a
+    ``BlockRowOperator``, and everything between acts componentwise on a ``BlockDiagonalOperator``.
+    Slots that stay identity across both operands fold away in `_normalize`, so a sum of two plain
+    streams still comes out as a single sliced segment.
 
-    An operand without exactly one stacked segment cannot be laid out this way, so the rule defers.
+    The operands must share n_lead, per-slice in/out structure, and both stack specs (a sum only
+    fuses if both sides map the same layout); otherwise, or if neither operand has a sliced
+    segment, the rule defers to a plain ``AdditionOperator``.
     """
 
-    reduced_class: type[AbstractStreamOperator]
+    left_operator_class = StreamOperator
+    right_operator_class = StreamOperator
 
     def check(self, left: AbstractLinearOperator, right: AbstractLinearOperator) -> None:
         super().check(left, right)
-        # Diagonal/row/column blocks carry the obs axis in their structures, so `__add__` already
-        # forces equal n there; StreamAddition structures are per-observation, making a mismatched-n
-        # sum legal algebra that must stay unreduced rather than crash in `_build`.
-        assert isinstance(left, AbstractStreamOperator)  # mypy
-        assert isinstance(right, AbstractStreamOperator)  # mypy
+        assert isinstance(left, StreamOperator)  # mypy
+        assert isinstance(right, StreamOperator)  # mypy
+        # An addition stream's structures are per-slice, so `__add__`'s structure check does not
+        # force equal n; a mismatched-n sum is legal algebra that must stay unreduced. Mixed specs
+        # (previously guaranteed equal by same-class dispatch) must now be checked explicitly too.
         if left.n_lead != right.n_lead:
+            raise NoReduction
+        per_slice_in = left.per_slice_in_structure
+        per_slice_out = left.per_slice_out_structure
+        if not structure_equal(per_slice_in, right.per_slice_in_structure):
+            raise NoReduction
+        if not structure_equal(per_slice_out, right.per_slice_out_structure):
+            raise NoReduction
+        if not _specs_equal(left.in_stacked, right.in_stacked, per_slice_in):
+            raise NoReduction
+        if not _specs_equal(left.out_stacked, right.out_stacked, per_slice_out):
             raise NoReduction
 
     def apply(
         self, left: AbstractLinearOperator, right: AbstractLinearOperator
     ) -> list[AbstractLinearOperator]:
-        assert isinstance(left, AbstractStreamOperator)  # mypy
-        assert isinstance(right, AbstractStreamOperator)  # mypy
-        split_left = _split_core(left)
-        split_right = _split_core(right)
-        if split_left is None or split_right is None:
-            raise NoReduction  # not a single-stacked-core body: defer to a plain AdditionOperator
-        pre_l, core_l, post_l = split_left
-        pre_r, core_r, post_r = split_right
-        trivial = all(isinstance(op, IdentityOperator) for op in (pre_l, post_l, pre_r, post_r))
-        if trivial:
-            core = (core_l + core_r).reduce()
-            return [self.reduced_class._build((StreamSegment(core, True),), n_lead=left.n_lead)]
-        pre = BlockColumnOperator([pre_l, pre_r])
-        core = BlockDiagonalOperator([core_l, core_r])
-        post = BlockRowOperator([post_l, post_r])
-        # composition order: post @ core @ pre
-        segments = (
-            StreamSegment(post, False),
-            StreamSegment(core, True),
-            StreamSegment(pre, False),
-        )
-        return [self.reduced_class._build(segments, n_lead=left.n_lead)]
-
-
-class StreamDiagonalAdditionRule(AbstractStreamAdditionFusionRule):
-    """`StreamDiagonal + StreamDiagonal = StreamDiagonal`."""
-
-    left_operator_class = StreamDiagonalOperator
-    right_operator_class = StreamDiagonalOperator
-    reduced_class = StreamDiagonalOperator
-
-
-class StreamColumnAdditionRule(AbstractStreamAdditionFusionRule):
-    """`StreamColumn + StreamColumn = StreamColumn`."""
-
-    left_operator_class = StreamColumnOperator
-    right_operator_class = StreamColumnOperator
-    reduced_class = StreamColumnOperator
-
-
-class StreamRowAdditionRule(AbstractStreamAdditionFusionRule):
-    """`StreamRow + StreamRow = StreamRow`."""
-
-    left_operator_class = StreamRowOperator
-    right_operator_class = StreamRowOperator
-    reduced_class = StreamRowOperator
-
-
-class StreamAdditionAdditionRule(AbstractStreamAdditionFusionRule):
-    """`StreamAddition + StreamAddition = StreamAddition`."""
-
-    left_operator_class = StreamAdditionOperator
-    right_operator_class = StreamAdditionOperator
-    reduced_class = StreamAdditionOperator
+        assert isinstance(left, StreamOperator)  # mypy
+        assert isinstance(right, StreamOperator)  # mypy
+        n_sliced = max(left.sliced_count, right.sliced_count)
+        if n_sliced == 0:
+            raise NoReduction  # nothing to stream: defer to a plain AdditionOperator
+        # Align the two bodies slot for slot, then block them up position-wise. The rightmost slot
+        # fans the shared input out over the two legs, the leftmost sums them back, and everything
+        # between acts componentwise. `_normalize` folds away the slots that stay identity.
+        aligned = [op._aligned_segments(n_sliced) for op in (left, right)]
+        last = 2 * n_sliced
+        segments = []
+        for position, slot in enumerate(zip(*aligned, strict=True)):
+            operators = [seg.operator for seg in slot]
+            if position == 0:
+                block: AbstractLinearOperator = BlockRowOperator(operators)
+            elif position == last:
+                block = BlockColumnOperator(operators)
+            else:
+                block = BlockDiagonalOperator(operators)
+            segments.append(StreamSegment(block, position % 2 == 1))
+        return [
+            StreamOperator.create(
+                tuple(segments),
+                n_lead=left.n_lead,
+                in_stacked=left.in_stacked,
+                out_stacked=left.out_stacked,
+            )
+        ]
 
 
 # ---------------------------------------------------------------------------
@@ -475,10 +586,10 @@ def _get_mesh() -> AbstractMesh:
 
 
 def _leading_size(operator: AbstractLinearOperator) -> int:
-    """Observation-axis size of a *stacked* operator: all (array) leaves share a leading axis.
+    """Batch-axis size of a *sliceable* operator: all (array) leaves share a leading axis.
 
     This only returns the leading axis size of the first leaf encountered. It does not check that
-    all leaves have consistent dimensions (see [`_check_stacked`][] for that).
+    all leaves have consistent dimensions (see [`_check_sliceable`][] for that).
     """
     for leaf in jax.tree.leaves(operator):
         if eqx.is_array(leaf) and jnp.ndim(leaf) >= 1:
@@ -486,18 +597,69 @@ def _leading_size(operator: AbstractLinearOperator) -> int:
     raise RuntimeError('cannot infer leading axis size: no non-scalar array leaf')
 
 
-def _prepend_axis(
-    structure: PyTree[jax.ShapeDtypeStruct], axis_size: int
+def _canonical_spec(spec: StackSpec, structure: PyTree[Any]) -> StackSpec:
+    """Collapse a spec that is uniform over ``structure`` to a bare bool; pass a mixed one through.
+
+    A spec has redundant spellings -- over a two-component structure, ``True`` and ``[True, True]``
+    say the same thing -- so equivalence is only decidable against the structure it applies to.
+
+    Worth normalising because specs are static fields, hence pytree aux data, hence part of treedef
+    equality: the same operator spelled two ways would otherwise land in two `jax.jit` cache
+    entries. `block_column` of two column streams really does produce ``[True, True]`` where
+    `column` produces ``True``.
+    """
+    leaves = jax.tree.leaves(jax.tree.broadcast(spec, structure))
+    if not leaves:
+        return spec  # no components, so no spelling to prefer
+    if all(leaves):
+        return True
+    if not any(leaves):
+        return False
+    return spec
+
+
+def _expand_structure(
+    structure: PyTree[jax.ShapeDtypeStruct], spec: StackSpec, n_lead: int
 ) -> PyTree[jax.ShapeDtypeStruct]:
-    return jax.tree.map(lambda s: jax.ShapeDtypeStruct((axis_size, *s.shape), s.dtype), structure)
+    """Prepend the batch axis on the stacked leaves of ``structure`` only."""
+    return jax.tree.map(
+        lambda stacked, s: jax.ShapeDtypeStruct((n_lead, *s.shape), s.dtype) if stacked else s,
+        jax.tree.broadcast(spec, structure),
+        structure,
+    )
 
 
-def _check_stacked(operator: AbstractLinearOperator, n_lead: int) -> None:
-    """Assert every array leaf of an *stacked* segment leads with the same axis size."""
+def _specs_equal(a: StackSpec, b: StackSpec, structure: PyTree[Any]) -> bool:
+    """Whether two specs mark the same leaves of ``structure`` as stacked.
+
+    Compares the expanded leaves rather than the specs themselves: `_canonical_spec` collapses
+    only *uniform* specs, so two mixed specs can agree leafwise while being spelled differently.
+    """
+    ea = jax.tree.leaves(jax.tree.broadcast(a, structure))
+    eb = jax.tree.leaves(jax.tree.broadcast(b, structure))
+    return ea == eb
+
+
+def _unsliceable_leaf_shape(
+    operator: AbstractLinearOperator, n_lead: int
+) -> tuple[int, ...] | None:
+    """Shape of the first array leaf that does not lead with the batch axis, else None."""
     for leaf in jax.tree.leaves(operator):
         if eqx.is_array(leaf) and (jnp.ndim(leaf) < 1 or jnp.shape(leaf)[0] != n_lead):
-            msg = f'expected leading axis size {n_lead=}, got shape {jnp.shape(leaf)}'
-            raise ValueError(msg)
+            return jnp.shape(leaf)
+    return None
+
+
+def _is_sliceable(operator: AbstractLinearOperator, n_lead: int) -> bool:
+    """Whether every array leaf leads with the batch axis, i.e. the operator can be sliced."""
+    return _unsliceable_leaf_shape(operator, n_lead) is None
+
+
+def _check_sliceable(operator: AbstractLinearOperator, n_lead: int) -> None:
+    """Assert an operator may be sliced: every array leaf leads with the batch axis."""
+    # `is not None`, not truthiness: a 0-d leaf has shape `()`, which is falsy but is a failure
+    if (shape := _unsliceable_leaf_shape(operator, n_lead)) is not None:
+        raise ValueError(f'expected leading axis size {n_lead=}, got shape {shape}')
 
 
 def _compose(
@@ -515,33 +677,43 @@ def _compose(
     return functools.reduce(lambda acc, operator: acc @ operator, operators).reduce()
 
 
-def _normalize(segments: tuple[StreamSegment, ...]) -> tuple[StreamSegment, ...]:
-    """Drop trivial shared identities and merge consecutive same-tag segments."""
+def _try_merge(left: StreamSegment, right: StreamSegment, n_lead: int) -> StreamSegment | None:
+    """Compose two adjacent segments into one, or return None if that would change what they do.
+
+    Segments of the same kind always compose. Across kinds, only a *pure* segment may join its
+    neighbour: it owns nothing, so being re-labelled sliced costs it nothing. A constant segment
+    that owns data must stay put -- that data is applied whole to every slice, and slicing it
+    instead would silently compute something else, including when its leading axis happens to
+    equal `n_lead` and the sliceability check below would wave it through.
+
+    The composed operator is checked too, since reduction can materialise data that was not there
+    before: relocating a `HomothetyOperator` promotes its scalar to a 0-d array, which `scan`
+    cannot slice. A scalar therefore never joins a sliced segment. That costs one constant segment,
+    applied once per step and leaving the sliced count unchanged, so nothing downstream is blocked.
+    """
+    # composition order: left is applied later, right first
+    if left.sliced != right.sliced and not (left.is_pure or right.is_pure):
+        return None
+    sliced = left.sliced or right.sliced
+    operator = (left.operator @ right.operator).reduce()
+    if sliced and not _is_sliceable(operator, n_lead):
+        return None
+    return StreamSegment(operator, sliced)
+
+
+def _normalize(segments: tuple[StreamSegment, ...], n_lead: int) -> tuple[StreamSegment, ...]:
+    """Drop constant identities and merge adjacent segments wherever that is legal."""
     merged: list[StreamSegment] = []
     for seg in segments:
-        if seg.trivial:
-            continue  # drop shared identities
-        if merged and merged[-1].stacked == seg.stacked:
-            # composition order: merged[-1] is to the left (applied later), seg to the right
-            merged[-1] = StreamSegment((merged[-1].operator @ seg.operator).reduce(), seg.stacked)
+        if seg.is_identity:
+            continue  # contributes nothing at all
+        candidate = _try_merge(merged[-1], seg, n_lead) if merged else None
+        if candidate is not None:
+            merged[-1] = candidate
         else:
             merged.append(seg)
-    # keep at least one segment, even if all were trivial
+    # keep at least one segment, even if all were trivial (`segments` is non-empty by contract)
     return tuple(merged) or (segments[0],)
-
-
-def _split_core(
-    op: AbstractStreamOperator,
-) -> tuple[AbstractLinearOperator, AbstractLinearOperator, AbstractLinearOperator] | None:
-    """Split a body into ``(pre, core, post)`` around its single stacked segment, or ``None``."""
-    stacked = [i for i, seg in enumerate(op.segments) if seg.stacked]
-    if len(stacked) != 1:
-        return None
-    i = stacked[0]
-    core = op.segments[i].operator
-    post = _compose(tuple(seg.operator for seg in op.segments[:i]), core.out_structure)
-    pre = _compose(tuple(seg.operator for seg in op.segments[i + 1 :]), core.in_structure)
-    return pre, core, post
 
 
 def _apply_chain(
@@ -549,7 +721,7 @@ def _apply_chain(
     static: tuple[AbstractLinearOperator, ...],
     x: PyTree[Inexact[Array, '...']],
 ) -> PyTree[Inexact[Array, '...']]:
-    """Apply one observation's segment chain, recombining each segment from its dyn/static split.
+    """Apply one slice's segment chain, recombining each segment from its dyn/static split.
 
     Segments are in composition order, so the last one is applied first (innermost).
     """

--- a/src/furax/mapmaking/streaming.py
+++ b/src/furax/mapmaking/streaming.py
@@ -407,6 +407,7 @@ class StreamOperator(AbstractLinearOperator):
         # prefix spec itself, so the input side needs no per-leaf mask.
         x_stacked, x_shared = eqx.partition(x, self.in_stacked)
         dyn, static = self._partition()
+        self._check_shared_replicated(x_shared, static, axis)
 
         # Stacked outputs are emitted per step; shared ones accumulate in the carry, then psum.
         per_slice_out = self.per_slice_out_structure
@@ -428,6 +429,13 @@ class StreamOperator(AbstractLinearOperator):
             return eqx.combine(ys, jax.lax.psum(carry, axis_name=axis))
 
         return kernel(dyn, static, x_stacked, x_shared)
+
+    def _check_shared_replicated(
+        self, x_shared: PyTree[Any], static: tuple[AbstractLinearOperator, ...], axis: str
+    ) -> None:
+        """Reject shared data sharded over the stream axis, by either route it arrives."""
+        _reject_axis_sharded(x_shared, axis)  # caller-supplied components
+        _reject_axis_sharded(static, axis)  # the operator's own shared-segment arrays
 
     @property
     def sliced_count(self) -> int:
@@ -673,6 +681,23 @@ def _get_mesh() -> AbstractMesh:
     if mesh.empty:
         raise RuntimeError('active mesh context required')
     return mesh
+
+
+def _reject_axis_sharded(pytree: PyTree[Any], axis: str) -> None:
+    """Raise if any array leaf of ``pytree`` is sharded along ``axis``."""
+    # a PartitionSpec is a leaf itself; `tuple(...)` exposes its entries, and `jax.tree.leaves`
+    # then flattens tuple entries and drops the None (unsharded) ones
+    bad = [
+        jax.tree_util.keystr(path) or '<root>'
+        for path, leaf in jax.tree.leaves_with_path(pytree)
+        if eqx.is_array(leaf) and axis in jax.tree.leaves(tuple(jax.typeof(leaf).sharding.spec))
+    ]
+    if bad:
+        msg = (
+            f'Found arrays sharded over {axis!r}: {", ".join(bad)}. '
+            'All shared components must be replicated along the stream axis.'
+        )
+        raise ValueError(msg)
 
 
 def _leading_size(operator: AbstractLinearOperator) -> int:

--- a/src/furax/mapmaking/streaming.py
+++ b/src/furax/mapmaking/streaming.py
@@ -1,6 +1,7 @@
 """Operators that stream a batched operator slice-by-slice across a sharded leading axis."""
 
 import functools
+from collections.abc import Sequence
 from dataclasses import field
 from typing import Any
 
@@ -44,8 +45,8 @@ class StreamSegment(eqx.Module):
     A third case cuts across those two. A *pure* segment ([`is_pure`][]) owns no data at all --
     an identity, or a block operator assembled only to route components around. It has nothing to
     slice or hold, so it belongs to neither camp and can join whichever neighbour it sits next to.
-    That is what lets the slot alignment emit structural operators freely: `_normalize` folds them
-    away again.
+    That is what lets the block constructors and the slot alignment emit structural operators
+    freely: `_normalize` folds them away again.
     """
 
     operator: AbstractLinearOperator
@@ -104,8 +105,11 @@ class StreamOperator(AbstractLinearOperator):
     | True       | False       | `row`        | (N,in) -> (out,)  |
     | False      | False       | `addition`   | (in,)  -> (out,)  |
 
-    A boundary need not be uniform: the reduction rules produce mixed streams -- some components
-    stacked, some shared -- which is this same class with prefix pytree specs.
+    Those four lay a single operator out over the batch axis. `block_row` / `block_column` do
+    something different despite the shared vocabulary: they lay several *streams* out over the
+    components of a block structure, giving a mixed boundary -- some components stacked, some
+    shared -- which is this same class with prefix pytree specs. The reduction rules produce mixed
+    streams too.
 
     An active mesh context is required when calling `mv`; use `jax.set_mesh` beforehand.
     """
@@ -206,6 +210,92 @@ class StreamOperator(AbstractLinearOperator):
             ...     rhs = A(pixel_map)          # (*in,) -> (*out,)
         """
         return cls._single_segment(operator, n_lead, in_stacked=False, out_stacked=False)
+
+    @classmethod
+    def block_row(cls, operands: Sequence[AbstractLinearOperator]) -> 'StreamOperator':
+        """Fuse parallel streams ``[S₁ | S₂ | ...]`` sharing one batch axis into one stream.
+
+        Where [`column`][furax.mapmaking.streaming.StreamOperator.column] and friends lay *one*
+        operator out over the batch axis, this lays several *streams* out over the components of a
+        block structure: ``H([u₁, ...]) = Σᵢ Sᵢ(uᵢ)``.
+
+        Writing each operand as a chain ``Sᵢ = Aᵢ ∘ Bᵢ ∘ … ∘ Zᵢ``, the identity
+        ``BlockRow([Sᵢ]) = BlockRow([Aᵢ]) @ BlockDiagonal([Bᵢ]) @ … @ BlockDiagonal([Zᵢ])`` lays
+        the fused stream out slot by slot: the leftmost sums the blocks, the rest act
+        componentwise, and every slot keeps its own sliced/constant kind. Chains of different shapes
+        are padded to agree first (see `_aligned_segments`). The result carries a per-block
+        ``in_stacked`` list and the operands' shared ``out_stacked``.
+
+        This is an explicit constructor, not a deferring reduction: a non-conforming operand raises.
+
+        Args:
+            operands: The streams to lay out side by side, at least one.
+
+        Raises:
+            TypeError: If an operand is not a stream operator.
+            ValueError: If an operand disagrees with the first on ``n_lead``, per-slice output
+                structure or ``out_stacked``, or if no operand has a sliced segment.
+        """
+        if not operands:
+            raise ValueError('stream block requires at least one operand')
+        ops: list[StreamOperator] = []
+        for op in operands:
+            if not isinstance(op, StreamOperator):
+                raise TypeError('stream block operands must be stream operators')
+            ops.append(op)
+        n_lead = ops[0].n_lead
+        per_slice_out = ops[0].per_slice_out_structure
+        ref_mask = jax.tree.leaves(jax.tree.broadcast(ops[0].out_stacked, per_slice_out))
+        for op in ops[1:]:
+            if op.n_lead != n_lead:
+                raise ValueError('stream block operands must share n_lead')
+            if not structure_equal(op.per_slice_out_structure, per_slice_out):
+                raise ValueError(
+                    'stream block operands must share their per-slice junction structure'
+                )
+            if jax.tree.leaves(jax.tree.broadcast(op.out_stacked, per_slice_out)) != ref_mask:
+                raise ValueError('stream block operands must share their junction stack spec')
+        n_sliced = max(op.sliced_count for op in ops)
+        if n_sliced == 0:
+            raise ValueError('stream block operands must have at least one sliced segment')
+        # Align the bodies slot for slot, then block them up position-wise: the leftmost slot sums
+        # the blocks, the rest act componentwise. `_normalize` folds away the slots that end up
+        # all-identity, so a body of plain streams still collapses to a single sliced segment.
+        aligned = [op._aligned_segments(n_sliced) for op in ops]
+        segments = []
+        for position, slot in enumerate(zip(*aligned, strict=True)):
+            operators = [seg.operator for seg in slot]
+            block = (
+                BlockRowOperator(operators) if position == 0 else BlockDiagonalOperator(operators)
+            )
+            segments.append(StreamSegment(block, position % 2 == 1))
+        return cls.create(
+            tuple(segments),
+            n_lead=n_lead,
+            in_stacked=[op.in_stacked for op in ops],
+            out_stacked=ops[0].out_stacked,
+        )
+
+    @classmethod
+    def block_column(cls, operands: Sequence[AbstractLinearOperator]) -> 'StreamOperator':
+        """Fuse parallel streams ``[S₁; S₂; ...]`` sharing one batch axis into one stream.
+
+        The transpose of [`block_row`][furax.mapmaking.streaming.StreamOperator.block_row]: fans a
+        single shared input across the blocks and collects their outputs into a list,
+        ``H(u) = [S₁(u), S₂(u), ...]``. Built as ``BlockRow([Sᵢᵀ])ᵀ``, so it fuses into the same
+        one-stacked-core layout, with the per-block spec landing on ``out_stacked`` instead of
+        ``in_stacked``.
+
+        Args:
+            operands: The streams to stack, at least one.
+
+        Raises:
+            TypeError: If an operand is not a stream operator.
+            ValueError: As for [`block_row`][furax.mapmaking.streaming.StreamOperator.block_row].
+        """
+        result = cls.block_row([op.T for op in operands]).T
+        assert isinstance(result, StreamOperator)  # mypy
+        return result
 
     @classmethod
     def create(

--- a/tests/mapmaking/test_streaming.py
+++ b/tests/mapmaking/test_streaming.py
@@ -1,4 +1,5 @@
 import jax
+import jax.extend
 import jax.numpy as jnp
 import numpy as np
 import pytest
@@ -7,13 +8,17 @@ from jaxtyping import Array, Inexact, PyTree
 from numpy.testing import assert_allclose
 
 from furax import AbstractLinearOperator, tree
-from furax.core import DiagonalOperator, HomothetyOperator
+from furax.core import BlockColumnOperator, BlockRowOperator, DiagonalOperator, HomothetyOperator
 from furax.mapmaking.streaming import (
+    AbstractStreamOperator,
     StreamAdditionOperator,
     StreamColumnOperator,
     StreamDiagonalOperator,
+    StreamOperator,
     StreamRowOperator,
     StreamSegment,
+    stream_block_column,
+    stream_block_row,
 )
 
 # ---------------------------------------------------------------------------
@@ -282,7 +287,9 @@ def test_marginal_weight_fusion() -> None:
     T = StreamDiagonalOperator.create(_make_blocks(P('obs')))  # in (N_IN,) -> out (N_OUT,)
     G = StreamDiagonalOperator.create(
         _TestOp(
-            jnp.broadcast_to(jnp.eye(N_IN), (N_OBS, N_IN, N_IN)),
+            # obs-sharded like W and T: a per-obs operator's leaves must share the obs sharding,
+            # else the fused scan sees mismatched per-shard leading axes under multiple devices.
+            jax.device_put(jnp.broadcast_to(jnp.eye(N_IN), (N_OBS, N_IN, N_IN)), P('obs')),
             in_structure=jax.ShapeDtypeStruct((N_IN,), jnp.float64),
         )
     )
@@ -370,3 +377,181 @@ def test_check_scanned_rejects_non_obs_body_leaf() -> None:
     bad = _make_blocks()  # leaves lead with N_OBS
     with pytest.raises(ValueError, match='leading axis size'):
         StreamDiagonalOperator._build((StreamSegment(bad, True),), n_lead=N_OBS + 1)
+
+
+# ---------------------------------------------------------------------------
+# Mixed (per-component) streams: joint shared-sky + stacked-amplitude systems
+# ---------------------------------------------------------------------------
+
+N_AMP = 2
+
+
+def _count_scans(jaxpr: jax.extend.core.Jaxpr) -> int:
+    """Total `scan` primitives in a jaxpr, recursing into closed sub-jaxprs (shard_map bodies)."""
+    n = 0
+    for eqn in jaxpr.eqns:
+        if eqn.primitive.name == 'scan':
+            n += 1
+        for value in eqn.params.values():
+            if isinstance(value, jax.extend.core.ClosedJaxpr):
+                n += _count_scans(value.jaxpr)
+            elif isinstance(value, jax.extend.core.Jaxpr):
+                n += _count_scans(value)
+    return n
+
+
+def _joint_operands() -> tuple[
+    StreamColumnOperator, StreamDiagonalOperator, StreamDiagonalOperator
+]:
+    """H_sky (shared sky -> tod), Te (stacked amps -> tod), W (tod weight)."""
+    h_sky = StreamColumnOperator.create(_make_blocks(P('obs')))  # (N_IN,) -> (N_OBS, N_OUT)
+    te = StreamDiagonalOperator.create(_make_blocks(P('obs'), n_in=N_AMP))  # (N_OBS, N_AMP) -> ...
+    w = StreamDiagonalOperator.create(_make_blocks(P('obs'), n_in=N_OUT))
+    return h_sky, te, w
+
+
+def test_stream_block_row_structure_and_specs() -> None:
+    h_sky, te, _ = _joint_operands()
+    h = stream_block_row([h_sky, te])
+    assert isinstance(h, StreamOperator)
+    assert h.in_stacked == [False, True]  # sky shared, amplitudes stacked
+    assert h.out_stacked is True  # both map into the (stacked) tod
+    in_struct = h.in_structure
+    assert in_struct[0].shape == (N_IN,)
+    assert in_struct[1].shape == (N_OBS, N_AMP)
+    assert h.out_structure.shape == (N_OBS, N_OUT)
+
+
+def test_stream_block_row_mv_and_transpose() -> None:
+    h_sky, te, _ = _joint_operands()
+    h = stream_block_row([h_sky, te])
+    hs = _per_obs(h_sky.segments[0].operator)
+    ts = _per_obs(te.segments[0].operator)
+
+    x_sky = jax.device_put(RNG.standard_normal((N_IN,), dtype=np.float64), P())
+    x_amp = jax.device_put(RNG.standard_normal((N_OBS, N_AMP), dtype=np.float64), P('obs'))
+    sky_np, amp_np = np.array(x_sky), np.array(jax.device_get(x_amp))
+    expected = np.stack([hs[i] @ sky_np + ts[i] @ amp_np[i] for i in range(N_OBS)])
+    assert_allclose(h([x_sky, x_amp]), expected, rtol=1e-10)
+
+    # transpose: tod -> [Σ H_iᵀ y_i (shared), stack(Te_iᵀ y_i)]
+    h_t = h.T
+    assert isinstance(h_t, StreamOperator)
+    assert h_t.out_stacked == [False, True]
+    y = jax.device_put(RNG.standard_normal((N_OBS, N_OUT), dtype=np.float64), P('obs'))
+    y_np = np.array(jax.device_get(y))
+    exp_sky = sum(hs[i].T @ y_np[i] for i in range(N_OBS))
+    exp_amp = np.stack([ts[i].T @ y_np[i] for i in range(N_OBS)])
+    out_sky, out_amp = h_t(y)
+    assert_allclose(out_sky, exp_sky, rtol=1e-10)
+    assert_allclose(out_amp, exp_amp, rtol=1e-10)
+
+
+def test_stream_block_column_fans_out_shared_input() -> None:
+    # a column shares one input across its blocks and stacks their outputs into a list; it is the
+    # transpose of the block-row of the transposed operands.
+    a = StreamColumnOperator.create(_make_blocks(P('obs')))  # (N_IN,) -> (N_OBS, N_OUT)
+    b = StreamColumnOperator.create(_make_blocks(P('obs')))
+    col = stream_block_column([a, b])
+    # both output legs are obs-stacked, so the spec is uniform and collapses to a plain column
+    assert isinstance(col, StreamColumnOperator)
+    assert col.in_stacked is False  # single shared input
+    assert col.out_stacked is True
+    x = jax.device_put(RNG.standard_normal((N_IN,), dtype=np.float64), P())
+    out_a, out_b = col(x)
+    assert_allclose(out_a, a(x), rtol=1e-10)
+    assert_allclose(out_b, b(x), rtol=1e-10)
+
+
+def test_mixed_normal_equations_fuse_to_single_scan() -> None:
+    h_sky, te, w = _joint_operands()
+    h = stream_block_row([h_sky, te])
+    a = (h.T @ w @ h).reduce()
+    assert isinstance(a, StreamOperator)
+    assert a.in_stacked == [False, True]
+    assert a.out_stacked == [False, True]
+    assert sum(seg.stacked for seg in a.segments) == 1  # one stacked core: one tod pass
+
+    # numerically identical to the old 2x2 block-of-reduced-streams assembly
+    a_ss = (h_sky.T @ w @ h_sky).reduce()
+    a_sa = (h_sky.T @ w @ te).reduce()
+    a_as = (te.T @ w @ h_sky).reduce()
+    a_aa = (te.T @ w @ te).reduce()
+    a_2x2 = BlockColumnOperator([BlockRowOperator([a_ss, a_sa]), BlockRowOperator([a_as, a_aa])])
+
+    x = [
+        jax.device_put(RNG.standard_normal((N_IN,), dtype=np.float64), P()),
+        jax.device_put(RNG.standard_normal((N_OBS, N_AMP), dtype=np.float64), P('obs')),
+    ]
+    fused, ref = a(x), a_2x2(x)
+    for leaf_a, leaf_b in zip(jax.tree.leaves(fused), jax.tree.leaves(ref), strict=True):
+        assert_allclose(leaf_a, leaf_b, rtol=1e-9)
+
+    # the point of the change: one scan for the fused operator vs four for the 2x2 assembly
+    assert _count_scans(jax.make_jaxpr(a.mv)(x).jaxpr) == 1
+    assert _count_scans(jax.make_jaxpr(a_2x2.mv)(x).jaxpr) == 4
+
+
+def test_mixed_output_sharding() -> None:
+    h_sky, te, w = _joint_operands()
+    a = (stream_block_row([h_sky, te]).T @ w @ stream_block_row([h_sky, te])).reduce()
+    x_struct = [
+        jax.ShapeDtypeStruct((N_IN,), jnp.float64, sharding=P()),
+        jax.ShapeDtypeStruct((N_OBS, N_AMP), jnp.float64, sharding=P('obs')),
+    ]
+    y = jax.eval_shape(a.mv, x_struct)
+    assert 'obs' not in y[0].sharding.spec  # sky leg replicated (not obs-sharded)
+    assert y[1].sharding.spec == P('obs', None)  # amplitude leg obs-sharded
+
+
+def test_addition_composition_does_not_fuse() -> None:
+    # a shared junction is a psum only available after the scan, so `Addition @ Addition` cannot
+    # fuse into one scan: (Σᵢaᵢ)(Σⱼbⱼ) != Σᵢ aᵢbᵢ. It must stay an unreduced composition.
+    a = StreamAdditionOperator.create(_make_blocks(P('obs'), n_in=N_OUT))
+    b = StreamAdditionOperator.create(_make_blocks(P('obs'), n_in=N_OUT))
+    reduced = (a @ b).reduce()
+    assert not isinstance(reduced, AbstractStreamOperator)
+    x = jax.device_put(RNG.standard_normal((N_OUT,), dtype=np.float64), P())
+    assert_allclose(reduced(x), a(b(x)), rtol=1e-10)
+
+
+def test_mixed_addition_fusion() -> None:
+    h_sky, te, w = _joint_operands()
+    left = (stream_block_row([h_sky, te]).T @ w @ stream_block_row([h_sky, te])).reduce()
+    h_sky2, te2, w2 = _joint_operands()
+    right = (stream_block_row([h_sky2, te2]).T @ w2 @ stream_block_row([h_sky2, te2])).reduce()
+    fused = (left + right).reduce()
+    assert isinstance(fused, StreamOperator)
+    assert sum(seg.stacked for seg in fused.segments) == 1
+    x = [
+        jax.device_put(RNG.standard_normal((N_IN,), dtype=np.float64), P()),
+        jax.device_put(RNG.standard_normal((N_OBS, N_AMP), dtype=np.float64), P('obs')),
+    ]
+    expected = tree.add(left(x), right(x))
+    for leaf_a, leaf_b in zip(jax.tree.leaves(fused(x)), jax.tree.leaves(expected), strict=True):
+        assert_allclose(leaf_a, leaf_b, rtol=1e-9)
+
+
+def test_homothety_on_mixed_stream() -> None:
+    h_sky, te, w = _joint_operands()
+    a = (stream_block_row([h_sky, te]).T @ w @ stream_block_row([h_sky, te])).reduce()
+    scaled = ((-2.0) * a).reduce()
+    assert isinstance(scaled, StreamOperator)
+    assert sum(seg.stacked for seg in scaled.segments) == 1  # scalar stays out of the stacked body
+    x = [
+        jax.device_put(RNG.standard_normal((N_IN,), dtype=np.float64), P()),
+        jax.device_put(RNG.standard_normal((N_OBS, N_AMP), dtype=np.float64), P('obs')),
+    ]
+    expected = tree.mul(-2.0, a(x))
+    for leaf_a, leaf_b in zip(jax.tree.leaves(scaled(x)), jax.tree.leaves(expected), strict=True):
+        assert_allclose(leaf_a, leaf_b, rtol=1e-9)
+
+
+def test_stream_block_row_rejects_non_conforming_operand() -> None:
+    h_sky, _, _ = _joint_operands()
+    # a plain (non-stream) operator is not a valid operand
+    dense = DiagonalOperator(
+        jnp.ones(N_IN), in_structure=jax.ShapeDtypeStruct((N_IN,), jnp.float64)
+    )
+    with pytest.raises(ValueError, match='stream operators'):
+        stream_block_row([h_sky, dense])

--- a/tests/mapmaking/test_streaming.py
+++ b/tests/mapmaking/test_streaming.py
@@ -10,7 +10,7 @@ from jaxtyping import Array, Inexact, PyTree
 from numpy.testing import assert_allclose
 
 from furax import AbstractLinearOperator, tree
-from furax.core import DiagonalOperator, HomothetyOperator
+from furax.core import BlockColumnOperator, BlockRowOperator, DiagonalOperator, HomothetyOperator
 from furax.mapmaking.streaming import StreamOperator, StreamSegment
 
 # ---------------------------------------------------------------------------
@@ -325,8 +325,10 @@ def test_stacked_segment_must_lead_with_obs_axis() -> None:
 
 
 # ---------------------------------------------------------------------------
-# Multi-segment bodies: constant maps that keep sliced segments apart
+# Mixed (per-component) streams: joint shared-sky + stacked-amplitude systems
 # ---------------------------------------------------------------------------
+
+N_AMP = 2
 
 
 def _count_scans(jaxpr: jax.extend.core.Jaxpr) -> int:
@@ -343,6 +345,93 @@ def _count_scans(jaxpr: jax.extend.core.Jaxpr) -> int:
     return n
 
 
+def _joint_operands() -> tuple[StreamOperator, StreamOperator, StreamOperator]:
+    """H_sky (shared sky -> tod), Te (stacked amps -> tod), W (tod weight)."""
+    h_sky = StreamOperator.column(_make_blocks(P('obs')))  # (N_IN,) -> (N_OBS, N_OUT)
+    te = StreamOperator.diagonal(_make_blocks(P('obs'), n_in=N_AMP))  # (N_OBS, N_AMP) -> ...
+    w = StreamOperator.diagonal(_make_blocks(P('obs'), n_in=N_OUT))
+    return h_sky, te, w
+
+
+def test_stream_block_row_structure_and_specs() -> None:
+    h_sky, te, _ = _joint_operands()
+    h = StreamOperator.block_row([h_sky, te])
+    assert isinstance(h, StreamOperator)
+    assert h.in_stacked == [False, True]  # sky shared, amplitudes stacked
+    assert h.out_stacked is True  # both map into the (stacked) tod
+    in_struct = h.in_structure
+    assert in_struct[0].shape == (N_IN,)
+    assert in_struct[1].shape == (N_OBS, N_AMP)
+    assert h.out_structure.shape == (N_OBS, N_OUT)
+
+
+def test_stream_block_row_mv_and_transpose() -> None:
+    h_sky, te, _ = _joint_operands()
+    h = StreamOperator.block_row([h_sky, te])
+    hs = _per_obs(h_sky.segments[0].operator)
+    ts = _per_obs(te.segments[0].operator)
+
+    x_sky = jax.device_put(RNG.standard_normal((N_IN,), dtype=np.float64), P())
+    x_amp = jax.device_put(RNG.standard_normal((N_OBS, N_AMP), dtype=np.float64), P('obs'))
+    sky_np, amp_np = np.array(x_sky), np.array(jax.device_get(x_amp))
+    expected = np.stack([hs[i] @ sky_np + ts[i] @ amp_np[i] for i in range(N_OBS)])
+    assert_allclose(h([x_sky, x_amp]), expected, rtol=1e-10)
+
+    # transpose: tod -> [Σ H_iᵀ y_i (shared), stack(Te_iᵀ y_i)]
+    h_t = h.T
+    assert isinstance(h_t, StreamOperator)
+    assert h_t.out_stacked == [False, True]
+    y = jax.device_put(RNG.standard_normal((N_OBS, N_OUT), dtype=np.float64), P('obs'))
+    y_np = np.array(jax.device_get(y))
+    exp_sky = sum(hs[i].T @ y_np[i] for i in range(N_OBS))
+    exp_amp = np.stack([ts[i].T @ y_np[i] for i in range(N_OBS)])
+    out_sky, out_amp = h_t(y)
+    assert_allclose(out_sky, exp_sky, rtol=1e-10)
+    assert_allclose(out_amp, exp_amp, rtol=1e-10)
+
+
+def _constant_wrapped(op: StreamOperator, *, post: bool) -> StreamOperator:
+    """Wrap a stream in a non-identity constant map, on the output (post) or input (pre) side.
+
+    Built from segments rather than from `scalar * op`, whose scalar the algebra is free to commute
+    to whichever side it likes; which side the constant segment sits on is what matters here.
+
+    The constant map has to own arrays: a leafless one (a scalar homothety, say) is legally folded
+    into the sliced core by `_normalize`, which is the case this helper is not about.
+    """
+    structure = op.segments[0].out_structure if post else op.segments[-1].in_structure
+    d = jax.device_put(RNG.standard_normal(structure.shape, dtype=np.float64), P())
+    shared = StreamSegment(DiagonalOperator(d, in_structure=structure), False)
+    segments = (shared,) + op.segments if post else op.segments + (shared,)
+    return StreamOperator.create(
+        segments, n_lead=op.n_lead, in_stacked=op.in_stacked, out_stacked=op.out_stacked
+    )
+
+
+@pytest.mark.parametrize('post', [False, True])
+def test_stream_block_row_keeps_shared_maps_out_of_the_body(post: bool) -> None:
+    # operands built by a layout constructor alone have no constant segments; wrapping them
+    # exercises the slots that keep a constant map beside the sliced core.
+    h_sky, te, _ = _joint_operands()
+    a = _constant_wrapped(h_sky, post=post)
+    b = _constant_wrapped(te, post=post)
+    h = StreamOperator.block_row([a, b])
+    # composition order: a post map lands left of the sliced core, a pre map right of it
+    assert [seg.sliced for seg in h.segments] == ([False, True] if post else [True, False])
+    assert h.in_stacked == [False, True]
+    x_sky = jax.device_put(RNG.standard_normal((N_IN,), dtype=np.float64), P())
+    x_amp = jax.device_put(RNG.standard_normal((N_OBS, N_AMP), dtype=np.float64), P('obs'))
+    assert_allclose(h([x_sky, x_amp]), tree.add(a(x_sky), b(x_amp)), rtol=1e-10)
+
+
+def test_structural_maps_fold_into_the_stacked_core() -> None:
+    # a block row's fan-in and fan-out carry no arrays when the operands have no shared
+    # segments, so `_normalize` folds those slots into the core rather than leaving them
+    h_sky, te, _ = _joint_operands()
+    h = StreamOperator.block_row([h_sky, te])
+    assert [seg.sliced for seg in h.segments] == [True]
+
+
 def _multi_stacked(n_in: int = N_IN) -> StreamOperator:
     """A body with two sliced segments, kept apart by an array-owning constant map.
 
@@ -357,6 +446,19 @@ def _multi_stacked(n_in: int = N_IN) -> StreamOperator:
         StreamSegment(_make_blocks(P('obs'), n_in=n_in), True),
     )
     return StreamOperator.create(segments, n_lead=N_OBS, in_stacked=False, out_stacked=True)
+
+
+def test_block_row_aligns_bodies_of_unequal_shape() -> None:
+    # one operand has a single sliced segment, the other two: padding with identities lets them
+    # be blocked up slot for slot, and the fused body keeps the deeper operand's two sliced slots
+    a = _multi_stacked()
+    b = StreamOperator.column(_make_blocks(P('obs'), n_in=N_AMP))
+    assert [seg.sliced for seg in a.segments] == [True, False, True]
+    h = StreamOperator.block_row([a, b])
+    assert [seg.sliced for seg in h.segments] == [True, False, True]
+    x_a = jax.device_put(RNG.standard_normal((N_IN,), dtype=np.float64), P())
+    x_b = jax.device_put(RNG.standard_normal((N_AMP,), dtype=np.float64), P())
+    assert_allclose(h([x_a, x_b]), tree.add(a(x_a), b(x_b)), rtol=1e-10)
 
 
 def test_multi_stacked_bodies_still_fuse_under_addition() -> None:
@@ -418,6 +520,64 @@ def test_array_owning_shared_map_is_never_folded() -> None:
     assert_allclose(op(x), expected, rtol=1e-10)
 
 
+def test_stream_block_column_fans_out_shared_input() -> None:
+    # a column shares one input across its blocks and stacks their outputs into a list; it is the
+    # transpose of the block-row of the transposed operands.
+    a = StreamOperator.column(_make_blocks(P('obs')))  # (N_IN,) -> (N_OBS, N_OUT)
+    b = StreamOperator.column(_make_blocks(P('obs')))
+    col = StreamOperator.block_column([a, b])
+    # both output legs are obs-stacked, so the spec is uniform and collapses to a plain column
+    # a uniform per-block spec collapses back to a bare bool, so this is a plain column again
+    assert (col.in_stacked, col.out_stacked) == (False, True)
+    x = jax.device_put(RNG.standard_normal((N_IN,), dtype=np.float64), P())
+    out_a, out_b = col(x)
+    assert_allclose(out_a, a(x), rtol=1e-10)
+    assert_allclose(out_b, b(x), rtol=1e-10)
+
+
+def test_mixed_normal_equations_fuse_to_single_scan() -> None:
+    h_sky, te, w = _joint_operands()
+    h = StreamOperator.block_row([h_sky, te])
+    a = (h.T @ w @ h).reduce()
+    assert isinstance(a, StreamOperator)
+    assert a.in_stacked == [False, True]
+    assert a.out_stacked == [False, True]
+    assert a.sliced_count == 1  # one sliced core: one tod pass
+
+    # numerically identical to the old 2x2 block-of-reduced-streams assembly
+    a_ss = (h_sky.T @ w @ h_sky).reduce()
+    a_sa = (h_sky.T @ w @ te).reduce()
+    a_as = (te.T @ w @ h_sky).reduce()
+    a_aa = (te.T @ w @ te).reduce()
+    a_2x2 = BlockColumnOperator([BlockRowOperator([a_ss, a_sa]), BlockRowOperator([a_as, a_aa])])
+
+    x = [
+        jax.device_put(RNG.standard_normal((N_IN,), dtype=np.float64), P()),
+        jax.device_put(RNG.standard_normal((N_OBS, N_AMP), dtype=np.float64), P('obs')),
+    ]
+    fused, ref = a(x), a_2x2(x)
+    for leaf_a, leaf_b in zip(jax.tree.leaves(fused), jax.tree.leaves(ref), strict=True):
+        assert_allclose(leaf_a, leaf_b, rtol=1e-9)
+
+    # the point of the change: one scan for the fused operator vs four for the 2x2 assembly
+    assert _count_scans(jax.make_jaxpr(a.mv)(x).jaxpr) == 1
+    assert _count_scans(jax.make_jaxpr(a_2x2.mv)(x).jaxpr) == 4
+
+
+def test_mixed_output_sharding() -> None:
+    h_sky, te, w = _joint_operands()
+    a = (
+        StreamOperator.block_row([h_sky, te]).T @ w @ StreamOperator.block_row([h_sky, te])
+    ).reduce()
+    x_struct = [
+        jax.ShapeDtypeStruct((N_IN,), jnp.float64, sharding=P()),
+        jax.ShapeDtypeStruct((N_OBS, N_AMP), jnp.float64, sharding=P('obs')),
+    ]
+    y = jax.eval_shape(a.mv, x_struct)
+    assert 'obs' not in y[0].sharding.spec  # sky leg replicated (not obs-sharded)
+    assert y[1].sharding.spec == P('obs', None)  # amplitude leg obs-sharded
+
+
 def test_addition_composition_does_not_fuse() -> None:
     # a shared junction is a psum only available after the scan, so `Addition @ Addition` cannot
     # fuse into one scan: (Σᵢaᵢ)(Σⱼbⱼ) != Σᵢ aᵢbᵢ. It must stay an unreduced composition.
@@ -427,6 +587,88 @@ def test_addition_composition_does_not_fuse() -> None:
     assert not isinstance(reduced, StreamOperator)
     x = jax.device_put(RNG.standard_normal((N_OUT,), dtype=np.float64), P())
     assert_allclose(reduced(x), a(b(x)), rtol=1e-10)
+
+
+def test_mixed_addition_fusion() -> None:
+    h_sky, te, w = _joint_operands()
+    left = (
+        StreamOperator.block_row([h_sky, te]).T @ w @ StreamOperator.block_row([h_sky, te])
+    ).reduce()
+    h_sky2, te2, w2 = _joint_operands()
+    right = (
+        StreamOperator.block_row([h_sky2, te2]).T @ w2 @ StreamOperator.block_row([h_sky2, te2])
+    ).reduce()
+    fused = (left + right).reduce()
+    assert isinstance(fused, StreamOperator)
+    assert fused.sliced_count == 1
+    x = [
+        jax.device_put(RNG.standard_normal((N_IN,), dtype=np.float64), P()),
+        jax.device_put(RNG.standard_normal((N_OBS, N_AMP), dtype=np.float64), P('obs')),
+    ]
+    expected = tree.add(left(x), right(x))
+    for leaf_a, leaf_b in zip(jax.tree.leaves(fused(x)), jax.tree.leaves(expected), strict=True):
+        assert_allclose(leaf_a, leaf_b, rtol=1e-9)
+
+
+def test_homothety_on_mixed_stream() -> None:
+    h_sky, te, w = _joint_operands()
+    a = (
+        StreamOperator.block_row([h_sky, te]).T @ w @ StreamOperator.block_row([h_sky, te])
+    ).reduce()
+    scaled = ((-2.0) * a).reduce()
+    assert isinstance(scaled, StreamOperator)
+    assert scaled.sliced_count == 1  # scalar stays out of the sliced body
+    x = [
+        jax.device_put(RNG.standard_normal((N_IN,), dtype=np.float64), P()),
+        jax.device_put(RNG.standard_normal((N_OBS, N_AMP), dtype=np.float64), P('obs')),
+    ]
+    expected = tree.mul(-2.0, a(x))
+    for leaf_a, leaf_b in zip(jax.tree.leaves(scaled(x)), jax.tree.leaves(expected), strict=True):
+        assert_allclose(leaf_a, leaf_b, rtol=1e-9)
+
+
+def _not_a_stream() -> AbstractLinearOperator:
+    return DiagonalOperator(jnp.ones(N_IN), in_structure=jax.ShapeDtypeStruct((N_IN,), jnp.float64))
+
+
+def _other_n_lead() -> AbstractLinearOperator:
+    return StreamOperator.column(_make_blocks(n_lead=N_OBS + 1))
+
+
+def _other_out_structure() -> AbstractLinearOperator:
+    return StreamOperator.column(_make_blocks(n_out=N_OUT + 1))
+
+
+def _other_out_stacked() -> AbstractLinearOperator:
+    # same per-slice out structure as a column, but summed rather than stacked
+    return StreamOperator.addition(_make_blocks())
+
+
+@pytest.mark.parametrize(
+    'make_operand, error, match',
+    [
+        (_not_a_stream, TypeError, 'must be stream operators'),
+        (_other_n_lead, ValueError, 'share n_lead'),
+        (_other_out_structure, ValueError, 'per-slice junction structure'),
+        (_other_out_stacked, ValueError, 'junction stack spec'),
+    ],
+)
+def test_stream_block_row_rejects_non_conforming_operand(
+    make_operand: Callable[[], AbstractLinearOperator], error: type[Exception], match: str
+) -> None:
+    h_sky, _, _ = _joint_operands()
+    with pytest.raises(error, match=match):
+        StreamOperator.block_row([h_sky, make_operand()])
+
+
+def test_stream_block_column_rejects_non_conforming_operand() -> None:
+    # the column delegates to the row constructor on transposed operands; `.T` is a bijection on
+    # stream operators, so a non-stream operand is still caught (and named side-neutrally)
+    h_sky, _, _ = _joint_operands()
+    with pytest.raises(TypeError, match='must be stream operators'):
+        StreamOperator.block_column([h_sky, _not_a_stream()])
+    with pytest.raises(ValueError, match='at least one operand'):
+        StreamOperator.block_column([])
 
 
 def test_create_rejects_non_prefix_spec() -> None:
@@ -489,3 +731,35 @@ class TestSharded:
         assert_allclose(op(x), expected, rtol=1e-10)
         struct = jax.ShapeDtypeStruct(x.shape, jnp.float64, sharding=_spec(in_stacked))
         assert jax.eval_shape(op.mv, struct).sharding.spec == _spec(out_stacked)
+
+    def test_mixed_normal_equations(self) -> None:
+        # a mixed boundary is what needs per-component out_specs: within one scan the sky leg is
+        # summed across shards and the amplitude leg stays sharded.
+        h_sky, te, w = _joint_operands()
+        h = StreamOperator.block_row([h_sky, te])
+        a = (h.T @ w @ h).reduce()
+        hs = _per_obs(h_sky.segments[0].operator)
+        ts = _per_obs(te.segments[0].operator)
+        ws = _per_obs(w.segments[0].operator)
+
+        x_sky = jax.device_put(RNG.standard_normal((N_IN,), dtype=np.float64), P())
+        x_amp = jax.device_put(RNG.standard_normal((N_OBS, N_AMP), dtype=np.float64), P('obs'))
+        sky_np, amp_np = np.array(x_sky), np.array(jax.device_get(x_amp))
+        wd = [ws[i] @ (hs[i] @ sky_np + ts[i] @ amp_np[i]) for i in range(N_OBS)]
+        exp_sky = sum(hs[i].T @ wd[i] for i in range(N_OBS))
+        exp_amp = np.stack([ts[i].T @ wd[i] for i in range(N_OBS)])
+
+        out_sky, out_amp = a([x_sky, x_amp])
+        assert_allclose(out_sky, exp_sky, rtol=1e-9)
+        assert_allclose(out_amp, exp_amp, rtol=1e-9)
+        assert _count_scans(jax.make_jaxpr(a.mv)([x_sky, x_amp]).jaxpr) == 1
+
+        y = jax.eval_shape(
+            a.mv,
+            [
+                jax.ShapeDtypeStruct((N_IN,), jnp.float64, sharding=P()),
+                jax.ShapeDtypeStruct((N_OBS, N_AMP), jnp.float64, sharding=P('obs')),
+            ],
+        )
+        assert 'obs' not in y[0].sharding.spec  # sky leg reduced, hence replicated
+        assert y[1].sharding.spec == P('obs', None)  # amplitude leg still sharded

--- a/tests/mapmaking/test_streaming.py
+++ b/tests/mapmaking/test_streaming.py
@@ -792,3 +792,11 @@ class TestSharded:
         )
         assert 'obs' not in y[0].sharding.spec  # sky leg reduced, hence replicated
         assert y[1].sharding.spec == P('obs', None)  # amplitude leg still sharded
+
+    def test_indivisible_batch_axis_is_rejected(self) -> None:
+        # the scan length is per shard, so a batch axis the shards do not divide has no valid one.
+        # Blocks stay unsharded here: `P('obs')` could not place them over the mesh to begin with.
+        n_lead = self.N_SHARDS + 1
+        op = StreamOperator.diagonal(_make_blocks(n_lead=n_lead))
+        with pytest.raises(ValueError, match='not divisible'):
+            op(jnp.zeros((n_lead, N_IN)))

--- a/tests/mapmaking/test_streaming.py
+++ b/tests/mapmaking/test_streaming.py
@@ -1,4 +1,7 @@
+from collections.abc import Callable, Iterator
+
 import jax
+import jax.extend
 import jax.numpy as jnp
 import numpy as np
 import pytest
@@ -8,13 +11,7 @@ from numpy.testing import assert_allclose
 
 from furax import AbstractLinearOperator, tree
 from furax.core import DiagonalOperator, HomothetyOperator
-from furax.mapmaking.streaming import (
-    StreamAdditionOperator,
-    StreamColumnOperator,
-    StreamDiagonalOperator,
-    StreamRowOperator,
-    StreamSegment,
-)
+from furax.mapmaking.streaming import StreamOperator, StreamSegment
 
 # ---------------------------------------------------------------------------
 # Minimal stacked operator for testing
@@ -23,14 +20,6 @@ from furax.mapmaking.streaming import (
 
 class _TestOp(AbstractLinearOperator):
     matrix: Inexact[Array, '...']
-
-    def __init__(
-        self,
-        matrix: Inexact[Array, '...'],
-        in_structure: PyTree[jax.ShapeDtypeStruct],
-    ) -> None:
-        object.__setattr__(self, 'matrix', matrix)
-        super().__init__(in_structure=in_structure)
 
     def mv(self, x: PyTree[Inexact[Array, '...']]) -> PyTree[Inexact[Array, '...']]:
         return jnp.einsum('...ij,...j->...i', self.matrix, x)
@@ -68,8 +57,10 @@ def set_mesh(mesh):
         yield
 
 
-def _make_blocks(sharding=None, *, n_in: int = N_IN) -> _TestOp:
-    matrices = RNG.standard_normal((N_OBS, N_OUT, n_in), dtype=np.float64)
+def _make_blocks(
+    sharding: P | None = None, *, n_lead: int = N_OBS, n_in: int = N_IN, n_out: int = N_OUT
+) -> _TestOp:
+    matrices = RNG.standard_normal((n_lead, n_out, n_in), dtype=np.float64)
     arr = jax.device_put(matrices, sharding)
     return _TestOp(arr, in_structure=jax.ShapeDtypeStruct((n_in,), jnp.float64))
 
@@ -80,131 +71,88 @@ def _per_obs(op: _TestOp) -> list[np.ndarray]:
 
 
 # ---------------------------------------------------------------------------
-# Structure shapes and sharding
+# The four uniform layouts
 # ---------------------------------------------------------------------------
 
-
-def test_structure_shapes() -> None:
-    blocks = _make_blocks()
-
-    op = StreamDiagonalOperator.create(blocks)
-    assert op.in_structure.shape == (N_OBS, N_IN)
-    assert op.out_structure.shape == (N_OBS, N_OUT)
-
-    op = StreamColumnOperator.create(blocks)
-    assert op.in_structure.shape == (N_IN,)
-    assert op.out_structure.shape == (N_OBS, N_OUT)
-
-    op = StreamRowOperator.create(blocks)
-    assert op.in_structure.shape == (N_OBS, N_IN)
-    assert op.out_structure.shape == (N_OUT,)
-
-    op = StreamAdditionOperator.create(blocks)
-    assert op.in_structure.shape == (N_IN,)
-    assert op.out_structure.shape == (N_OUT,)
+# A layout *is* its boundary spec pair; these four constructors are the uniform combinations.
+_LAYOUTS = [
+    pytest.param(StreamOperator.diagonal, True, True, id='diagonal'),
+    pytest.param(StreamOperator.column, False, True, id='column'),
+    pytest.param(StreamOperator.row, True, False, id='row'),
+    pytest.param(StreamOperator.addition, False, False, id='addition'),
+]
 
 
-# ---------------------------------------------------------------------------
-# Sharded forward
-# ---------------------------------------------------------------------------
+def _spec(stacked: bool) -> P:
+    """Sharding of a boundary component: a stacked one carries the obs axis, a shared one does not."""
+    return P('obs', None) if stacked else P(None)
 
 
-def test_sharded_diagonal_mv() -> None:
+def _boundary(stacked: bool, size: int) -> jax.Array:
+    """Random input/output for a boundary component, shaped and sharded to match its spec."""
+    shape = (N_OBS, size) if stacked else (size,)
+    return jax.device_put(
+        RNG.standard_normal(shape, dtype=np.float64), P('obs') if stacked else P()
+    )
+
+
+def _reference(
+    matrices: list[np.ndarray], x: np.ndarray, *, in_stacked: bool, out_stacked: bool
+) -> np.ndarray:
+    """Apply the blocks slice by slice, the way the boundary spec pair says to.
+
+    A stacked input is sliced per block and a shared one goes to every block; a stacked output is
+    stacked back up and a shared one summed. That is the whole meaning of the spec pair, so one
+    reference covers all four layouts.
+    """
+    per_slice = [m @ (x[i] if in_stacked else x) for i, m in enumerate(matrices)]
+    return np.stack(per_slice) if out_stacked else sum(per_slice)
+
+
+@pytest.mark.parametrize('make_stream, in_stacked, out_stacked', _LAYOUTS)
+def test_layout_structure_and_mv(
+    make_stream: Callable[[AbstractLinearOperator], StreamOperator],
+    in_stacked: bool,
+    out_stacked: bool,
+) -> None:
     blocks = _make_blocks(P('obs'))
-    op = StreamDiagonalOperator.create(blocks)
-    x = jax.device_put(RNG.standard_normal((N_OBS, N_IN), dtype=np.float64), P('obs'))
-    x_np = np.array(jax.device_get(x))
-    expected = np.stack([m @ x_np[i] for i, m in enumerate(_per_obs(blocks))])
+    op = make_stream(blocks)
+    assert (op.in_stacked, op.out_stacked) == (in_stacked, out_stacked)
+    assert op.in_structure.shape == ((N_OBS, N_IN) if in_stacked else (N_IN,))
+    assert op.out_structure.shape == ((N_OBS, N_OUT) if out_stacked else (N_OUT,))
+
+    x = _boundary(in_stacked, N_IN)
+    expected = _reference(
+        _per_obs(blocks),
+        np.asarray(jax.device_get(x)),
+        in_stacked=in_stacked,
+        out_stacked=out_stacked,
+    )
     assert_allclose(op(x), expected, rtol=1e-10)
 
+    # the output carries the obs axis exactly when out_stacked says it should
+    struct = jax.ShapeDtypeStruct(x.shape, jnp.float64, sharding=_spec(in_stacked))
+    assert jax.eval_shape(op.mv, struct).sharding.spec == _spec(out_stacked)
 
-def test_sharded_column_mv() -> None:
+
+@pytest.mark.parametrize('make_stream, in_stacked, out_stacked', _LAYOUTS)
+def test_layout_transpose(
+    make_stream: Callable[[AbstractLinearOperator], StreamOperator],
+    in_stacked: bool,
+    out_stacked: bool,
+) -> None:
     blocks = _make_blocks(P('obs'))
-    op = StreamColumnOperator.create(blocks)
-    x = jax.device_put(RNG.standard_normal((N_IN,), dtype=np.float64), P())
-    expected = np.stack([m @ np.array(x) for m in _per_obs(blocks)])
-    assert_allclose(op(x), expected, rtol=1e-10)
-
-
-def test_sharded_row_mv() -> None:
-    blocks = _make_blocks(P('obs'))
-    op = StreamRowOperator.create(blocks)
-    x = jax.device_put(RNG.standard_normal((N_OBS, N_IN), dtype=np.float64), P('obs'))
-    x_np = np.array(jax.device_get(x))
-    expected = sum(m @ x_np[i] for i, m in enumerate(_per_obs(blocks)))
-    assert_allclose(op(x), expected, rtol=1e-10)
-
-
-def test_sharded_addition_mv() -> None:
-    blocks = _make_blocks(P('obs'))
-    op = StreamAdditionOperator.create(blocks)
-    x = jax.device_put(RNG.standard_normal((N_IN,), dtype=np.float64), P())
-    expected = sum(m @ np.array(x) for m in _per_obs(blocks))
-    assert_allclose(op(x), expected, rtol=1e-10)
-
-
-# ---------------------------------------------------------------------------
-# Sharded transpose
-# ---------------------------------------------------------------------------
-
-
-def test_sharded_diagonal_transpose() -> None:
-    blocks = _make_blocks(P('obs'))
-    op_T = StreamDiagonalOperator.create(blocks).T
-    assert isinstance(op_T, StreamDiagonalOperator)
-    y = jax.device_put(RNG.standard_normal((N_OBS, N_OUT), dtype=np.float64), P('obs'))
-    y_np = np.array(jax.device_get(y))
-    expected = np.stack([m.T @ y_np[i] for i, m in enumerate(_per_obs(blocks))])
+    op_T = make_stream(blocks).T
+    # transposing swaps the boundary: column <-> row, diagonal and addition map to themselves
+    assert (op_T.in_stacked, op_T.out_stacked) == (out_stacked, in_stacked)
+    y = _boundary(out_stacked, N_OUT)
+    expected = _reference(
+        [m.T for m in _per_obs(blocks)],
+        np.asarray(jax.device_get(y)),
+        in_stacked=out_stacked,
+        out_stacked=in_stacked,
+    )
     assert_allclose(op_T(y), expected, rtol=1e-10)
-
-
-def test_sharded_column_transpose_is_row() -> None:
-    blocks = _make_blocks(P('obs'))
-    op_T = StreamColumnOperator.create(blocks).T
-    assert isinstance(op_T, StreamRowOperator)
-    y = jax.device_put(RNG.standard_normal((N_OBS, N_OUT), dtype=np.float64), P('obs'))
-    y_np = np.array(jax.device_get(y))
-    expected = sum(m.T @ y_np[i] for i, m in enumerate(_per_obs(blocks)))
-    assert_allclose(op_T(y), expected, rtol=1e-10)
-
-
-def test_sharded_row_transpose_is_column() -> None:
-    blocks = _make_blocks(P('obs'))
-    op_T = StreamRowOperator.create(blocks).T
-    assert isinstance(op_T, StreamColumnOperator)
-    y = jax.device_put(RNG.standard_normal((N_OUT,), dtype=np.float64), P())
-    expected = np.stack([m.T @ np.array(y) for m in _per_obs(blocks)])
-    assert_allclose(op_T(y), expected, rtol=1e-10)
-
-
-def test_sharded_addition_transpose() -> None:
-    blocks = _make_blocks(P('obs'))
-    op_T = StreamAdditionOperator.create(blocks).T
-    assert isinstance(op_T, StreamAdditionOperator)
-    y = jax.device_put(RNG.standard_normal((N_OUT,), dtype=np.float64), P())
-    expected = sum(m.T @ np.array(y) for m in _per_obs(blocks))
-    assert_allclose(op_T(y), expected, rtol=1e-10)
-
-
-# ---------------------------------------------------------------------------
-# Output sharding
-# ---------------------------------------------------------------------------
-
-
-def test_sharded_output_sharding() -> None:
-    blocks = _make_blocks(P('obs'))
-
-    cases = [
-        (StreamDiagonalOperator, (N_OBS, N_IN), P('obs', None), P('obs', None)),
-        (StreamColumnOperator, (N_IN,), P(None), P('obs', None)),
-        (StreamRowOperator, (N_OBS, N_IN), P('obs', None), P(None)),
-        (StreamAdditionOperator, (N_IN,), P(None), P(None)),
-    ]
-    for cls, shape, x_spec, expected_spec in cases:
-        op = cls.create(blocks)
-        x_struct = jax.ShapeDtypeStruct(shape, jnp.float64, sharding=x_spec)
-        y = jax.eval_shape(op.mv, x_struct)
-        assert y.sharding.spec == expected_spec
 
 
 # ---------------------------------------------------------------------------
@@ -213,31 +161,51 @@ def test_sharded_output_sharding() -> None:
 
 
 def test_sharded_fusion_ht_w_h() -> None:
-    H = StreamColumnOperator.create(_make_blocks(P('obs')))
-    W = StreamDiagonalOperator.create(_make_blocks(P('obs'), n_in=N_OUT))
+    H = StreamOperator.column(_make_blocks(P('obs')))
+    W = StreamOperator.diagonal(_make_blocks(P('obs'), n_in=N_OUT))
     reduced = (H.T @ W @ H).reduce()
-    assert isinstance(reduced, StreamAdditionOperator)
+    assert (reduced.in_stacked, reduced.out_stacked) == (False, False)
     x = jax.device_put(RNG.standard_normal((N_IN,), dtype=np.float64), P())
     assert_allclose(reduced(x), (H.T @ W @ H)(x), rtol=1e-10)
 
 
 # ---------------------------------------------------------------------------
-# Closed-over maps: scalars/shared operators fold into pre/post, not the scanned body
+# Constant segments: data that does not carry the batch axis stays out of the sliced body
 # ---------------------------------------------------------------------------
 
 
-def test_homothety_on_block_lands_in_closed_over_map() -> None:
-    # `(-2) * block` attaches the scalar as a shared segment on the input side (rightmost in
-    # composition order, since `c * op` puts the scalar on the input side), leaving the stacked core.
-    blocks = _make_blocks(P('obs'))
-    op = ((-2.0) * StreamDiagonalOperator.create(blocks)).reduce()
-    assert isinstance(op, StreamDiagonalOperator)
-    assert [seg.stacked for seg in op.segments] == [True, False]
-    assert isinstance(op.segments[-1].operator, HomothetyOperator)
-    x = jax.device_put(RNG.standard_normal((N_OBS, N_IN), dtype=np.float64), P('obs'))
+@pytest.mark.parametrize(
+    'n_in, n_out, scalar_leads',
+    [
+        pytest.param(N_IN, N_OUT, False, id='input-side'),
+        pytest.param(N_OUT, N_IN, True, id='output-side'),
+    ],
+)
+def test_homothety_stays_out_of_the_sliced_body(n_in: int, n_out: int, scalar_leads: bool) -> None:
+    # `c * block` attaches the scalar as its own constant segment: it owns a leaf, so `_try_merge`
+    # will not fold it into a sliced segment where `scan` would try to slice it.
+    #
+    # Which end it lands on is not decided by writing `c * block` rather than `block @ c`. The
+    # algebra commutes a scalar to whichever structure is smaller before `HomothetyStreamRule`
+    # sees the composition, so the same expression reaches both of that rule's branches depending
+    # only on the block shape -- and transposing then carries the segment across.
+    blocks = _make_blocks(P('obs'), n_in=n_in, n_out=n_out)
+    op = ((-2.0) * StreamOperator.diagonal(blocks)).reduce()
+    assert (op.in_stacked, op.out_stacked) == (True, True)
+    assert [seg.sliced for seg in op.segments] == ([False, True] if scalar_leads else [True, False])
+    assert isinstance(op.segments[0 if scalar_leads else -1].operator, HomothetyOperator)
+    x = jax.device_put(RNG.standard_normal((N_OBS, n_in), dtype=np.float64), P('obs'))
     x_np = np.array(jax.device_get(x))
     expected = np.stack([-2.0 * (m @ x_np[i]) for i, m in enumerate(_per_obs(blocks))])
     assert_allclose(op(x), expected, rtol=1e-10)
+
+    op_T = op.T
+    assert (op_T.in_stacked, op_T.out_stacked) == (True, True)
+    assert isinstance(op_T.segments[-1 if scalar_leads else 0].operator, HomothetyOperator)
+    y = jax.device_put(RNG.standard_normal((N_OBS, n_out), dtype=np.float64), P('obs'))
+    y_np = np.array(jax.device_get(y))
+    expected_T = np.stack([-2.0 * (m.T @ y_np[i]) for i, m in enumerate(_per_obs(blocks))])
+    assert_allclose(op_T(y), expected_T, rtol=1e-10)
 
 
 # ---------------------------------------------------------------------------
@@ -245,50 +213,47 @@ def test_homothety_on_block_lands_in_closed_over_map() -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_addition_fusion_diagonal() -> None:
-    A = StreamDiagonalOperator.create(_make_blocks(P('obs')))
-    B = StreamDiagonalOperator.create(_make_blocks(P('obs')))
+@pytest.mark.parametrize('make_stream, in_stacked, out_stacked', _LAYOUTS)
+def test_addition_fusion(
+    make_stream: Callable[[AbstractLinearOperator], StreamOperator],
+    in_stacked: bool,
+    out_stacked: bool,
+) -> None:
+    A = make_stream(_make_blocks(P('obs')))
+    B = make_stream(_make_blocks(P('obs')))
     reduced = (A + B).reduce()
-    assert isinstance(reduced, StreamDiagonalOperator)
-    x = jax.device_put(RNG.standard_normal((N_OBS, N_IN), dtype=np.float64), P('obs'))
+    assert (reduced.in_stacked, reduced.out_stacked) == (in_stacked, out_stacked)
+    x = _boundary(in_stacked, N_IN)
     assert_allclose(reduced(x), tree.add(A(x), B(x)), rtol=1e-10)
 
 
 def test_subtraction_fusion_diagonal() -> None:
-    # `A - B` -> `A + (-1) * B`: the -1 lands in B's closed-over `pre`, then addition fusion
-    # combines the two via BlockColumn/BlockDiagonal/BlockRow into a single StreamDiagonal,
-    # keeping the scalar out of the strictly obs-stacked body.
-    A = StreamDiagonalOperator.create(_make_blocks(P('obs')))
-    B = StreamDiagonalOperator.create(_make_blocks(P('obs')))
+    # `A - B` -> `A + (-1) * B`: the -1 becomes a constant segment on B, then addition fusion
+    # blocks the two bodies up slot by slot, keeping the scalar out of the sliced body.
+    A = StreamOperator.diagonal(_make_blocks(P('obs')))
+    B = StreamOperator.diagonal(_make_blocks(P('obs')))
     reduced = (A - B).reduce()
-    assert isinstance(reduced, StreamDiagonalOperator)
+    assert (reduced.in_stacked, reduced.out_stacked) == (True, True)
     x = jax.device_put(RNG.standard_normal((N_OBS, N_IN), dtype=np.float64), P('obs'))
     assert_allclose(reduced(x), tree.sub(A(x), B(x)), rtol=1e-10)
-
-
-def test_addition_fusion_row() -> None:
-    A = StreamRowOperator.create(_make_blocks(P('obs')))
-    B = StreamRowOperator.create(_make_blocks(P('obs')))
-    reduced = (A + B).reduce()
-    assert isinstance(reduced, StreamRowOperator)
-    x = jax.device_put(RNG.standard_normal((N_OBS, N_IN), dtype=np.float64), P('obs'))
-    assert_allclose(reduced(x), tree.add(A(x), B(x)), rtol=1e-10)
 
 
 def test_marginal_weight_fusion() -> None:
     # the marginalisation shape `W - W T G T.T W` reduces to a single StreamDiagonal.
     # W: per-obs (N_OUT, N_OUT); T: per-obs (N_OUT, N_IN) amplitudes->tod; G: per-obs (N_IN, N_IN).
-    W = StreamDiagonalOperator.create(_make_blocks(P('obs'), n_in=N_OUT))
-    T = StreamDiagonalOperator.create(_make_blocks(P('obs')))  # in (N_IN,) -> out (N_OUT,)
-    G = StreamDiagonalOperator.create(
+    W = StreamOperator.diagonal(_make_blocks(P('obs'), n_in=N_OUT))
+    T = StreamOperator.diagonal(_make_blocks(P('obs')))  # in (N_IN,) -> out (N_OUT,)
+    G = StreamOperator.diagonal(
         _TestOp(
-            jnp.broadcast_to(jnp.eye(N_IN), (N_OBS, N_IN, N_IN)),
+            # obs-sharded like W and T: a per-obs operator's leaves must share the obs sharding,
+            # else the fused scan sees mismatched per-shard leading axes under multiple devices.
+            jax.device_put(jnp.broadcast_to(jnp.eye(N_IN), (N_OBS, N_IN, N_IN)), P('obs')),
             in_structure=jax.ShapeDtypeStruct((N_IN,), jnp.float64),
         )
     )
     chain = W @ T @ G @ T.T @ W
     Wm = (W - chain).reduce()
-    assert isinstance(Wm, StreamDiagonalOperator)
+    assert (Wm.in_stacked, Wm.out_stacked) == (True, True)
     x = jax.device_put(RNG.standard_normal((N_OBS, N_OUT), dtype=np.float64), P('obs'))
     expected = tree.sub(W(x), chain(x))
     assert_allclose(Wm(x), expected, rtol=1e-10)
@@ -297,11 +262,11 @@ def test_marginal_weight_fusion() -> None:
 def test_fused_block_composes_with_sharded_block() -> None:
     # Regression: a fused block must carry the obs-axis sharding in its public structure so it
     # still composes with other sharded streams. `A - B` exercises both the homothety rule
-    # (the −1 folds into a closed-over map) and the addition-fusion rule; before the fix their
-    # final `_build` ran under the empty mesh, leaving an unsharded structure that raised when
+    # (the −1 becomes a constant segment) and the addition-fusion rule; before the fix their
+    # final `create` ran under the empty mesh, leaving an unsharded structure that raised when
     # composed. Square blocks so the product is well-defined.
-    A = StreamDiagonalOperator.create(_make_blocks(P('obs'), n_in=N_OUT))
-    B = StreamDiagonalOperator.create(_make_blocks(P('obs'), n_in=N_OUT))
+    A = StreamOperator.diagonal(_make_blocks(P('obs'), n_in=N_OUT))
+    B = StreamOperator.diagonal(_make_blocks(P('obs'), n_in=N_OUT))
     fused = (A - B).reduce()
     composed = (A @ fused).reduce()  # must not raise on the structure check
     x = jax.device_put(RNG.standard_normal((N_OBS, N_OUT), dtype=np.float64), P('obs'))
@@ -310,22 +275,25 @@ def test_fused_block_composes_with_sharded_block() -> None:
 
 def test_create_carries_explicit_obs_size() -> None:
     # n is declared, not re-inferred from leaf shapes downstream; create starts with one stacked seg.
-    W = StreamDiagonalOperator.create(_make_blocks(P('obs')))
+    W = StreamOperator.diagonal(_make_blocks(P('obs')))
     assert W.n_lead == N_OBS
     assert len(W.segments) == 1
-    assert W.segments[0].stacked
+    assert W.segments[0].sliced
     assert W.segments[0].operator.matrix.shape[0] == N_OBS
 
 
 def test_non_scalar_static_post_is_applied() -> None:
-    # a NON-scalar shared segment (a shared-across-observation diagonal, leaf shape (N_OUT,) with no
+    # a NON-scalar constant segment (a shared-across-observation diagonal, leaf shape (N_OUT,) with no
     # obs axis) is a valid output-side segment: it must be accepted and applied after the core.
     blocks = _make_blocks(P('obs'))  # per-obs (N_OUT, N_IN)
     d = jax.device_put(RNG.standard_normal((N_OUT,), dtype=np.float64), P())
     post = DiagonalOperator(d, in_structure=jax.ShapeDtypeStruct((N_OUT,), jnp.float64))
     # composition order (post @ core): post is applied after the sliced core, so it comes first
-    op = StreamDiagonalOperator._build(
-        (StreamSegment(post, False), StreamSegment(blocks, True)), n_lead=N_OBS
+    op = StreamOperator.create(
+        (StreamSegment(post, False), StreamSegment(blocks, True)),
+        n_lead=N_OBS,
+        in_stacked=True,
+        out_stacked=True,
     )
     x = jax.device_put(RNG.standard_normal((N_OBS, N_IN), dtype=np.float64), P('obs'))
     x_np = np.array(jax.device_get(x))
@@ -334,39 +302,190 @@ def test_non_scalar_static_post_is_applied() -> None:
     assert_allclose(op(x), expected, rtol=1e-10)
 
 
-def test_transpose_roundtrips_static() -> None:
-    # an input-side shared map moves to the output side under transpose (segments reverse).
-    blocks = _make_blocks(P('obs'))
-    op = ((-3.0) * StreamDiagonalOperator.create(blocks)).reduce()
-    assert isinstance(op.segments[-1].operator, HomothetyOperator)  # input side (applied first)
-    op_T = op.T
-    assert isinstance(op_T, StreamDiagonalOperator)
-    assert isinstance(
-        op_T.segments[0].operator, HomothetyOperator
-    )  # now output side (applied last)
-    y = jax.device_put(RNG.standard_normal((N_OBS, N_OUT), dtype=np.float64), P('obs'))
-    y_np = np.array(jax.device_get(y))
-    expected = np.stack([-3.0 * (m.T @ y_np[i]) for i, m in enumerate(_per_obs(blocks))])
-    assert_allclose(op_T(y), expected, rtol=1e-10)
-
-
 def test_addition_fusion_defers_on_obs_size_mismatch() -> None:
-    # StreamAddition structures are per-observation, so summing blocks with different obs sizes is
-    # legal algebra; fusion must defer (stay unreduced) rather than crash on mis-stacked bodies.
-    A = StreamAdditionOperator.create(_make_blocks(P('obs')))
+    # an addition stream's structures are per-observation, so summing blocks of different obs
+    # sizes is legal algebra; fusion must defer rather than crash on mis-stacked bodies.
+    A = StreamOperator.addition(_make_blocks(P('obs')))
     matrices = RNG.standard_normal((2 * N_OBS, N_OUT, N_IN), dtype=np.float64)
     bigger = _TestOp(
         jax.device_put(matrices, P('obs')), in_structure=jax.ShapeDtypeStruct((N_IN,), jnp.float64)
     )
-    B = StreamAdditionOperator.create(bigger)
+    B = StreamOperator.addition(bigger)
     reduced = (A + B).reduce()
-    assert not isinstance(reduced, StreamAdditionOperator)
+    assert not isinstance(reduced, StreamOperator)
     x = jax.device_put(RNG.standard_normal((N_IN,), dtype=np.float64), P())
     assert_allclose(reduced(x), tree.add(A(x), B(x)), rtol=1e-10)
 
 
-def test_check_scanned_rejects_non_obs_body_leaf() -> None:
-    # a stacked segment leaf that does not lead with the obs axis is a mis-tagged operator: raise.
+def test_stacked_segment_must_lead_with_obs_axis() -> None:
+    # a sliced segment leaf that does not lead with the obs axis is a mis-tagged operator: raise.
     bad = _make_blocks()  # leaves lead with N_OBS
     with pytest.raises(ValueError, match='leading axis size'):
-        StreamDiagonalOperator._build((StreamSegment(bad, True),), n_lead=N_OBS + 1)
+        StreamOperator.diagonal(bad, n_lead=N_OBS + 1)
+
+
+# ---------------------------------------------------------------------------
+# Multi-segment bodies: constant maps that keep sliced segments apart
+# ---------------------------------------------------------------------------
+
+
+def _count_scans(jaxpr: jax.extend.core.Jaxpr) -> int:
+    """Total `scan` primitives in a jaxpr, recursing into closed sub-jaxprs (shard_map bodies)."""
+    n = 0
+    for eqn in jaxpr.eqns:
+        if eqn.primitive.name == 'scan':
+            n += 1
+        for value in eqn.params.values():
+            if isinstance(value, jax.extend.core.ClosedJaxpr):
+                n += _count_scans(value.jaxpr)
+            elif isinstance(value, jax.extend.core.Jaxpr):
+                n += _count_scans(value)
+    return n
+
+
+def _multi_stacked(n_in: int = N_IN) -> StreamOperator:
+    """A body with two sliced segments, kept apart by an array-owning constant map.
+
+    A constant map that owns arrays cannot be folded into the sliced core (it would then be sliced),
+    so bodies like this survive normalization and are what the slot alignment exists for.
+    """
+    d = jax.device_put(RNG.standard_normal((N_OUT,), dtype=np.float64), P())
+    shared = DiagonalOperator(d, in_structure=jax.ShapeDtypeStruct((N_OUT,), jnp.float64))
+    segments = (
+        StreamSegment(_make_blocks(P('obs'), n_in=N_OUT), True),
+        StreamSegment(shared, False),
+        StreamSegment(_make_blocks(P('obs'), n_in=n_in), True),
+    )
+    return StreamOperator.create(segments, n_lead=N_OBS, in_stacked=False, out_stacked=True)
+
+
+def test_multi_stacked_bodies_still_fuse_under_addition() -> None:
+    # before slot alignment this deferred to a plain AdditionOperator, i.e. one scan per operand
+    a, b = _multi_stacked(), _multi_stacked()
+    fused = (a + b).reduce()
+    assert isinstance(fused, StreamOperator)
+    x = jax.device_put(RNG.standard_normal((N_IN,), dtype=np.float64), P())
+    assert_allclose(fused(x), tree.add(a(x), b(x)), rtol=1e-10)
+    assert _count_scans(jax.make_jaxpr(fused.mv)(x).jaxpr) == 1
+
+
+def test_segment_structure_does_not_depend_on_trace_context() -> None:
+    # a Python float is not an array until something traces it, so deciding the fold on "holds an
+    # array" would give this operator one structure eagerly and another under jit -- and structure
+    # is pytree metadata, so the two would neither compose nor share a jit cache entry
+    blocks = _make_blocks(P('obs'))
+
+    def build(scale: float | jax.Array) -> StreamOperator:
+        homo = HomothetyOperator(scale, in_structure=jax.ShapeDtypeStruct((N_IN,), jnp.float64))
+        return StreamOperator.create(
+            (StreamSegment(blocks, True), StreamSegment(homo, False)),
+            n_lead=N_OBS,
+            in_stacked=True,
+            out_stacked=True,
+        )
+
+    expected = jax.tree.structure(build(2.0))
+    assert jax.tree.structure(build(jnp.asarray(2.0))) == expected
+
+    traced: list[jax.tree_util.PyTreeDef] = []
+
+    @jax.jit
+    def under_trace(scale: jax.Array) -> jax.Array:
+        traced.append(jax.tree.structure(build(scale)))
+        return scale
+
+    under_trace(jnp.asarray(2.0))
+    assert traced == [expected]
+
+
+def test_array_owning_shared_map_is_never_folded() -> None:
+    # a shared array is applied whole to every slice, so folding it into the sliced core would
+    # compute something else -- even here, where its leading axis matches n_lead and the
+    # sliceability check alone would wave it through
+    d = jax.device_put(RNG.standard_normal((N_OBS,), dtype=np.float64), P())
+    shared = DiagonalOperator(d, in_structure=jax.ShapeDtypeStruct((N_OBS,), jnp.float64))
+    op = StreamOperator.create(
+        (StreamSegment(shared, False), StreamSegment(_make_blocks(P('obs'), n_out=N_OBS), True)),
+        n_lead=N_OBS,
+        in_stacked=True,
+        out_stacked=True,
+    )
+    assert [seg.sliced for seg in op.segments] == [False, True]
+    x = jax.device_put(RNG.standard_normal((N_OBS, N_IN), dtype=np.float64), P('obs'))
+    x_np, d_np = np.array(jax.device_get(x)), np.array(jax.device_get(d))
+    blocks = _per_obs(op.segments[1].operator)
+    expected = np.stack([d_np * (m @ x_np[i]) for i, m in enumerate(blocks)])
+    assert_allclose(op(x), expected, rtol=1e-10)
+
+
+def test_addition_composition_does_not_fuse() -> None:
+    # a shared junction is a psum only available after the scan, so `Addition @ Addition` cannot
+    # fuse into one scan: (Σᵢaᵢ)(Σⱼbⱼ) != Σᵢ aᵢbᵢ. It must stay an unreduced composition.
+    a = StreamOperator.addition(_make_blocks(P('obs'), n_in=N_OUT))
+    b = StreamOperator.addition(_make_blocks(P('obs'), n_in=N_OUT))
+    reduced = (a @ b).reduce()
+    assert not isinstance(reduced, StreamOperator)
+    x = jax.device_put(RNG.standard_normal((N_OUT,), dtype=np.float64), P())
+    assert_allclose(reduced(x), a(b(x)), rtol=1e-10)
+
+
+def test_create_rejects_non_prefix_spec() -> None:
+    # a two-component spec cannot resolve against this operator's single-leaf input structure;
+    # jax names the offending key path and subtree types, so no wrapping is needed
+    with pytest.raises(ValueError, match='pytree structure error'):
+        StreamOperator.create(
+            (StreamSegment(_make_blocks(), True),),
+            n_lead=N_OBS,
+            in_stacked=[True, False],
+            out_stacked=True,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Multi-device: the paths a single-shard mesh cannot reach
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.distributed
+class TestSharded:
+    """Exercises `mv` on a mesh with more than one shard.
+
+    On the single-device mesh of a default run the sharded machinery is invisible: `psum` is the
+    identity, the per-shard scan length equals `n_lead`, and every output spec describes the whole
+    array. The parts that only mean something across shards -- per-component `out_specs`, the
+    shared-output carry and its reduction, the scan length -- are covered here.
+
+    The mesh is built from the first `N_SHARDS` devices rather than all of them, so the class does
+    not care how many the session provides and `N_OBS` need only divide `N_SHARDS`.
+    """
+
+    N_SHARDS = 2
+
+    @pytest.fixture(autouse=True)
+    def sharded_mesh(self) -> Iterator[None]:
+        """Shadow the module mesh; arrays built in a test resolve `P('obs')` against this one."""
+        devices = jax.devices()[: self.N_SHARDS]
+        with jax.set_mesh(jax.make_mesh((len(devices),), ('obs',), devices=devices)):
+            yield
+
+    @pytest.mark.parametrize('make_stream, in_stacked, out_stacked', _LAYOUTS)
+    def test_layout_mv(
+        self,
+        make_stream: Callable[[AbstractLinearOperator], StreamOperator],
+        in_stacked: bool,
+        out_stacked: bool,
+    ) -> None:
+        blocks = _make_blocks(P('obs'))
+        op = make_stream(blocks)
+        x = _boundary(in_stacked, N_IN)
+        expected = _reference(
+            _per_obs(blocks),
+            np.asarray(jax.device_get(x)),
+            in_stacked=in_stacked,
+            out_stacked=out_stacked,
+        )
+        # a shared output is a per-shard partial sum reduced by `psum`; a stacked one is the shards'
+        # slices concatenated. Both are no-ops on one shard, so this is where they mean something.
+        assert_allclose(op(x), expected, rtol=1e-10)
+        struct = jax.ShapeDtypeStruct(x.shape, jnp.float64, sharding=_spec(in_stacked))
+        assert jax.eval_shape(op.mv, struct).sharding.spec == _spec(out_stacked)

--- a/tests/mapmaking/test_streaming.py
+++ b/tests/mapmaking/test_streaming.py
@@ -325,6 +325,35 @@ def test_stacked_segment_must_lead_with_obs_axis() -> None:
 
 
 # ---------------------------------------------------------------------------
+# Shared data must be replicated along the stream axis
+# ---------------------------------------------------------------------------
+
+
+def test_shared_input_sharded_over_obs_is_rejected() -> None:
+    # shard_map infers its in_specs from the arguments, so an obs-sharded shared input raises
+    # nothing there: each shard silently sees a different slice. Catch it up front instead.
+    h = StreamOperator.column(_make_blocks(P('obs'), n_in=N_OBS))
+    x = jax.device_put(RNG.standard_normal((N_OBS,), dtype=np.float64), P('obs'))
+    with pytest.raises(ValueError, match='sharded over'):
+        h(x)
+
+
+def test_shared_segment_sharded_over_obs_is_rejected() -> None:
+    # same trap on the other entry point for shared data: a constant segment's own arrays
+    d = jax.device_put(RNG.standard_normal((N_OBS,), dtype=np.float64), P('obs'))
+    post = DiagonalOperator(d, in_structure=jax.ShapeDtypeStruct((N_OBS,), jnp.float64))
+    op = StreamOperator.create(
+        (StreamSegment(post, False), StreamSegment(_make_blocks(P('obs'), n_out=N_OBS), True)),
+        n_lead=N_OBS,
+        in_stacked=True,
+        out_stacked=True,
+    )
+    x = jax.device_put(RNG.standard_normal((N_OBS, N_IN), dtype=np.float64), P('obs'))
+    with pytest.raises(ValueError, match='sharded over'):
+        op(x)
+
+
+# ---------------------------------------------------------------------------
 # Mixed (per-component) streams: joint shared-sky + stacked-amplitude systems
 # ---------------------------------------------------------------------------
 

--- a/zensical.toml
+++ b/zensical.toml
@@ -43,6 +43,7 @@ nav = [
           "api/mapmaking/mapmaker.md",
           "api/mapmaking/config.md",
           "api/mapmaking/preconditioner.md",
+          "api/mapmaking/streaming.md",
       ] },
       { "Other subpackages" = [
           "api/math.md",


### PR DESCRIPTION
## Summary

Yet another generalisation pulled out of #125.

Streaming had four operator classes for what is one operator with two flags: which side carries the stream axis. A layout being a type meant it could not vary per component, so a joint system (shared sky plus per-observation amplitudes) had to be assembled as a 2x2 block of separately reduced streams: four passes over the TOD where one suffices.

- layout is now data on a single `StreamOperator` (`in_stacked`/`out_stacked`), uniform or per component
- eight fusion rules collapse to three, since every composition of the uniform layouts meets at a stacked junction
- `block_row`/`block_column` lay several streams out over the components of a block structure, so a joint system's normal equations fuse to one scan
- two silent failures now raise: shared data sharded over the stream axis, where each shard quietly saw a different slice, and a stream axis the mesh shards do not divide

Migration:

```
StreamDiagonalOperator.create(op)  ->  StreamOperator.diagonal(op)
StreamColumnOperator.create(op)    ->  StreamOperator.column(op)
StreamRowOperator.create(op)       ->  StreamOperator.row(op)
StreamAdditionOperator.create(op)  ->  StreamOperator.addition(op)
```

## Checklist

- [x] Tests added/updated for new or changed behavior
- [x] `uvx prek run -a` passes (ruff, mypy, etc.)
- [x] Added a changelog entry under `[Unreleased]` in `docs/development/changelog.md`, or this PR doesn't need one (e.g. internal refactor, CI-only change)
- [x] Updated docs for user-facing changes (docstrings, `docs/`)
