### PR TITLE
Add `profile()` method to AbstractLinearOperator

### DIFF
--- a/docs/api/profiling.md
+++ b/docs/api/profiling.md
@@ -1,0 +1,5 @@
+# `furax.profiling`
+
+::: furax.profiling
+    options:
+      show_root_heading: false

--- a/docs/development/changelog.md
+++ b/docs/development/changelog.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `StreamOperator.block_row`/`block_column`: fuse several streams into one, evaluating a joint system in a single pass over the data (#190)
 - API reference page for `furax.mapmaking.streaming` (#190)
+- `AbstractLinearOperator.profile()` and a new `furax.profiling` module for estimated cost analysis (#193)
 
 ### Changed
 

--- a/src/furax/__init__.py
+++ b/src/furax/__init__.py
@@ -33,6 +33,7 @@ from .core import (
     upper_triangular,
 )
 from .interfaces.lineax import as_lineax_operator
+from .profiling import DeviceBalance, ProfileReport, measure_balance, profile
 
 __all__ = [
     # core
@@ -67,6 +68,11 @@ __all__ = [
     'positive_semidefinite',
     'negative_semidefinite',
     'idempotent',
+    # profiling
+    'DeviceBalance',
+    'ProfileReport',
+    'measure_balance',
+    'profile',
     # config
     'Config',
     # tree

--- a/src/furax/__init__.py
+++ b/src/furax/__init__.py
@@ -33,7 +33,6 @@ from .core import (
     upper_triangular,
 )
 from .interfaces.lineax import as_lineax_operator
-from .profiling import DeviceBalance, ProfileReport, measure_balance, profile
 
 __all__ = [
     # core
@@ -68,11 +67,6 @@ __all__ = [
     'positive_semidefinite',
     'negative_semidefinite',
     'idempotent',
-    # profiling
-    'DeviceBalance',
-    'ProfileReport',
-    'measure_balance',
-    'profile',
     # config
     'Config',
     # tree

--- a/src/furax/core/_base.py
+++ b/src/furax/core/_base.py
@@ -268,11 +268,13 @@ class AbstractLinearOperator(ABC):
 
             ```
             Profile on cpu (float32) peak=192.18 GFLOP/s bandwidth=9.19 GB/s ridge=20.9 flop/byte
-              flops       1.02 KFLOP  transcendentals=0
-              bytes       12.00KiB
-              intensity   0.0833 flop/byte
-              bound       memory-bound, at best 765.73 MFLOP/s (0.4% of peak)
-              memory      args=8.00KiB out=4.00KiB temp=0.00B peak=12.00KiB
+              flops           1.02 KFLOP
+              transcendental  0 ops, 0.00 FLOP (x10 weight)
+              total flops     1.02 KFLOP
+              bytes           12.00KiB
+              intensity       0.0833 flop/byte
+              bound           memory-bound, at best 765.73 MFLOP/s (0.4% of peak)
+              memory          args=8.00KiB out=4.00KiB temp=0.00B peak=12.00KiB
             ```
         """
         from furax.profiling import device_of, measure_balance, profile  # avoids a circular import

--- a/src/furax/core/_base.py
+++ b/src/furax/core/_base.py
@@ -238,23 +238,23 @@ class AbstractLinearOperator(ABC):
 
         return matrix
 
-    def profile(self, *, measure: bool = True) -> 'ProfileReport':
+    def profile(self, *, measure: bool = False) -> 'ProfileReport':
         """Returns the static cost of applying the operator: flops, bytes and what limits them.
 
         The counts are static: the operator is compiled ahead of time and XLA's cost model is read
-        off the executable, without applying it to anything. Deciding what those counts *mean*,
-        however, needs the device's peak rates, and by default they are measured — see `measure`
-        below. See [`furax.profiling`][] for the caveats that come with a static cost model.
+        off the executable, without applying it to anything. Deciding what those counts *mean* also
+        needs the device's peak rates, which have to be measured — see `measure` below. See
+        [`furax.profiling`][] for the caveats that come with a static cost model.
 
         Args:
             measure: Whether to measure peak throughputs with
                 [`measure_balance`][furax.profiling.measure_balance], which is what makes the
-                compute- or memory-bound verdict possible. This **runs benchmarks**: a large matmul
-                and two arrays of tens of MiB, taking on the order of a second and allocating a few
-                hundred MiB, cached per device and dtype. Pass `False` in memory-tight code, or to
-                keep `profile()` free of side effects: the report still carries flops, bytes and
-                buffer sizes, and leaves the bound unknown. The rates are measured on the device the
-                operator's arrays are committed to, falling back to `jax.devices()[0]`.
+                compute- or memory-bound verdict possible. Off by default, because it **runs
+                benchmarks**: a large matmul and two arrays of tens of MiB, taking on the order of
+                a second and allocating a few hundred MiB, cached per device and dtype. With
+                `False` the report still carries flops, bytes and buffer sizes, and leaves the
+                bound unknown. The rates are measured on the device the operator's arrays are
+                committed to, falling back to `jax.devices()[0]`.
 
         Returns:
             The [`ProfileReport`][furax.profiling.ProfileReport] for a single application of the
@@ -265,12 +265,12 @@ class AbstractLinearOperator(ABC):
 
             >>> structure = jax.ShapeDtypeStruct((1 << 22,), jnp.float32)
             >>> op = DiagonalOperator(jnp.ones(1 << 22, jnp.float32), in_structure=structure)
-            >>> report = op.profile(measure=False)
+            >>> report = op.profile()
             >>> report.flops, report.bytes_accessed
             (4194304.0, 50331648.0)
 
-            The verdict needs `measure=True` (the default). Printing the report then gives, with
-            the rates depending on the machine:
+            The verdict needs `measure=True`. Printing the report then gives, with the rates
+            depending on the machine:
 
             ```
             Profile on cpu (float32) peak=180.71 GFLOP/s bandwidth=9.83 GB/s ridge=18.4 flop/byte

--- a/src/furax/core/_base.py
+++ b/src/furax/core/_base.py
@@ -264,19 +264,21 @@ class AbstractLinearOperator(ABC):
             >>> report.flops, report.bytes_accessed
             (4194304.0, 50331648.0)
 
-            The verdict needs `measure=True` (the default), and then reads, on one machine:
+            The verdict needs `measure=True` (the default). Printing the report then gives, with
+            the rates depending on the machine:
 
             ```
-            Profile on NVIDIA H100 80GB HBM3 (float32) peak=... ridge=147 flop/byte
+            Profile on cpu (float32) peak=178.54 GFLOP/s bandwidth=9.03GiB/s ridge=18.4 flop/byte
               flops       4.19 MFLOP  transcendentals=0
               bytes       48.00MiB
               intensity   0.0833 flop/byte
-              bound       memory-bound, at best 279.62 GFLOP/s (0.6% of peak)
+              bound       memory-bound, at best 807.62 MFLOP/s (0.5% of peak)
               memory      args=32.00MiB out=16.00MiB temp=0.00B peak=48.00MiB
             ```
 
-            An operator that only scales its input reads three bytes for every flop it does, so it
-            can never exceed a small fraction of peak on any machine, however it is implemented.
+            Scaling a vector reads the input and the diagonal and writes the output — twelve bytes
+            of traffic per multiply — so it stays far below any device's ridge, however it is
+            implemented.
         """
         from furax.profiling import measure_balance, profile  # avoids a circular import
 

--- a/src/furax/core/_base.py
+++ b/src/furax/core/_base.py
@@ -4,7 +4,7 @@ from abc import ABC, abstractmethod
 from collections.abc import Callable
 from dataclasses import dataclass, field
 from enum import IntFlag, auto
-from typing import Any, ClassVar, dataclass_transform, overload
+from typing import TYPE_CHECKING, Any, ClassVar, dataclass_transform, overload
 
 import jax
 import jax.numpy as jnp
@@ -18,6 +18,9 @@ from furax._config import Config, ConfigState
 from furax.tree import zeros_like
 
 from .utils import register_dataclass_with_keys
+
+if TYPE_CHECKING:
+    from furax.profiling import ProfileReport
 
 
 def structure_equal(a: PyTree[jax.ShapeDtypeStruct], b: PyTree[jax.ShapeDtypeStruct]) -> bool:
@@ -234,6 +237,53 @@ class AbstractLinearOperator(ABC):
             matrix, jcounter = jax.lax.fori_loop(0, leaf.size, body, (matrix, jcounter))
 
         return matrix
+
+    def profile(self, *, measure: bool = True) -> 'ProfileReport':
+        """Returns the static cost of applying the operator: flops, bytes and what limits them.
+
+        The operator is compiled ahead of time and XLA's cost model is read off the executable;
+        nothing is executed and no input is allocated. See [`furax.profiling`][] for the caveats
+        that come with a static cost model.
+
+        Args:
+            measure: Whether to measure this device's peak throughputs with
+                [`measure_balance`][furax.measure_balance], which is what makes the compute- or
+                memory-bound verdict possible. It runs microbenchmarks taking on the order of a
+                second, cached per device and dtype. With `False`, the report still carries flops
+                and bytes but leaves the bound unknown.
+
+        Returns:
+            The [`ProfileReport`][furax.ProfileReport] for a single application of the operator.
+
+        Examples:
+            The flop and byte counts are exact and machine-independent:
+
+            >>> structure = jax.ShapeDtypeStruct((1 << 22,), jnp.float32)
+            >>> op = DiagonalOperator(jnp.ones(1 << 22, jnp.float32), in_structure=structure)
+            >>> report = op.profile(measure=False)
+            >>> report.flops, report.bytes_accessed
+            (4194304.0, 50331648.0)
+
+            The verdict needs `measure=True` (the default), and then reads, on one machine:
+
+            ```
+            Profile on NVIDIA H100 80GB HBM3 (float32) peak=... ridge=147 flop/byte
+              flops       4.19 MFLOP  transcendentals=0
+              bytes       48.00MiB
+              intensity   0.0833 flop/byte
+              bound       memory-bound, at best 279.62 GFLOP/s (0.6% of peak)
+              memory      args=32.00MiB out=16.00MiB temp=0.00B peak=48.00MiB
+            ```
+
+            An operator that only scales its input reads three bytes for every flop it does, so it
+            can never exceed a small fraction of peak on any machine, however it is implemented.
+        """
+        from furax.profiling import measure_balance, profile  # avoids a circular import
+
+        balance = measure_balance(dtype=self.in_promoted_dtype) if measure else None
+        # `self` is passed as an argument, not captured: closed-over arrays become XLA constants,
+        # which erases their traffic from the byte count and lets constant-folding remove work.
+        return profile(lambda op, x: op.mv(x), self, self.in_structure, balance=balance)
 
     def transpose(self) -> 'AbstractLinearOperator':
         return TransposeOperator(self)

--- a/src/furax/core/_base.py
+++ b/src/furax/core/_base.py
@@ -241,16 +241,20 @@ class AbstractLinearOperator(ABC):
     def profile(self, *, measure: bool = True) -> 'ProfileReport':
         """Returns the static cost of applying the operator: flops, bytes and what limits them.
 
-        The operator is compiled ahead of time and XLA's cost model is read off the executable;
-        nothing is executed and no input is allocated. See [`furax.profiling`][] for the caveats
-        that come with a static cost model.
+        The counts are static: the operator is compiled ahead of time and XLA's cost model is read
+        off the executable, without applying it to anything. Deciding what those counts *mean*,
+        however, needs the device's peak rates, and by default they are measured — see `measure`
+        below. See [`furax.profiling`][] for the caveats that come with a static cost model.
 
         Args:
-            measure: Whether to measure this device's peak throughputs with
+            measure: Whether to measure peak throughputs with
                 [`measure_balance`][furax.profiling.measure_balance], which is what makes the
-                compute- or memory-bound verdict possible. It runs microbenchmarks taking on the
-                order of a second, cached per device and dtype. With `False`, the report still
-                carries flops and bytes but leaves the bound unknown.
+                compute- or memory-bound verdict possible. This **runs benchmarks**: a large matmul
+                and two arrays of tens of MiB, taking on the order of a second and allocating a few
+                hundred MiB, cached per device and dtype. Pass `False` in memory-tight code, or to
+                keep `profile()` free of side effects: the report still carries flops, bytes and
+                buffer sizes, and leaves the bound unknown. The rates are measured on the device the
+                operator's arrays are committed to, falling back to `jax.devices()[0]`.
 
         Returns:
             The [`ProfileReport`][furax.profiling.ProfileReport] for a single application of the
@@ -269,11 +273,11 @@ class AbstractLinearOperator(ABC):
             the rates depending on the machine:
 
             ```
-            Profile on cpu (float32) peak=178.54 GFLOP/s bandwidth=9.03GiB/s ridge=18.4 flop/byte
+            Profile on cpu (float32) peak=180.71 GFLOP/s bandwidth=9.83 GB/s ridge=18.4 flop/byte
               flops       4.19 MFLOP  transcendentals=0
               bytes       48.00MiB
               intensity   0.0833 flop/byte
-              bound       memory-bound, at best 807.62 MFLOP/s (0.5% of peak)
+              bound       memory-bound, at best 819.36 MFLOP/s (0.5% of peak)
               memory      args=32.00MiB out=16.00MiB temp=0.00B peak=48.00MiB
             ```
 
@@ -281,9 +285,14 @@ class AbstractLinearOperator(ABC):
             of traffic per multiply — so it stays far below any device's ridge, however it is
             implemented.
         """
-        from furax.profiling import measure_balance, profile  # avoids a circular import
+        from furax.profiling import device_of, measure_balance, profile  # avoids a circular import
 
-        balance = measure_balance(dtype=self.in_promoted_dtype) if measure else None
+        # measure where the operator's arrays live: counts from one device compared against rates
+        # from another are meaningless. `device_of` returns None for uncommitted arrays, which is
+        # where `measure_balance` and XLA both default to `jax.devices()[0]`.
+        balance = (
+            measure_balance(device_of(self), dtype=self.in_promoted_dtype) if measure else None
+        )
         # `self` is passed as an argument, not captured: closed-over arrays become XLA constants,
         # which erases their traffic from the byte count and lets constant-folding remove work.
         return profile(lambda op, x: op.mv(x), self, self.in_structure, balance=balance)

--- a/src/furax/core/_base.py
+++ b/src/furax/core/_base.py
@@ -239,60 +239,50 @@ class AbstractLinearOperator(ABC):
         return matrix
 
     def profile(self, *, measure: bool = False) -> 'ProfileReport':
-        """Returns the static cost of applying the operator: flops, bytes and what limits them.
+        """Returns a cost estimate of applying the operator.
 
-        The counts are static: the operator is compiled ahead of time and XLA's cost model is read
-        off the executable, without applying it to anything. Deciding what those counts *mean* also
-        needs the device's peak rates, which have to be measured — see `measure` below. See
-        [`furax.profiling`][] for the caveats that come with a static cost model.
+        This estimate comes from the XLA compiler. See [`furax.profiling`] for caveats.
 
         Args:
-            measure: Whether to measure peak throughputs with
-                [`measure_balance`][furax.profiling.measure_balance], which is what makes the
-                compute- or memory-bound verdict possible. Off by default, because it **runs
-                benchmarks**: a large matmul and two arrays of tens of MiB, taking on the order of
-                a second and allocating a few hundred MiB, cached per device and dtype. With
-                `False` the report still carries flops, bytes and buffer sizes, and leaves the
-                bound unknown. The rates are measured on the device the operator's arrays are
-                committed to, falling back to `jax.devices()[0]`.
+            measure: Measure peak flop/bytes per second using [`measure_balance`]
+                [furax.profiling.measure_balance]. The operator is traced alongside the input.
+                The rates are measured on the device that the operator's arrays are committed to.
 
         Returns:
-            The [`ProfileReport`][furax.profiling.ProfileReport] for a single application of the
-            operator.
+            The [`ProfileReport`][furax.profiling.ProfileReport] of the operator's `mv`.
 
         Examples:
-            The flop and byte counts are exact and machine-independent:
+            Estimate the cost of a diagonal matrix-vector product:
 
-            >>> structure = jax.ShapeDtypeStruct((1 << 22,), jnp.float32)
-            >>> op = DiagonalOperator(jnp.ones(1 << 22, jnp.float32), in_structure=structure)
+            >>> n = 1024
+            >>> structure = jax.ShapeDtypeStruct((n,), jnp.float32)
+            >>> op = DiagonalOperator(jnp.ones(n, jnp.float32), in_structure=structure)
             >>> report = op.profile()
-            >>> report.flops, report.bytes_accessed
-            (4194304.0, 50331648.0)
+            >>> report.flops  # one multiply per element
+            1024.0
+            >>> # the operator is traced alongside the input, so the diagonal counts as traffic
+            >>> report.bytes_accessed / (n * 4)  # input + diagonal + output, not just in + out
+            3.0
 
-            The verdict needs `measure=True`. Printing the report then gives, with the rates
-            depending on the machine:
+            With `measure=True`, the report gives a memory- or compute-bound diagnostic:
 
             ```
-            Profile on cpu (float32) peak=180.71 GFLOP/s bandwidth=9.83 GB/s ridge=18.4 flop/byte
-              flops       4.19 MFLOP  transcendentals=0
-              bytes       48.00MiB
+            Profile on cpu (float32) peak=192.18 GFLOP/s bandwidth=9.19 GB/s ridge=20.9 flop/byte
+              flops       1.02 KFLOP  transcendentals=0
+              bytes       12.00KiB
               intensity   0.0833 flop/byte
-              bound       memory-bound, at best 819.36 MFLOP/s (0.5% of peak)
-              memory      args=32.00MiB out=16.00MiB temp=0.00B peak=48.00MiB
+              bound       memory-bound, at best 765.73 MFLOP/s (0.4% of peak)
+              memory      args=8.00KiB out=4.00KiB temp=0.00B peak=12.00KiB
             ```
-
-            Scaling a vector reads the input and the diagonal and writes the output — twelve bytes
-            of traffic per multiply — so it stays far below any device's ridge, however it is
-            implemented.
         """
         from furax.profiling import device_of, measure_balance, profile  # avoids a circular import
 
-        # measure where the operator's arrays live: counts from one device compared against rates
-        # from another are meaningless. `device_of` returns None for uncommitted arrays, which is
-        # where `measure_balance` and XLA both default to `jax.devices()[0]`.
-        balance = (
-            measure_balance(device_of(self), dtype=self.in_promoted_dtype) if measure else None
-        )
+        if measure:
+            # measure where the operator's arrays live
+            # uncommitted arrays default to `jax.devices()[0]`
+            balance = measure_balance(device_of(self), dtype=self.in_promoted_dtype)
+        else:
+            balance = None
         # `self` is passed as an argument, not captured: closed-over arrays become XLA constants,
         # which erases their traffic from the byte count and lets constant-folding remove work.
         return profile(lambda op, x: op.mv(x), self, self.in_structure, balance=balance)

--- a/src/furax/core/_base.py
+++ b/src/furax/core/_base.py
@@ -247,13 +247,14 @@ class AbstractLinearOperator(ABC):
 
         Args:
             measure: Whether to measure this device's peak throughputs with
-                [`measure_balance`][furax.measure_balance], which is what makes the compute- or
-                memory-bound verdict possible. It runs microbenchmarks taking on the order of a
-                second, cached per device and dtype. With `False`, the report still carries flops
-                and bytes but leaves the bound unknown.
+                [`measure_balance`][furax.profiling.measure_balance], which is what makes the
+                compute- or memory-bound verdict possible. It runs microbenchmarks taking on the
+                order of a second, cached per device and dtype. With `False`, the report still
+                carries flops and bytes but leaves the bound unknown.
 
         Returns:
-            The [`ProfileReport`][furax.ProfileReport] for a single application of the operator.
+            The [`ProfileReport`][furax.profiling.ProfileReport] for a single application of the
+            operator.
 
         Examples:
             The flop and byte counts are exact and machine-independent:

--- a/src/furax/mapmaking/mapmaker.py
+++ b/src/furax/mapmaking/mapmaker.py
@@ -45,6 +45,7 @@ from furax.obs.landscapes import (
 from furax.obs.operators import HWPOperator, LinearPolarizerOperator, QURotationOperator
 from furax.obs.pointing import PointingOperator
 from furax.obs.stokes import Stokes, StokesI, StokesIQU, StokesType, ValidStokesLiteral
+from furax.profiling import format_bytes
 
 from . import templates
 from ._geometry import minimum_enclosing_arc
@@ -200,18 +201,18 @@ class MultiObservationMapMaker[T]:
         )
         logger_info(
             f'dataset obs={self.n_observations} slots={n_slots_global} slot_overhead=+{slot_overhead:.1%} '
-            f'slots_per_proc={n_per_proc} slots_per_dev={n_per_dev} slot_size={_format_bytes(per_slot_bytes)}'
+            f'slots_per_proc={n_per_proc} slots_per_dev={n_per_dev} slot_size={format_bytes(per_slot_bytes)}'
         )
         logger_info(
-            f'dataset real={_format_bytes(real_bytes)} global={_format_bytes(global_bytes)} '
+            f'dataset real={format_bytes(real_bytes)} global={format_bytes(global_bytes)} '
             f'byte_overhead=+{byte_overhead:.1%}'
         )
 
         rank_pad = n_pad / n_per_proc
         logger_info(
             f'rank={rank} obs={start}:{start + n_owned} real={n_owned} pad={n_pad} '
-            f'pad_pct={rank_pad:.1%} real_size={_format_bytes(per_slot_bytes * n_owned)} '
-            f'pad_size={_format_bytes(per_slot_bytes * n_pad)}'
+            f'pad_pct={rank_pad:.1%} real_size={format_bytes(per_slot_bytes * n_owned)} '
+            f'pad_size={format_bytes(per_slot_bytes * n_pad)}'
         )
 
         with jax.set_mesh(self.mesh):
@@ -486,14 +487,6 @@ class MultiObservationMapMaker[T]:
         # create the final shape and WCS objects for this covering box
         shape, wcs = pixell.enmap.geometry(pos=union_box, res=res, proj=proj)
         return WCSLandscape.from_wcs(shape, wcs, lc.stokes, self.config.dtype)
-
-
-def _format_bytes(n: float) -> str:
-    for unit in ('B', 'KiB', 'MiB', 'GiB', 'TiB'):
-        if n < 1024:
-            return f'{n:.2f}{unit}'
-        n /= 1024
-    return f'{n:.2f}PiB'
 
 
 def get_obs_distribution_to_process(

--- a/src/furax/profiling.py
+++ b/src/furax/profiling.py
@@ -136,8 +136,10 @@ class ProfileReport:
 
     Warning:
         `flops` and `bytes_accessed` are estimates from XLA's static cost model, not measurements
-        from hardware counters: they are the arithmetic and the buffer traffic the compiler
-        attributes to the program. Everything derived from them is an estimate too.
+        from hardware counters. JAX documents that model as a debugging aid whose structure "may be
+        inconsistent across versions of JAX and jaxlib, or even across invocations", and the
+        individual counters are undocumented XLA internals. Read these numbers, and everything
+        derived from them, as indications rather than facts.
 
     Attributes:
         flops: Floating-point operations, from XLA's cost model. Excludes `transcendentals`.
@@ -165,14 +167,25 @@ class ProfileReport:
     cost_available: bool = True
 
     @property
+    def total_flops(self) -> float:
+        """[`flops`][] plus [`transcendentals`][], counting each transcendental as one operation.
+
+        XLA counts `sin`, `exp` and friends separately from `flops`, so a kernel that is nothing but
+        transcendentals reports `flops == 0`. Charging one operation each keeps it from looking
+        free, and understates it: a transcendental costs several flops. How XLA arrives at either
+        counter is undocumented, so this is a convention, not a conversion.
+        """
+        return self.flops + self.transcendentals
+
+    @property
     def arithmetic_intensity(self) -> float:
-        r"""Flops performed per byte moved: $I = \text{flops} / \text{bytes}$.
+        """Arithmetic per byte moved: [`total_flops`][] over [`bytes_accessed`][], in flop/byte.
 
         Returns `0.0` when no bytes are moved.
         """
         if self.bytes_accessed == 0:
             return 0.0
-        return self.flops / self.bytes_accessed
+        return self.total_flops / self.bytes_accessed
 
     @property
     def attainable_flops(self) -> float | None:
@@ -212,33 +225,43 @@ class ProfileReport:
 
     def __str__(self) -> str:
         header = 'Profile' if self.balance is None else f'Profile on {self.balance}'
-        flops = 'unavailable' if not self.cost_available else _format_count(self.flops, 'FLOP')
-        lines = [
-            header,
-            f'  flops       {flops}  transcendentals={self.transcendentals:.0f}',
-            f'  bytes       {format_bytes(self.bytes_accessed)}',
-            f'  intensity   {self.arithmetic_intensity:.3g} flop/byte',
-            (
-                f'  memory      args={format_bytes(self.argument_bytes)} '
-                f'out={format_bytes(self.output_bytes)} temp={format_bytes(self.temp_bytes)} '
-                f'peak={format_bytes(self.peak_bytes)}'
-            ),
-        ]
-        if self.balance is None:
-            lines.insert(4, '  bound       unknown (no machine balance measured)')
-        elif self.flops == 0 and self.cost_available:
-            # '0.0% of peak' would read as a failure rather than as an absence of arithmetic
-            lines.insert(4, '  bound       memory (pure data movement, no arithmetic)')
+        if not self.cost_available:
+            # every count is zero because the backend declined to report, so nothing derived from
+            # them may be shown as a number: it would read as a measurement of a free computation
+            flops = intensity = bound = 'unavailable'
         else:
-            bound = 'memory' if self.is_memory_bound else 'compute'
-            efficiency = self.efficiency
-            lines.insert(
-                4,
-                f'  bound       {bound}-bound, at best '
-                f'{_format_count(self.attainable_flops or 0.0, "FLOP/s")} '
-                f'({efficiency:.1%} of peak)',
-            )
-        return '\n'.join(lines)
+            flops = _format_count(self.flops, 'FLOP')
+            intensity = f'{self.arithmetic_intensity:.3g} flop/byte'
+            bound = self._format_bound()
+        return '\n'.join(
+            [
+                header,
+                f'  flops       {flops}  transcendentals={self.transcendentals:.0f}',
+                f'  bytes       {format_bytes(self.bytes_accessed)}',
+                f'  intensity   {intensity}',
+                f'  bound       {bound}',
+                (
+                    f'  memory      args={format_bytes(self.argument_bytes)} '
+                    f'out={format_bytes(self.output_bytes)} temp={format_bytes(self.temp_bytes)} '
+                    f'peak={format_bytes(self.peak_bytes)}'
+                ),
+            ]
+        )
+
+    def _format_bound(self) -> str:
+        """Renders the bound line, given that a cost analysis was available."""
+        if self.balance is None:
+            return 'unknown (no machine balance measured)'
+        if self.total_flops == 0:
+            # '0.0% of peak' would read as a failure rather than as an absence of arithmetic
+            return 'memory (pure data movement, no arithmetic)'
+        efficiency = self.efficiency
+        assert efficiency is not None and self.attainable_flops is not None  # balance is not None
+        bound = 'memory' if self.is_memory_bound else 'compute'
+        return (
+            f'{bound}-bound, at best {_format_count(self.attainable_flops, "FLOP/s")} '
+            f'({efficiency:.1%} of peak)'
+        )
 
 
 def _time_best(fn: Any, *args: Any) -> float:

--- a/src/furax/profiling.py
+++ b/src/furax/profiling.py
@@ -19,6 +19,7 @@ from jax.typing import DTypeLike
 __all__ = [
     'DeviceBalance',
     'ProfileReport',
+    'device_of',
     'format_bytes',
     'measure_balance',
     'profile',
@@ -33,7 +34,37 @@ _MATMUL_SIZE_DEFAULT = 4096
 _BANDWIDTH_SIZE = 1 << 24
 _REPEATS = 5
 
-_BALANCE_CACHE: dict[tuple[jax.Device, np.dtype[np.floating[Any]]], 'DeviceBalance'] = {}
+_BALANCE_CACHE: dict[tuple[jax.Device, np.dtype[Any]], 'DeviceBalance'] = {}
+
+
+def _format_quantity(n: float, unit: str, *, base: int, separator: str = ' ') -> str:
+    """Formats a quantity with the largest prefix that keeps it above one.
+
+    Args:
+        n: The quantity to format.
+        unit: The unit the prefix is applied to, e.g. `'B'` or `'FLOP/s'`.
+        base: `1000` for decimal SI prefixes (`k`, `M`, ...), `1024` for binary ones (`Ki`, `Mi`).
+        separator: What to put between the number and the prefixed unit.
+
+    Returns:
+        The quantity, rounded to two decimals and suffixed with the prefixed unit.
+
+    Examples:
+        >>> _format_quantity(2.1e9, 'FLOP', base=1000)
+        '2.10 GFLOP'
+
+        >>> _format_quantity(1536, 'B', base=1024, separator='')
+        '1.50KiB'
+    """
+    for prefix in ('', 'K', 'M', 'G', 'T'):
+        if n < base:
+            break
+        n /= base
+    else:
+        prefix = 'P'
+    if prefix and base == 1024:
+        prefix += 'i'  # KiB, MiB, ... but plain B for the unprefixed case
+    return f'{n:.2f}{separator}{prefix}{unit}'
 
 
 def format_bytes(n: float) -> str:
@@ -49,34 +80,26 @@ def format_bytes(n: float) -> str:
         >>> format_bytes(1536)
         '1.50KiB'
     """
-    for unit in ('B', 'KiB', 'MiB', 'GiB', 'TiB'):
-        if n < 1024:
-            return f'{n:.2f}{unit}'
-        n /= 1024
-    return f'{n:.2f}PiB'
+    return _format_quantity(n, 'B', base=1024, separator='')
 
 
 def _format_count(n: float, unit: str) -> str:
     """Formats a count with a decimal SI prefix, e.g. ``_format_count(2.1e9, 'FLOP')``."""
-    for prefix in ('', 'K', 'M', 'G', 'T'):
-        if n < 1000:
-            return f'{n:.2f} {prefix}{unit}'
-        n /= 1000
-    return f'{n:.2f} P{unit}'
+    return _format_quantity(n, unit, base=1000)
 
 
-def _real_float_dtype(dtype: DTypeLike) -> np.dtype[np.floating[Any]]:
+def _real_float_dtype(dtype: DTypeLike) -> np.dtype[Any]:
     """Maps a dtype onto the real floating-point dtype whose peak rates should be measured.
 
-    Complex dtypes are mapped to their component dtype and non-inexact dtypes to float32, since the
-    microbenchmarks measure floating-point throughput. float64 is downgraded when x64 is disabled,
-    where float64 arrays cannot be created at all.
+    Complex dtypes are mapped to their component dtype and non-floating dtypes to float32, since
+    the microbenchmarks measure floating-point throughput. float64 is downgraded when x64 is
+    disabled, where float64 arrays cannot be created at all.
     """
     given = np.dtype(dtype)
-    if np.issubdtype(given, np.complexfloating):
+    if jnp.issubdtype(given, jnp.complexfloating):
         result = np.dtype(given.type(0).real.dtype)
-    elif np.issubdtype(given, np.floating):
-        result = np.dtype(given)
+    elif jnp.issubdtype(given, jnp.floating):
+        result = given
     else:
         result = np.dtype(np.float32)
     if result == np.float64 and not jax.config.jax_enable_x64:
@@ -109,7 +132,7 @@ class DeviceBalance:
     """
 
     device_kind: str
-    dtype: np.dtype[np.floating[Any]]
+    dtype: np.dtype[Any]
     peak_flops: float
     peak_bandwidth: float
 
@@ -122,7 +145,10 @@ class DeviceBalance:
         return (
             f'{self.device_kind} ({self.dtype.name}) '
             f'peak={_format_count(self.peak_flops, "FLOP/s")} '
-            f'bandwidth={format_bytes(self.peak_bandwidth)}/s '
+            # decimal units, like the flop rate and like vendor bandwidth figures: a binary
+            # bandwidth here would make `ridge` a decimal-over-binary ratio that cannot be
+            # checked against either
+            f'bandwidth={_format_count(self.peak_bandwidth, "B/s")} '
             f'ridge={self.ridge:.3g} flop/byte'
         )
 
@@ -275,6 +301,28 @@ def _time_best(fn: Any, *args: Any) -> float:
     return best
 
 
+def device_of(tree: Any) -> jax.Device | None:
+    """Returns the device a pytree's arrays are committed to, if they agree on one.
+
+    Returns `None` when the tree holds no committed array — no leaves, uncommitted leaves, or
+    leaves committed to different devices. That is the signal to fall back to a default rather
+    than to trust any one of them.
+
+    Args:
+        tree: The pytree to inspect.
+
+    Returns:
+        The single device every committed array leaf lives on, or `None`.
+    """
+    devices = {
+        device
+        for leaf in jax.tree.leaves(tree)
+        if isinstance(leaf, jax.Array) and leaf.committed
+        for device in leaf.devices()
+    }
+    return devices.pop() if len(devices) == 1 else None
+
+
 def measure_balance(
     device: jax.Device | None = None, dtype: DTypeLike = jnp.float32
 ) -> DeviceBalance:
@@ -287,11 +335,14 @@ def measure_balance(
     are free.
 
     The dtype matters: single- and double-precision peak rates differ by up to a factor 64 on
-    accelerators. Complex dtypes are measured with their component dtype, and integer dtypes with
-    float32.
+    accelerators. Complex dtypes are measured with their component dtype, and non-floating dtypes
+    with float32.
 
     Args:
-        device: The device to measure. Defaults to `jax.devices()[0]`.
+        device: The device to measure. Defaults to `jax.devices()[0]`, which is where JAX places
+            uncommitted arrays. Pass the device the profiled computation actually runs on when it
+            differs — comparing counts from one device against rates from another says nothing.
+            [`device_of`][] derives it from an operator or a pytree.
         dtype: The dtype to measure the rates for.
 
     Returns:
@@ -301,6 +352,10 @@ def measure_balance(
         This runs actual computations and takes on the order of a second the first time it is
         called for a given `(device, dtype)`. Pass `measure=False` to
         [`AbstractLinearOperator.profile`][furax.core.AbstractLinearOperator.profile] to skip it.
+
+        The rates describe one device. Under a mesh the microbenchmark arrays follow the mesh
+        rather than the single device named here, so the result does not describe sharded
+        execution.
     """
     if device is None:
         device = jax.devices()[0]

--- a/src/furax/profiling.py
+++ b/src/furax/profiling.py
@@ -41,7 +41,8 @@ _MATMUL_SIZE_DEFAULT = 4096
 _BANDWIDTH_SIZE = 1 << 24
 _REPEATS = 5
 
-TRANSCENDENTAL_FLOPS = 10
+# How many flops one transcendental operation is worth (for reporting purposes)
+_TRANSCENDENTAL_FLOPS = 10
 
 
 def _format_quantity(n: float, unit: str, *, base: Literal[1000, 1024], sep: str = ' ') -> str:
@@ -185,14 +186,20 @@ class ProfileReport:
     cost_available: bool = True
 
     @property
-    def total_flops(self) -> float:
-        """[`flops`][] plus [`transcendentals`][], counted as 10 flops.
+    def transcendental_flops(self) -> float:
+        """[`transcendentals`][] weighted as 10 flops each.
 
         XLA counts `sin`, `exp` and friends separately from `flops`. These functions are more
-        computationally expensive than basic arithmetic, and may use special hardware units.
-        For the sake of simplicity, we count each one as 10 flops.
+        computationally expensive than basic arithmetic, and may use special hardware units. How
+        much more depends on the function and on the device, so any single weight is arbitrary; we
+        use 10, and report this contribution separately from `flops` so it can be discounted.
         """
-        return self.flops + TRANSCENDENTAL_FLOPS * self.transcendentals
+        return _TRANSCENDENTAL_FLOPS * self.transcendentals
+
+    @property
+    def total_flops(self) -> float:
+        """[`flops`][] plus [`transcendental_flops`][]."""
+        return self.flops + self.transcendental_flops
 
     @property
     def arithmetic_intensity(self) -> float:
@@ -232,8 +239,8 @@ class ProfileReport:
 
     @property
     def bound(self) -> Bound | None:
-        """What limits this computation on the device, or `None` if no `balance` was measured."""
-        if self.balance is None:
+        """What limits this computation on the device; `None` when no verdict can be reached."""
+        if self.balance is None or not self.cost_available:
             return None
         ridge = self.balance.ridge
         if abs(self.arithmetic_intensity - ridge) <= ridge * self.balance.ridge_error:
@@ -245,20 +252,28 @@ class ProfileReport:
         if not self.cost_available:
             # every count is zero because the backend declined to report, so nothing derived from
             # them may be shown as a number: it would read as a measurement of a free computation
-            flops = intensity = bound = 'unavailable'
+            flops = transcendentals = total = intensity = bound = 'unavailable'
         else:
             flops = _format_count(self.flops, 'FLOP')
+            transcendentals = (
+                f'{self.transcendentals:.0f} ops, '
+                f'{_format_count(self.transcendental_flops, "FLOP")} '
+                f'(x{_TRANSCENDENTAL_FLOPS} weight)'
+            )
+            total = _format_count(self.total_flops, 'FLOP')
             intensity = f'{self.arithmetic_intensity:.3g} flop/byte'
             bound = self._format_bound()
         return '\n'.join(
             [
                 header,
-                f'  flops       {flops}  transcendentals={self.transcendentals:.0f}',
-                f'  bytes       {format_bytes(self.bytes_accessed)}',
-                f'  intensity   {intensity}',
-                f'  bound       {bound}',
+                f'  flops           {flops}',
+                f'  transcendental  {transcendentals}',
+                f'  total flops     {total}',
+                f'  bytes           {format_bytes(self.bytes_accessed)}',
+                f'  intensity       {intensity}',
+                f'  bound           {bound}',
                 (
-                    f'  memory      args={format_bytes(self.argument_bytes)} '
+                    f'  memory          args={format_bytes(self.argument_bytes)} '
                     f'out={format_bytes(self.output_bytes)} temp={format_bytes(self.temp_bytes)} '
                     f'peak={format_bytes(self.peak_bytes)}'
                 ),

--- a/src/furax/profiling.py
+++ b/src/furax/profiling.py
@@ -15,7 +15,7 @@ Warning:
 import time
 from dataclasses import dataclass
 from enum import StrEnum
-from typing import Any, Literal
+from typing import Any, ClassVar, Literal
 
 import jax
 import jax.numpy as jnp
@@ -31,18 +31,6 @@ __all__ = [
     'measure_balance',
     'profile',
 ]
-
-# Problem sizes for the microbenchmarks in `measure_balance`. Accelerators need a large matmul to
-# reach peak; on CPU the same size would take seconds for no extra accuracy.
-_MATMUL_SIZE = {'cpu': 1024}
-_MATMUL_SIZE_DEFAULT = 4096
-# element count of the arrays added together to measure bandwidth: 3 x 64 MiB of traffic in
-# float32, far beyond any last-level cache, so the timing reflects main memory and not cache
-_BANDWIDTH_SIZE = 1 << 24
-_REPEATS = 5
-
-# How many flops one transcendental operation is worth (for reporting purposes)
-_TRANSCENDENTAL_FLOPS = 10
 
 
 def _format_quantity(n: float, unit: str, *, base: Literal[1000, 1024], sep: str = ' ') -> str:
@@ -185,6 +173,9 @@ class ProfileReport:
     balance: DeviceBalance | None = None
     cost_available: bool = True
 
+    # how many flops one transcendental operation is worth (for reporting purposes)
+    _TRANSCENDENTAL_FLOPS: ClassVar[int] = 10
+
     @property
     def transcendental_flops(self) -> float:
         """[`transcendentals`][] weighted as 10 flops each.
@@ -194,7 +185,7 @@ class ProfileReport:
         much more depends on the function and on the device, so any single weight is arbitrary; we
         use 10, and report this contribution separately from `flops` so it can be discounted.
         """
-        return _TRANSCENDENTAL_FLOPS * self.transcendentals
+        return self._TRANSCENDENTAL_FLOPS * self.transcendentals
 
     @property
     def total_flops(self) -> float:
@@ -258,7 +249,7 @@ class ProfileReport:
             transcendentals = (
                 f'{self.transcendentals:.0f} ops, '
                 f'{_format_count(self.transcendental_flops, "FLOP")} '
-                f'(x{_TRANSCENDENTAL_FLOPS} weight)'
+                f'(x{self._TRANSCENDENTAL_FLOPS} weight)'
             )
             total = _format_count(self.total_flops, 'FLOP')
             intensity = f'{self.arithmetic_intensity:.3g} flop/byte'
@@ -295,6 +286,13 @@ class ProfileReport:
             f'{self.bound}-bound, at best {_format_count(self.attainable_flops, "FLOP/s")} '
             f'({efficiency:.1%} of peak)'
         )
+
+
+# Problem sizes for microbenchmarks
+_MATMUL_SIZE = {'cpu': 1024}
+_MATMUL_SIZE_DEFAULT = 4096  # large matmul for accelerators
+_BANDWIDTH_SIZE = 1 << 24  # 64 MiB (f32) -> 3x traffic, larger than typical cache
+_REPEATS = 5
 
 
 def _peak_rate(work: float, times: list[float]) -> tuple[float, float]:

--- a/src/furax/profiling.py
+++ b/src/furax/profiling.py
@@ -1,0 +1,383 @@
+"""Static cost model for compiled computations.
+
+Reports the flops, memory traffic and buffer sizes of a computation without running it. The
+computation is lowered and compiled ahead of time, and XLA's estimates are read off the resulting
+executable with [`jax.stages.Compiled.cost_analysis`][] (flops, bytes accessed) and
+[`jax.stages.Compiled.memory_analysis`][] (argument / output / temporary buffer sizes). Shapes and
+dtypes are therefore enough: no input needs to be allocated.
+"""
+
+import time
+from dataclasses import dataclass
+from typing import Any
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+from jax.typing import DTypeLike
+
+__all__ = [
+    'DeviceBalance',
+    'ProfileReport',
+    'format_bytes',
+    'measure_balance',
+    'profile',
+]
+
+# Problem sizes for the microbenchmarks in `measure_balance`. Accelerators need a large matmul to
+# reach peak; on CPU the same size would take seconds for no extra accuracy.
+_MATMUL_SIZE = {'cpu': 1024}
+_MATMUL_SIZE_DEFAULT = 4096
+# element count of the arrays added together to measure bandwidth: 3 x 64 MiB of traffic in
+# float32, far beyond any last-level cache, so the timing reflects main memory and not cache
+_BANDWIDTH_SIZE = 1 << 24
+_REPEATS = 5
+
+_BALANCE_CACHE: dict[tuple[jax.Device, np.dtype[np.floating[Any]]], 'DeviceBalance'] = {}
+
+
+def format_bytes(n: float) -> str:
+    """Formats a byte count with a binary unit suffix.
+
+    Args:
+        n: The number of bytes.
+
+    Returns:
+        The byte count, rounded to two decimals and suffixed with a binary unit.
+
+    Examples:
+        >>> format_bytes(1536)
+        '1.50KiB'
+    """
+    for unit in ('B', 'KiB', 'MiB', 'GiB', 'TiB'):
+        if n < 1024:
+            return f'{n:.2f}{unit}'
+        n /= 1024
+    return f'{n:.2f}PiB'
+
+
+def _format_count(n: float, unit: str) -> str:
+    """Formats a count with a decimal SI prefix, e.g. ``_format_count(2.1e9, 'FLOP')``."""
+    for prefix in ('', 'K', 'M', 'G', 'T'):
+        if n < 1000:
+            return f'{n:.2f} {prefix}{unit}'
+        n /= 1000
+    return f'{n:.2f} P{unit}'
+
+
+def _real_float_dtype(dtype: DTypeLike) -> np.dtype[np.floating[Any]]:
+    """Maps a dtype onto the real floating-point dtype whose peak rates should be measured.
+
+    Complex dtypes are mapped to their component dtype and non-inexact dtypes to float32, since the
+    microbenchmarks measure floating-point throughput. float64 is downgraded when x64 is disabled,
+    where float64 arrays cannot be created at all.
+    """
+    given = np.dtype(dtype)
+    if np.issubdtype(given, np.complexfloating):
+        result = np.dtype(given.type(0).real.dtype)
+    elif np.issubdtype(given, np.floating):
+        result = np.dtype(given)
+    else:
+        result = np.dtype(np.float32)
+    if result == np.float64 and not jax.config.jax_enable_x64:
+        result = np.dtype(np.float32)
+    return result
+
+
+@dataclass(frozen=True)
+class DeviceBalance:
+    """Measured peak throughputs of a device, for one dtype.
+
+    A device performs only so many flops per second and moves only so many bytes per second. Their
+    ratio, [`ridge`][], is how much arithmetic it must be given per byte to keep its arithmetic
+    units fed — typically tens of flops per byte.
+
+    Compare it to a computation's [`ProfileReport.arithmetic_intensity`][], the flops it performs
+    per byte it touches. Below the ridge the computation is *memory-bound*: the units idle waiting
+    for data. Above the ridge it is *compute-bound*: the data arrives faster than the units consume
+    it, and the arithmetic sets the pace.
+
+    A matrix-vector product reads a whole matrix to do only two flops per element, so it is
+    typically memory-bound on all devices; a large matrix-matrix product reuses each element many
+    times, and is compute-bound on most devices.
+
+    Attributes:
+        device_kind: The `device_kind` of the [`jax.Device`][], e.g. `'NVIDIA H100 80GB HBM3'`.
+        dtype: The dtype the rates were measured with.
+        peak_flops: Measured peak arithmetic throughput, in flop/s.
+        peak_bandwidth: Measured peak memory throughput, in byte/s.
+    """
+
+    device_kind: str
+    dtype: np.dtype[np.floating[Any]]
+    peak_flops: float
+    peak_bandwidth: float
+
+    @property
+    def ridge(self) -> float:
+        """The ridge point in flop/byte: [`peak_flops`][] divided by [`peak_bandwidth`][]."""
+        return self.peak_flops / self.peak_bandwidth
+
+    def __str__(self) -> str:
+        return (
+            f'{self.device_kind} ({self.dtype.name}) '
+            f'peak={_format_count(self.peak_flops, "FLOP/s")} '
+            f'bandwidth={format_bytes(self.peak_bandwidth)}/s '
+            f'ridge={self.ridge:.3g} flop/byte'
+        )
+
+
+@dataclass(frozen=True)
+class ProfileReport:
+    """The static cost of one compiled computation.
+
+    This is the result of a call to [`profile`][], or [`AbstractLinearOperator.profile`]
+    [furax.core.AbstractLinearOperator.profile] for an operator.
+
+    Warning:
+        `flops` and `bytes_accessed` are estimates from XLA's static cost model, not measurements
+        from hardware counters: they are the arithmetic and the buffer traffic the compiler
+        attributes to the program. Everything derived from them is an estimate too.
+
+    Attributes:
+        flops: Floating-point operations, from XLA's cost model. Excludes `transcendentals`.
+        transcendentals: Transcendental operations (`sin`, `exp`, ...), counted separately by XLA.
+        bytes_accessed: Total buffer traffic, from XLA's cost model.
+        argument_bytes: Total size of the executable's arguments.
+        output_bytes: Total size of the executable's outputs.
+        temp_bytes: Peak size of the scratch buffers, i.e. the memory needed on top of the
+            arguments and outputs.
+        peak_bytes: Peak device memory attributed to the executable.
+        balance: A [`DeviceBalance`][] to evaluate profile counts against.
+        cost_available: Whether XLA reported a cost analysis at all. When `False`, `flops`,
+            `transcendentals` and `bytes_accessed` are zero because the backend declined to
+            provide them, not because the computation is free.
+    """
+
+    flops: float
+    transcendentals: float
+    bytes_accessed: float
+    argument_bytes: int
+    output_bytes: int
+    temp_bytes: int
+    peak_bytes: int
+    balance: DeviceBalance | None = None
+    cost_available: bool = True
+
+    @property
+    def arithmetic_intensity(self) -> float:
+        r"""Flops performed per byte moved: $I = \text{flops} / \text{bytes}$.
+
+        Returns `0.0` when no bytes are moved.
+        """
+        if self.bytes_accessed == 0:
+            return 0.0
+        return self.flops / self.bytes_accessed
+
+    @property
+    def attainable_flops(self) -> float | None:
+        """The fastest this computation could run on the device, in flop/s.
+
+        Two ceilings apply and the lower one wins: the device's [`DeviceBalance.peak_flops`][], and
+        what its bandwidth can sustain at this computation's [`arithmetic_intensity`][], which is
+        `arithmetic_intensity * peak_bandwidth`. A compute-bound computation is capped by the
+        first, a memory-bound one by the second. `None` if `balance` is `None`.
+        """
+        if self.balance is None:
+            return None
+        return min(self.balance.peak_flops, self.arithmetic_intensity * self.balance.peak_bandwidth)
+
+    @property
+    def efficiency(self) -> float | None:
+        """The attainable throughput as a fraction of peak, in `[0, 1]`.
+
+        A memory-bound computation has a low efficiency *by construction*: it is the fraction of
+        the machine's arithmetic units the computation can possibly keep busy, not a measurement of
+        how well it is implemented. `None` if no `balance` was measured.
+        """
+        attainable = self.attainable_flops
+        if attainable is None or self.balance is None:
+            return None
+        return attainable / self.balance.peak_flops
+
+    @property
+    def is_memory_bound(self) -> bool | None:
+        """Whether the arithmetic intensity is below the machine's ridge point.
+
+        `None` if no `balance` was measured.
+        """
+        if self.balance is None:
+            return None
+        return self.arithmetic_intensity < self.balance.ridge
+
+    def __str__(self) -> str:
+        header = 'Profile' if self.balance is None else f'Profile on {self.balance}'
+        flops = 'unavailable' if not self.cost_available else _format_count(self.flops, 'FLOP')
+        lines = [
+            header,
+            f'  flops       {flops}  transcendentals={self.transcendentals:.0f}',
+            f'  bytes       {format_bytes(self.bytes_accessed)}',
+            f'  intensity   {self.arithmetic_intensity:.3g} flop/byte',
+            (
+                f'  memory      args={format_bytes(self.argument_bytes)} '
+                f'out={format_bytes(self.output_bytes)} temp={format_bytes(self.temp_bytes)} '
+                f'peak={format_bytes(self.peak_bytes)}'
+            ),
+        ]
+        if self.balance is None:
+            lines.insert(4, '  bound       unknown (no machine balance measured)')
+        elif self.flops == 0 and self.cost_available:
+            # '0.0% of peak' would read as a failure rather than as an absence of arithmetic
+            lines.insert(4, '  bound       memory (pure data movement, no arithmetic)')
+        else:
+            bound = 'memory' if self.is_memory_bound else 'compute'
+            efficiency = self.efficiency
+            lines.insert(
+                4,
+                f'  bound       {bound}-bound, at best '
+                f'{_format_count(self.attainable_flops or 0.0, "FLOP/s")} '
+                f'({efficiency:.1%} of peak)',
+            )
+        return '\n'.join(lines)
+
+
+def _time_best(fn: Any, *args: Any) -> float:
+    """Returns the shortest wall time of `_REPEATS` calls, in seconds, after one warm-up call."""
+    jax.block_until_ready(fn(*args))
+    best = float('inf')
+    for _ in range(_REPEATS):
+        start = time.perf_counter()
+        jax.block_until_ready(fn(*args))
+        best = min(best, time.perf_counter() - start)
+    return best
+
+
+def measure_balance(
+    device: jax.Device | None = None, dtype: DTypeLike = jnp.float32
+) -> DeviceBalance:
+    """Measures a device's peak arithmetic and memory throughput.
+
+    Peak flop/s is measured with a large square matmul ($2n^3$ flops), which has enough data reuse
+    to keep the arithmetic units busy. Peak byte/s is measured by adding two arrays far larger than
+    any cache ($3n$ elements of traffic: two read, one written), which has none. Both take the best
+    of several runs after a warm-up. Results are cached per `(device, dtype)`, so repeated calls
+    are free.
+
+    The dtype matters: single- and double-precision peak rates differ by up to a factor 64 on
+    accelerators. Complex dtypes are measured with their component dtype, and integer dtypes with
+    float32.
+
+    Args:
+        device: The device to measure. Defaults to `jax.devices()[0]`.
+        dtype: The dtype to measure the rates for.
+
+    Returns:
+        The measured [`DeviceBalance`][].
+
+    Warning:
+        This runs actual computations and takes on the order of a second the first time it is
+        called for a given `(device, dtype)`. Pass `measure=False` to
+        [`AbstractLinearOperator.profile`][furax.core.AbstractLinearOperator.profile] to skip it.
+    """
+    if device is None:
+        device = jax.devices()[0]
+    dtype = _real_float_dtype(dtype)
+
+    key = (device, dtype)
+    if (cached := _BALANCE_CACHE.get(key)) is not None:
+        return cached
+
+    with jax.default_device(device):
+        n = _MATMUL_SIZE.get(device.platform, _MATMUL_SIZE_DEFAULT)
+        a = jnp.ones((n, n), dtype)
+        seconds = _time_best(jax.jit(jnp.matmul), a, a)
+        peak_flops = 2 * n**3 / seconds
+
+        # two distinct arrays: passing the same buffer twice would let XLA read it once
+        x = jnp.ones(_BANDWIDTH_SIZE, dtype)
+        y = jnp.zeros(_BANDWIDTH_SIZE, dtype)
+        seconds = _time_best(jax.jit(jnp.add), x, y)
+        peak_bandwidth = 3 * x.nbytes / seconds  # two reads and one write
+
+    balance = DeviceBalance(device.device_kind, dtype, peak_flops, peak_bandwidth)
+    _BALANCE_CACHE[key] = balance
+    return balance
+
+
+def _normalize_cost_analysis(cost: Any) -> tuple[dict[str, float], bool]:
+    """Reduces the backend-dependent shapes of `cost_analysis()` to a single dict.
+
+    Depending on the backend and the jax version this is `None` (unsupported), a dict, or a list
+    holding one dict per computation. Returns the dict and whether one was available at all.
+    """
+    if isinstance(cost, list):
+        cost = cost[0] if cost else None
+    if not isinstance(cost, dict):
+        return {}, False
+    return cost, True
+
+
+def _normalize_memory_analysis(memory: Any) -> tuple[int, int, int, int]:
+    """Extracts `(argument, output, temp, peak)` byte counts, tolerating an absent analysis.
+
+    Like the cost analysis, the memory analysis is optional for a backend to provide.
+    """
+    if memory is None:
+        return 0, 0, 0, 0
+    return (
+        memory.argument_size_in_bytes,
+        memory.output_size_in_bytes,
+        memory.temp_size_in_bytes,
+        memory.peak_memory_in_bytes,
+    )
+
+
+def profile(
+    fn: Any, *args: Any, balance: DeviceBalance | None = None, **kwargs: Any
+) -> ProfileReport:
+    """Compiles a function and reports its static cost.
+
+    The arguments are passed to [`jax.stages.Lowered`][] and may be concrete arrays or
+    [`jax.ShapeDtypeStruct`][] — nothing is executed, so shapes and dtypes are enough.
+
+    Args:
+        fn: The function to compile. Must be jittable.
+        *args: The positional arguments to lower `fn` with.
+        balance: The [`DeviceBalance`][] to evaluate the counts against. Without one, the report
+            still carries flops and bytes but cannot say whether the computation is compute- or
+            memory-bound.
+        **kwargs: The keyword arguments to lower `fn` with.
+
+    Returns:
+        The [`ProfileReport`][] for the compiled executable.
+
+    Important:
+        Anything `fn` closes over becomes an XLA constant rather than a buffer read: its bytes
+        disappear from the count and constant-folding may delete the arithmetic that consumes it
+        outright. Pass every array `fn` depends on as an argument instead. This is why
+        [`AbstractLinearOperator.profile`][furax.core.AbstractLinearOperator.profile] lowers
+        `lambda op, x: op.mv(x)` with the operator as an argument, rather than lowering `op.mv`.
+
+    Examples:
+        >>> import jax.numpy as jnp
+        >>> report = profile(jnp.matmul, jnp.zeros((64, 64)), jnp.zeros((64, 64)))
+        >>> report.flops
+        524288.0
+    """
+    compiled = jax.jit(fn).lower(*args, **kwargs).compile()
+    cost, cost_available = _normalize_cost_analysis(compiled.cost_analysis())
+    argument_bytes, output_bytes, temp_bytes, peak_bytes = _normalize_memory_analysis(
+        compiled.memory_analysis()
+    )
+    return ProfileReport(
+        # a kernel that only moves data has no 'flops' key at all, hence the defaults
+        flops=float(cost.get('flops', 0.0)),
+        transcendentals=float(cost.get('transcendentals', 0.0)),
+        bytes_accessed=float(cost.get('bytes accessed', 0.0)),
+        argument_bytes=argument_bytes,
+        output_bytes=output_bytes,
+        temp_bytes=temp_bytes,
+        peak_bytes=peak_bytes,
+        balance=balance,
+        cost_available=cost_available,
+    )

--- a/src/furax/profiling.py
+++ b/src/furax/profiling.py
@@ -14,6 +14,7 @@ Warning:
 
 import time
 from dataclasses import dataclass
+from enum import StrEnum
 from typing import Any, Literal
 
 import jax
@@ -22,6 +23,7 @@ import numpy as np
 from jax.typing import DTypeLike
 
 __all__ = [
+    'Bound',
     'DeviceBalance',
     'ProfileReport',
     'device_of',
@@ -38,8 +40,6 @@ _MATMUL_SIZE_DEFAULT = 4096
 # float32, far beyond any last-level cache, so the timing reflects main memory and not cache
 _BANDWIDTH_SIZE = 1 << 24
 _REPEATS = 5
-
-_BALANCE_CACHE: dict[tuple[jax.Device, np.dtype[Any]], 'DeviceBalance'] = {}
 
 
 def _format_quantity(n: float, unit: str, *, base: Literal[1000, 1024], sep: str = ' ') -> str:
@@ -82,6 +82,19 @@ def _real_float_dtype(dtype: DTypeLike) -> np.dtype[Any]:
     return result
 
 
+class Bound(StrEnum):
+    """What limits a computation on a device, from [`ProfileReport.bound`][]."""
+
+    MEMORY = 'memory'
+    """The computation waits on data: its arithmetic intensity is below the ridge."""
+
+    COMPUTE = 'compute'
+    """The arithmetic sets the pace: the intensity is above the ridge."""
+
+    AMBIGUOUS = 'ambiguous'
+    """The intensity is within the ridge's measurement error, so the two cannot be told apart."""
+
+
 @dataclass(frozen=True)
 class DeviceBalance:
     """Peak throughputs (flops and bytes per second) of a device, for one dtype.
@@ -105,17 +118,27 @@ class DeviceBalance:
         dtype: The dtype the rates were measured with.
         peak_flops: Measured peak arithmetic throughput, in flop/s.
         peak_bandwidth: Measured peak memory throughput, in byte/s.
+        flops_error: Relative spread of the arithmetic measurement over its repeats.
+        bandwidth_error: Relative spread of the memory measurement over its repeats.
     """
 
     device_kind: str
     dtype: np.dtype[Any]
     peak_flops: float
     peak_bandwidth: float
+    flops_error: float = 0.0
+    bandwidth_error: float = 0.0
 
     @property
     def ridge(self) -> float:
         """The ridge point in flop/byte: [`peak_flops`][] divided by [`peak_bandwidth`][]."""
         return self.peak_flops / self.peak_bandwidth
+
+    @property
+    def ridge_error(self) -> float:
+        """Relative uncertainty on [`ridge`][]."""
+        # a ratio's relative errors add in quadrature
+        return float(np.hypot(self.flops_error, self.bandwidth_error))
 
     def __str__(self) -> str:
         return (
@@ -123,7 +146,7 @@ class DeviceBalance:
             f'peak={_format_count(self.peak_flops, "FLOP/s")} '
             # decimal units for consistency with flop rate
             f'bandwidth={_format_count(self.peak_bandwidth, "B/s")} '
-            f'ridge={self.ridge:.3g} flop/byte'
+            f'ridge={self.ridge:.3g}±{self.ridge_error:.0%} flop/byte'
         )
 
 
@@ -207,14 +230,14 @@ class ProfileReport:
         return attainable / self.balance.peak_flops
 
     @property
-    def is_memory_bound(self) -> bool | None:
-        """Whether the arithmetic intensity is below the machine's ridge point.
-
-        `None` if no `balance` was measured.
-        """
+    def bound(self) -> Bound | None:
+        """What limits this computation on the device, or `None` if no `balance` was measured."""
         if self.balance is None:
             return None
-        return self.arithmetic_intensity < self.balance.ridge
+        ridge = self.balance.ridge
+        if abs(self.arithmetic_intensity - ridge) <= ridge * self.balance.ridge_error:
+            return Bound.AMBIGUOUS
+        return Bound.MEMORY if self.arithmetic_intensity < ridge else Bound.COMPUTE
 
     def __str__(self) -> str:
         header = 'Profile' if self.balance is None else f'Profile on {self.balance}'
@@ -248,24 +271,30 @@ class ProfileReport:
         if self.total_flops == 0:
             # '0.0% of peak' would read as a failure rather than as an absence of arithmetic
             return 'memory (pure data movement, no arithmetic)'
+        if self.bound is Bound.AMBIGUOUS:
+            return f'{Bound.AMBIGUOUS} (intensity within the ridge measurement error)'
         efficiency = self.efficiency
         assert efficiency is not None and self.attainable_flops is not None  # balance is not None
-        bound = 'memory' if self.is_memory_bound else 'compute'
         return (
-            f'{bound}-bound, at best {_format_count(self.attainable_flops, "FLOP/s")} '
+            f'{self.bound}-bound, at best {_format_count(self.attainable_flops, "FLOP/s")} '
             f'({efficiency:.1%} of peak)'
         )
 
 
-def _time_best(fn: Any, *args: Any) -> float:
-    """Returns the shortest wall time of `_REPEATS` calls, in seconds, after one warm-up call."""
+def _peak_rate(work: float, times: list[float]) -> tuple[float, float]:
+    rates = work / np.asarray(times)
+    return float(rates.max()), float(rates.std() / rates.mean())
+
+
+def _time_repeats(fn: Any, *args: Any) -> list[float]:
+    """Returns the wall time of `_REPEATS` calls, in seconds, after one warm-up call."""
     jax.block_until_ready(fn(*args))
-    best = float('inf')
+    times = []
     for _ in range(_REPEATS):
         start = time.perf_counter()
         jax.block_until_ready(fn(*args))
-        best = min(best, time.perf_counter() - start)
-    return best
+        times.append(time.perf_counter() - start)
+    return times
 
 
 def device_of(tree: Any) -> jax.Device | None:
@@ -298,6 +327,9 @@ def measure_balance(
     Peak flop/s is measured with a large square matmul ($2n^3$ flops) to keep the arithmetic units
     busy. Peak byte/s is measured by adding two large arrays together ($3n$ elements of traffic).
 
+    Each rate is the best of several repeats, and their relative spread is recorded alongside it.
+    Expect a few percent on an idle machine and tens of percent on a contended one.
+
     The dtype matters: single- and double-precision peak rates differ by up to a factor 64 on
     accelerators. Complex dtypes are measured with their component dtype, and non-floating dtypes
     with float32.
@@ -313,25 +345,20 @@ def measure_balance(
         device = jax.devices()[0]
     dtype = _real_float_dtype(dtype)
 
-    key = (device, dtype)
-    if (cached := _BALANCE_CACHE.get(key)) is not None:
-        return cached
-
     with jax.default_device(device):
         n = _MATMUL_SIZE.get(device.platform, _MATMUL_SIZE_DEFAULT)
         a = jnp.ones((n, n), dtype)
-        seconds = _time_best(jax.jit(jnp.matmul), a, a)
-        peak_flops = 2 * n**3 / seconds
+        peak_flops, flops_error = _peak_rate(2 * n**3, _time_repeats(jax.jit(jnp.matmul), a, a))
 
         # two distinct arrays: passing the same buffer twice would let XLA read it once
         x = jnp.ones(_BANDWIDTH_SIZE, dtype)
         y = jnp.zeros(_BANDWIDTH_SIZE, dtype)
-        seconds = _time_best(jax.jit(jnp.add), x, y)
-        peak_bandwidth = 3 * x.nbytes / seconds  # two reads and one write
+        traffic = 3 * x.nbytes  # two reads and one write
+        peak_bandwidth, bandwidth_error = _peak_rate(traffic, _time_repeats(jax.jit(jnp.add), x, y))
 
-    balance = DeviceBalance(device.device_kind, dtype, peak_flops, peak_bandwidth)
-    _BALANCE_CACHE[key] = balance
-    return balance
+    return DeviceBalance(
+        device.device_kind, dtype, peak_flops, peak_bandwidth, flops_error, bandwidth_error
+    )
 
 
 def _normalize_cost_analysis(cost: Any) -> tuple[dict[str, float], bool]:

--- a/src/furax/profiling.py
+++ b/src/furax/profiling.py
@@ -41,6 +41,8 @@ _MATMUL_SIZE_DEFAULT = 4096
 _BANDWIDTH_SIZE = 1 << 24
 _REPEATS = 5
 
+TRANSCENDENTAL_FLOPS = 10
+
 
 def _format_quantity(n: float, unit: str, *, base: Literal[1000, 1024], sep: str = ' ') -> str:
     for prefix in ('', 'K', 'M', 'G', 'T'):
@@ -184,14 +186,13 @@ class ProfileReport:
 
     @property
     def total_flops(self) -> float:
-        """[`flops`][] plus [`transcendentals`][], counting each transcendental as one operation.
+        """[`flops`][] plus [`transcendentals`][], counted as 10 flops.
 
-        XLA counts `sin`, `exp` and friends separately from `flops`, so a kernel that is nothing but
-        transcendentals reports `flops == 0`. Charging one operation each keeps it from looking
-        free, and understates it: a transcendental costs several flops. How XLA arrives at either
-        counter is undocumented, so this is a convention, not a conversion.
+        XLA counts `sin`, `exp` and friends separately from `flops`. These functions are more
+        computationally expensive than basic arithmetic, and may use special hardware units.
+        For the sake of simplicity, we count each one as 10 flops.
         """
-        return self.flops + self.transcendentals
+        return self.flops + TRANSCENDENTAL_FLOPS * self.transcendentals
 
     @property
     def arithmetic_intensity(self) -> float:

--- a/src/furax/profiling.py
+++ b/src/furax/profiling.py
@@ -1,15 +1,20 @@
-"""Static cost model for compiled computations.
+"""Static cost estimation for jit-compiled computations.
 
-Reports the flops, memory traffic and buffer sizes of a computation without running it. The
-computation is lowered and compiled ahead of time, and XLA's estimates are read off the resulting
-executable with [`jax.stages.Compiled.cost_analysis`][] (flops, bytes accessed) and
-[`jax.stages.Compiled.memory_analysis`][] (argument / output / temporary buffer sizes). Shapes and
-dtypes are therefore enough: no input needs to be allocated.
+This module provides utilities to estimate the flops, memory traffic and buffer sizes of a
+computation without running it. The computation is lowered and compiled, so we can read off the
+estimates from the resulting executable (see [`jax.stages.Compiled.cost_analysis`][] and
+[`jax.stages.Compiled.memory_analysis`][]).
+
+Warning:
+    Those statistics are estimates computed by the underlying XLA compiler, not measurements from
+    hardware counters. JAX documents it as a debugging tool whose structure "may be inconsistent
+    across versions of JAX and jaxlib, or even across invocations". Read these numbers, and
+    everything derived from them, as indications rather than facts.
 """
 
 import time
 from dataclasses import dataclass
-from typing import Any
+from typing import Any, Literal
 
 import jax
 import jax.numpy as jnp
@@ -37,25 +42,7 @@ _REPEATS = 5
 _BALANCE_CACHE: dict[tuple[jax.Device, np.dtype[Any]], 'DeviceBalance'] = {}
 
 
-def _format_quantity(n: float, unit: str, *, base: int, separator: str = ' ') -> str:
-    """Formats a quantity with the largest prefix that keeps it above one.
-
-    Args:
-        n: The quantity to format.
-        unit: The unit the prefix is applied to, e.g. `'B'` or `'FLOP/s'`.
-        base: `1000` for decimal SI prefixes (`k`, `M`, ...), `1024` for binary ones (`Ki`, `Mi`).
-        separator: What to put between the number and the prefixed unit.
-
-    Returns:
-        The quantity, rounded to two decimals and suffixed with the prefixed unit.
-
-    Examples:
-        >>> _format_quantity(2.1e9, 'FLOP', base=1000)
-        '2.10 GFLOP'
-
-        >>> _format_quantity(1536, 'B', base=1024, separator='')
-        '1.50KiB'
-    """
+def _format_quantity(n: float, unit: str, *, base: Literal[1000, 1024], sep: str = ' ') -> str:
     for prefix in ('', 'K', 'M', 'G', 'T'):
         if n < base:
             break
@@ -64,27 +51,15 @@ def _format_quantity(n: float, unit: str, *, base: int, separator: str = ' ') ->
         prefix = 'P'
     if prefix and base == 1024:
         prefix += 'i'  # KiB, MiB, ... but plain B for the unprefixed case
-    return f'{n:.2f}{separator}{prefix}{unit}'
+    return f'{n:.2f}{sep}{prefix}{unit}'
 
 
 def format_bytes(n: float) -> str:
-    """Formats a byte count with a binary unit suffix.
-
-    Args:
-        n: The number of bytes.
-
-    Returns:
-        The byte count, rounded to two decimals and suffixed with a binary unit.
-
-    Examples:
-        >>> format_bytes(1536)
-        '1.50KiB'
-    """
-    return _format_quantity(n, 'B', base=1024, separator='')
+    # e.g. 1536 -> '150.00KiB'
+    return _format_quantity(n, 'B', base=1024, sep='')
 
 
 def _format_count(n: float, unit: str) -> str:
-    """Formats a count with a decimal SI prefix, e.g. ``_format_count(2.1e9, 'FLOP')``."""
     return _format_quantity(n, unit, base=1000)
 
 
@@ -109,20 +84,21 @@ def _real_float_dtype(dtype: DTypeLike) -> np.dtype[Any]:
 
 @dataclass(frozen=True)
 class DeviceBalance:
-    """Measured peak throughputs of a device, for one dtype.
+    """Peak throughputs (flops and bytes per second) of a device, for one dtype.
 
-    A device performs only so many flops per second and moves only so many bytes per second. Their
-    ratio, [`ridge`][], is how much arithmetic it must be given per byte to keep its arithmetic
-    units fed — typically tens of flops per byte.
+    A device performs only so many flops per second and moves only so many bytes per second.
+    The ratio of these quantities, [`ridge`][], is how much arithmetic it must be given per byte to
+    keep its arithmetic units fed (typically tens of flops per byte).
 
-    Compare it to a computation's [`ProfileReport.arithmetic_intensity`][], the flops it performs
-    per byte it touches. Below the ridge the computation is *memory-bound*: the units idle waiting
-    for data. Above the ridge it is *compute-bound*: the data arrives faster than the units consume
-    it, and the arithmetic sets the pace.
+    The ridge point can be compared to a computation's [`ProfileReport.arithmetic_intensity`][],
+    i.e., the flops it performs per byte it touches.
+
+    - Below the ridge the computation is *memory-bound*: units are mostly idle, waiting for data.
+    - Above the ridge it is *compute-bound*: the data arrives faster than the units can consume it.
 
     A matrix-vector product reads a whole matrix to do only two flops per element, so it is
-    typically memory-bound on all devices; a large matrix-matrix product reuses each element many
-    times, and is compute-bound on most devices.
+    typically memory-bound on all kinds of devices; a large matrix-matrix product reuses each
+    element many times, and is compute-bound on most devices.
 
     Attributes:
         device_kind: The `device_kind` of the [`jax.Device`][], e.g. `'NVIDIA H100 80GB HBM3'`.
@@ -145,9 +121,7 @@ class DeviceBalance:
         return (
             f'{self.device_kind} ({self.dtype.name}) '
             f'peak={_format_count(self.peak_flops, "FLOP/s")} '
-            # decimal units, like the flop rate and like vendor bandwidth figures: a binary
-            # bandwidth here would make `ridge` a decimal-over-binary ratio that cannot be
-            # checked against either
+            # decimal units for consistency with flop rate
             f'bandwidth={_format_count(self.peak_bandwidth, "B/s")} '
             f'ridge={self.ridge:.3g} flop/byte'
         )
@@ -155,17 +129,10 @@ class DeviceBalance:
 
 @dataclass(frozen=True)
 class ProfileReport:
-    """The static cost of one compiled computation.
+    """The estimated cost of one compiled computation.
 
     This is the result of a call to [`profile`][], or [`AbstractLinearOperator.profile`]
     [furax.core.AbstractLinearOperator.profile] for an operator.
-
-    Warning:
-        `flops` and `bytes_accessed` are estimates from XLA's static cost model, not measurements
-        from hardware counters. JAX documents that model as a debugging aid whose structure "may be
-        inconsistent across versions of JAX and jaxlib, or even across invocations", and the
-        individual counters are undocumented XLA internals. Read these numbers, and everything
-        derived from them, as indications rather than facts.
 
     Attributes:
         flops: Floating-point operations, from XLA's cost model. Excludes `transcendentals`.
@@ -217,8 +184,8 @@ class ProfileReport:
     def attainable_flops(self) -> float | None:
         """The fastest this computation could run on the device, in flop/s.
 
-        Two ceilings apply and the lower one wins: the device's [`DeviceBalance.peak_flops`][], and
-        what its bandwidth can sustain at this computation's [`arithmetic_intensity`][], which is
+        This is the minimum of the device's [`DeviceBalance.peak_flops`][] and what its bandwidth
+        can sustain at this computation's [`arithmetic_intensity`][], namely
         `arithmetic_intensity * peak_bandwidth`. A compute-bound computation is capped by the
         first, a memory-bound one by the second. `None` if `balance` is `None`.
         """
@@ -230,7 +197,7 @@ class ProfileReport:
     def efficiency(self) -> float | None:
         """The attainable throughput as a fraction of peak, in `[0, 1]`.
 
-        A memory-bound computation has a low efficiency *by construction*: it is the fraction of
+        A memory-bound computation has a low efficiency *by definition*: it is the fraction of
         the machine's arithmetic units the computation can possibly keep busy, not a measurement of
         how well it is implemented. `None` if no `balance` was measured.
         """
@@ -328,35 +295,19 @@ def measure_balance(
 ) -> DeviceBalance:
     """Measures a device's peak arithmetic and memory throughput.
 
-    Peak flop/s is measured with a large square matmul ($2n^3$ flops), which has enough data reuse
-    to keep the arithmetic units busy. Peak byte/s is measured by adding two arrays far larger than
-    any cache ($3n$ elements of traffic: two read, one written), which has none. Both take the best
-    of several runs after a warm-up. Results are cached per `(device, dtype)`, so repeated calls
-    are free.
+    Peak flop/s is measured with a large square matmul ($2n^3$ flops) to keep the arithmetic units
+    busy. Peak byte/s is measured by adding two large arrays together ($3n$ elements of traffic).
 
     The dtype matters: single- and double-precision peak rates differ by up to a factor 64 on
     accelerators. Complex dtypes are measured with their component dtype, and non-floating dtypes
     with float32.
 
     Args:
-        device: The device to measure. Defaults to `jax.devices()[0]`, which is where JAX places
-            uncommitted arrays. Pass the device the profiled computation actually runs on when it
-            differs — comparing counts from one device against rates from another says nothing.
-            [`device_of`][] derives it from an operator or a pytree.
+        device: The device to measure. Defaults to `jax.devices()[0]`.
         dtype: The dtype to measure the rates for.
 
     Returns:
         The measured [`DeviceBalance`][].
-
-    Warning:
-        This runs actual computations and takes on the order of a second the first time it is
-        called for a given `(device, dtype)`. That is why
-        [`AbstractLinearOperator.profile`][furax.core.AbstractLinearOperator.profile] does not call
-        it unless asked with `measure=True`.
-
-        The rates describe one device. Under a mesh the microbenchmark arrays follow the mesh
-        rather than the single device named here, so the result does not describe sharded
-        execution.
     """
     if device is None:
         device = jax.devices()[0]
@@ -433,9 +384,7 @@ def profile(
     Important:
         Anything `fn` closes over becomes an XLA constant rather than a buffer read: its bytes
         disappear from the count and constant-folding may delete the arithmetic that consumes it
-        outright. Pass every array `fn` depends on as an argument instead. This is why
-        [`AbstractLinearOperator.profile`][furax.core.AbstractLinearOperator.profile] lowers
-        `lambda op, x: op.mv(x)` with the operator as an argument, rather than lowering `op.mv`.
+        outright. Pass every array `fn` depends on as an argument instead.
 
     Examples:
         >>> import jax.numpy as jnp

--- a/src/furax/profiling.py
+++ b/src/furax/profiling.py
@@ -350,8 +350,9 @@ def measure_balance(
 
     Warning:
         This runs actual computations and takes on the order of a second the first time it is
-        called for a given `(device, dtype)`. Pass `measure=False` to
-        [`AbstractLinearOperator.profile`][furax.core.AbstractLinearOperator.profile] to skip it.
+        called for a given `(device, dtype)`. That is why
+        [`AbstractLinearOperator.profile`][furax.core.AbstractLinearOperator.profile] does not call
+        it unless asked with `measure=True`.
 
         The rates describe one device. Under a mesh the microbenchmark arrays follow the mesh
         rather than the single device named here, so the result does not describe sharded

--- a/tests/test_profiling.py
+++ b/tests/test_profiling.py
@@ -9,7 +9,6 @@ from jax.typing import DTypeLike
 from furax import DiagonalOperator, IdentityOperator
 from furax.obs.stokes import StokesIQU
 from furax.profiling import (
-    _TRANSCENDENTAL_FLOPS,
     Bound,
     DeviceBalance,
     ProfileReport,
@@ -156,13 +155,12 @@ def test_transcendentals_count_as_arithmetic(balance: DeviceBalance) -> None:
     # XLA reports `exp`/`sin` under `transcendentals`, not `flops`; ignoring them would call a
     # kernel that is nothing but arithmetic "pure data movement"
     report = ProfileReport(5.0, 2.0, 10.0, 0, 0, 0, 0, balance=balance)
-    assert report.transcendental_flops == 2 * _TRANSCENDENTAL_FLOPS
-    assert report.total_flops == 5.0 + 2 * _TRANSCENDENTAL_FLOPS
-    assert report.arithmetic_intensity == report.total_flops / 10.0
+    assert report.transcendental_flops == 2 * ProfileReport._TRANSCENDENTAL_FLOPS
+    assert report.total_flops == 5.0 + 2 * ProfileReport._TRANSCENDENTAL_FLOPS
     assert 'pure data movement' not in str(report)
     assert 'memory-bound' in str(report)
     # the weighted contribution is broken out, so a reader can discount the arbitrary weight
-    assert f'2 ops, 20.00 FLOP (x{_TRANSCENDENTAL_FLOPS} weight)' in str(report)
+    assert f'2 ops, 20.00 FLOP (x{ProfileReport._TRANSCENDENTAL_FLOPS} weight)' in str(report)
 
 
 def test_an_unavailable_cost_analysis_yields_no_verdict(balance: DeviceBalance) -> None:

--- a/tests/test_profiling.py
+++ b/tests/test_profiling.py
@@ -9,9 +9,11 @@ from jax.typing import DTypeLike
 from furax import DiagonalOperator, IdentityOperator
 from furax.obs.stokes import StokesIQU
 from furax.profiling import (
+    Bound,
     DeviceBalance,
     ProfileReport,
     _normalize_cost_analysis,
+    _peak_rate,
     _real_float_dtype,
     device_of,
     format_bytes,
@@ -98,13 +100,43 @@ def balance() -> DeviceBalance:
 
 def test_ridge_point(balance: DeviceBalance) -> None:
     assert balance.ridge == 10.0
+    assert balance.ridge_error == 0.0  # a hand-built balance carries no measurement spread
     assert 'test-device' in str(balance)
+
+
+def test_ridge_error_combines_both_measurements() -> None:
+    # relative errors of a ratio add in quadrature
+    noisy = DeviceBalance('test-device', np.dtype(_F32), 1000.0, 100.0, 0.03, 0.04)
+    assert noisy.ridge_error == pytest.approx(0.05)
+    assert '±5%' in str(noisy)
+
+
+@pytest.mark.parametrize(
+    'intensity, expected',
+    [
+        pytest.param(1.0, Bound.MEMORY, id='far-below'),
+        pytest.param(9.5, Bound.AMBIGUOUS, id='just-below'),
+        pytest.param(10.0, Bound.AMBIGUOUS, id='on-the-ridge'),
+        pytest.param(10.5, Bound.AMBIGUOUS, id='just-above'),
+        pytest.param(100.0, Bound.COMPUTE, id='far-above'),
+    ],
+)
+def test_a_verdict_within_the_measurement_error_is_ambiguous(
+    intensity: float, expected: Bound
+) -> None:
+    # ridge 10 flop/byte, measured to +-10%: nothing in [9, 11] can be called either way
+    noisy = DeviceBalance('test-device', np.dtype(_F32), 1000.0, 100.0, 0.1, 0.0)
+    report = _report(intensity * 10.0, 10.0, noisy)
+    assert report.bound is expected
+    if expected is Bound.AMBIGUOUS:
+        assert 'ambiguous' in str(report)
+        assert 'of peak' not in str(report)  # no verdict means no efficiency claim
 
 
 def test_roofline_below_the_ridge(balance: DeviceBalance) -> None:
     report = _report(10.0, 10.0, balance)  # intensity 1 flop/byte
     assert report.arithmetic_intensity == 1.0
-    assert report.is_memory_bound
+    assert report.bound is Bound.MEMORY
     assert report.attainable_flops == 100.0  # bandwidth-limited: 1 flop/byte x 100 byte/s
     assert report.efficiency == 0.1
     assert 'memory-bound' in str(report)
@@ -114,7 +146,7 @@ def test_a_computation_without_arithmetic_is_not_reported_as_inefficient(
     balance: DeviceBalance,
 ) -> None:
     report = _report(0.0, 10.0, balance)
-    assert report.is_memory_bound
+    assert report.bound is Bound.MEMORY
     assert 'pure data movement' in str(report)
     assert '0.0% of peak' not in str(report)
 
@@ -141,7 +173,7 @@ def test_an_unavailable_cost_analysis_yields_no_verdict(balance: DeviceBalance) 
 def test_roofline_above_the_ridge(balance: DeviceBalance) -> None:
     report = _report(1000.0, 10.0, balance)  # intensity 100 flop/byte
     assert report.arithmetic_intensity == 100.0
-    assert not report.is_memory_bound
+    assert report.bound is Bound.COMPUTE
     assert report.attainable_flops == 1000.0  # clamped at peak, not 100 x 100
     assert report.efficiency == 1.0
     assert 'compute-bound' in str(report)
@@ -222,10 +254,20 @@ def test_real_float_dtype_downgrades_float64_without_x64() -> None:
     assert _real_float_dtype(np.complex128) == np.dtype(np.float32)
 
 
+def test_peak_rate_takes_the_best_and_reports_the_spread() -> None:
+    # the peak comes from the fastest repeat; the spread says how quiet the machine was
+    peak, error = _peak_rate(100.0, [1.0, 2.0])  # rates 100 and 50
+    assert peak == 100.0
+    assert error == pytest.approx(np.std([100.0, 50.0]) / 75.0)
+
+    peak, error = _peak_rate(100.0, [2.0, 2.0])
+    assert (peak, error) == (50.0, 0.0)
+
+
 @pytest.mark.slow
-def test_measure_balance_is_positive_and_cached() -> None:
+def test_measure_balance_is_positive() -> None:
     balance = measure_balance(dtype=_F32)
     assert balance.peak_flops > 0
     assert balance.peak_bandwidth > 0
     assert balance.ridge > 0
-    assert measure_balance(dtype=_F32) is balance  # cached, not re-measured
+    assert 0.0 <= balance.ridge_error < 1.0

--- a/tests/test_profiling.py
+++ b/tests/test_profiling.py
@@ -10,6 +10,7 @@ from furax.profiling import (
     ProfileReport,
     _normalize_cost_analysis,
     _real_float_dtype,
+    device_of,
     format_bytes,
     measure_balance,
 )
@@ -197,10 +198,27 @@ def test_format_bytes(n: int, expected: str) -> None:
         (np.complex64, np.float32),  # measured with the component dtype
         (np.complex128, np.float64),
         (np.int32, np.float32),  # the microbenchmarks measure floating-point throughput
+        # ml_dtypes extension types
+        (jnp.bfloat16, jnp.bfloat16),
+        (jnp.float16, jnp.float16),
     ],
 )
 def test_real_float_dtype(dtype: type, expected: type) -> None:
     assert _real_float_dtype(dtype) == np.dtype(expected)
+
+
+def test_device_of_ignores_uncommitted_arrays() -> None:
+    # an uncommitted array can be moved by JAX at will, so it names no device
+    op = _diagonal_operator(16)
+    assert device_of(op) is None
+    assert device_of(jnp.ones(4)) is None
+
+
+def test_device_of_finds_a_committed_device() -> None:
+    device = jax.devices()[0]
+    committed = jax.device_put(jnp.ones(16, _F32), device)
+    op = DiagonalOperator(committed, in_structure=jax.ShapeDtypeStruct((16,), _F32))
+    assert device_of(op) is device
 
 
 # the mapmaking pipeline runs with x64 disabled when `double_precision=False`, where a float64

--- a/tests/test_profiling.py
+++ b/tests/test_profiling.py
@@ -126,6 +126,25 @@ def test_a_computation_without_arithmetic_is_not_reported_as_inefficient(
     assert '0.0% of peak' not in str(report)
 
 
+def test_transcendentals_count_as_arithmetic(balance: DeviceBalance) -> None:
+    # XLA reports `exp`/`sin` under `transcendentals`, not `flops`; ignoring them would call a
+    # kernel that is nothing but arithmetic "pure data movement"
+    report = ProfileReport(0.0, 20.0, 10.0, 0, 0, 0, 0, balance=balance)
+    assert report.total_flops == 20.0
+    assert report.arithmetic_intensity == 2.0
+    assert 'pure data movement' not in str(report)
+    assert 'memory-bound' in str(report)
+
+
+def test_an_unavailable_cost_analysis_yields_no_verdict(balance: DeviceBalance) -> None:
+    # a balance must not turn absent counts into a confident bound
+    report = ProfileReport(0.0, 0.0, 0.0, 0, 0, 0, 0, balance=balance, cost_available=False)
+    rendered = str(report)
+    assert rendered.count('unavailable') == 3  # flops, intensity, bound
+    assert 'memory-bound' not in rendered
+    assert '% of peak' not in rendered
+
+
 def test_roofline_above_the_ridge(balance: DeviceBalance) -> None:
     report = _report(1000.0, 10.0, balance)  # intensity 100 flop/byte
     assert report.arithmetic_intensity == 100.0

--- a/tests/test_profiling.py
+++ b/tests/test_profiling.py
@@ -9,7 +9,7 @@ from jax.typing import DTypeLike
 from furax import DiagonalOperator, IdentityOperator
 from furax.obs.stokes import StokesIQU
 from furax.profiling import (
-    TRANSCENDENTAL_FLOPS,
+    _TRANSCENDENTAL_FLOPS,
     Bound,
     DeviceBalance,
     ProfileReport,
@@ -156,17 +156,23 @@ def test_transcendentals_count_as_arithmetic(balance: DeviceBalance) -> None:
     # XLA reports `exp`/`sin` under `transcendentals`, not `flops`; ignoring them would call a
     # kernel that is nothing but arithmetic "pure data movement"
     report = ProfileReport(5.0, 2.0, 10.0, 0, 0, 0, 0, balance=balance)
-    assert report.total_flops == 5.0 + 2 * TRANSCENDENTAL_FLOPS
+    assert report.transcendental_flops == 2 * _TRANSCENDENTAL_FLOPS
+    assert report.total_flops == 5.0 + 2 * _TRANSCENDENTAL_FLOPS
     assert report.arithmetic_intensity == report.total_flops / 10.0
     assert 'pure data movement' not in str(report)
     assert 'memory-bound' in str(report)
+    # the weighted contribution is broken out, so a reader can discount the arbitrary weight
+    assert f'2 ops, 20.00 FLOP (x{_TRANSCENDENTAL_FLOPS} weight)' in str(report)
 
 
 def test_an_unavailable_cost_analysis_yields_no_verdict(balance: DeviceBalance) -> None:
     # a balance must not turn absent counts into a confident bound
     report = ProfileReport(0.0, 0.0, 0.0, 0, 0, 0, 0, balance=balance, cost_available=False)
+    # zeroed counts sit below any ridge, so a naive verdict would confidently say 'memory'
+    assert report.bound is None
     rendered = str(report)
-    assert rendered.count('unavailable') == 3  # flops, intensity, bound
+    # flops, transcendental, total, intensity, bound
+    assert rendered.count('unavailable') == 5
     assert 'memory-bound' not in rendered
     assert '% of peak' not in rendered
 

--- a/tests/test_profiling.py
+++ b/tests/test_profiling.py
@@ -26,7 +26,7 @@ def _diagonal_operator(n: int, dtype: type = _F32) -> DiagonalOperator:
 
 @pytest.mark.parametrize('n', [16, 1024])
 def test_diagonal_counts_are_exact(n: int) -> None:
-    report = _diagonal_operator(n).profile(measure=False)
+    report = _diagonal_operator(n).profile()
     assert report.flops == n  # one multiply per element
     assert report.bytes_accessed == 3 * n * 4  # input, diagonal, output
     assert report.transcendentals == 0
@@ -42,7 +42,7 @@ def test_operator_arrays_are_counted_as_traffic() -> None:
     """
     n = 1024
     op = _diagonal_operator(n)
-    report = op.profile(measure=False)
+    report = op.profile()
 
     passthrough_bytes = nbytes(op.in_structure) + nbytes(op.out_structure)
     assert report.bytes_accessed > passthrough_bytes
@@ -52,9 +52,7 @@ def test_operator_arrays_are_counted_as_traffic() -> None:
 
 def test_identity_reports_zero_flops() -> None:
     # a kernel that only moves data has no 'flops' key in the cost analysis at all
-    report = IdentityOperator(in_structure=jax.ShapeDtypeStruct((256,), _F32)).profile(
-        measure=False
-    )
+    report = IdentityOperator(in_structure=jax.ShapeDtypeStruct((256,), _F32)).profile()
     assert report.cost_available
     assert report.flops == 0.0
     assert report.bytes_accessed > 0
@@ -75,7 +73,7 @@ def test_identity_reports_zero_flops() -> None:
     ],
 )
 def test_pytree_structures_need_no_special_casing(structure: object) -> None:
-    report = IdentityOperator(in_structure=structure).profile(measure=False)
+    report = IdentityOperator(in_structure=structure).profile()
     assert report.bytes_accessed > 0
     assert str(report)
 

--- a/tests/test_profiling.py
+++ b/tests/test_profiling.py
@@ -1,7 +1,10 @@
+from typing import Any
+
 import jax
 import jax.numpy as jnp
 import numpy as np
 import pytest
+from jax.typing import DTypeLike
 
 from furax import DiagonalOperator, IdentityOperator
 from furax.obs.stokes import StokesIQU
@@ -19,9 +22,9 @@ from furax.tree import nbytes
 _F32 = jnp.float32
 
 
-def _diagonal_operator(n: int, dtype: type = _F32) -> DiagonalOperator:
-    structure = jax.ShapeDtypeStruct((n,), dtype)
-    return DiagonalOperator(jnp.ones(n, dtype), in_structure=structure)
+def _diagonal_operator(n: int, dtype: DTypeLike = _F32) -> DiagonalOperator:
+    ones = jnp.ones(n, dtype)
+    return DiagonalOperator(ones, in_structure=jax.ShapeDtypeStruct.like(ones))
 
 
 @pytest.mark.parametrize('n', [16, 1024])
@@ -72,19 +75,10 @@ def test_identity_reports_zero_flops() -> None:
         pytest.param(StokesIQU.structure_for((8,), _F32), id='StokesIQU'),
     ],
 )
-def test_pytree_structures_need_no_special_casing(structure: object) -> None:
+def test_pytree_structures_need_no_special_casing(structure: Any) -> None:
     report = IdentityOperator(in_structure=structure).profile()
     assert report.bytes_accessed > 0
     assert str(report)
-
-
-def test_report_without_balance_leaves_the_bound_unknown() -> None:
-    report = _diagonal_operator(64).profile(measure=False)
-    assert report.balance is None
-    assert report.is_memory_bound is None
-    assert report.attainable_flops is None
-    assert report.efficiency is None
-    assert 'unknown' in str(report)
 
 
 def test_arithmetic_intensity_of_an_empty_computation() -> None:
@@ -99,7 +93,7 @@ def _report(flops: float, bytes_accessed: float, balance: DeviceBalance) -> Prof
 @pytest.fixture
 def balance() -> DeviceBalance:
     # ridge = 1000 / 100 = 10 flop/byte
-    return DeviceBalance('test-device', np.dtype(np.float32), 1000.0, 100.0)
+    return DeviceBalance('test-device', np.dtype(_F32), 1000.0, 100.0)
 
 
 def test_ridge_point(balance: DeviceBalance) -> None:
@@ -162,7 +156,7 @@ def test_roofline_above_the_ridge(balance: DeviceBalance) -> None:
         pytest.param([], {}, False, id='empty-list'),
     ],
 )
-def test_normalize_cost_analysis(cost: object, expected: dict[str, float], available: bool) -> None:
+def test_normalize_cost_analysis(cost, expected: dict[str, float], available: bool) -> None:
     # the shape of `cost_analysis()` varies with the backend and the jax version
     assert _normalize_cost_analysis(cost) == (expected, available)
 
@@ -201,7 +195,7 @@ def test_format_bytes(n: int, expected: str) -> None:
         (jnp.float16, jnp.float16),
     ],
 )
-def test_real_float_dtype(dtype: type, expected: type) -> None:
+def test_real_float_dtype(dtype: DTypeLike, expected: DTypeLike) -> None:
     assert _real_float_dtype(dtype) == np.dtype(expected)
 
 

--- a/tests/test_profiling.py
+++ b/tests/test_profiling.py
@@ -9,6 +9,7 @@ from jax.typing import DTypeLike
 from furax import DiagonalOperator, IdentityOperator
 from furax.obs.stokes import StokesIQU
 from furax.profiling import (
+    TRANSCENDENTAL_FLOPS,
     Bound,
     DeviceBalance,
     ProfileReport,
@@ -154,9 +155,9 @@ def test_a_computation_without_arithmetic_is_not_reported_as_inefficient(
 def test_transcendentals_count_as_arithmetic(balance: DeviceBalance) -> None:
     # XLA reports `exp`/`sin` under `transcendentals`, not `flops`; ignoring them would call a
     # kernel that is nothing but arithmetic "pure data movement"
-    report = ProfileReport(0.0, 20.0, 10.0, 0, 0, 0, 0, balance=balance)
-    assert report.total_flops == 20.0
-    assert report.arithmetic_intensity == 2.0
+    report = ProfileReport(5.0, 2.0, 10.0, 0, 0, 0, 0, balance=balance)
+    assert report.total_flops == 5.0 + 2 * TRANSCENDENTAL_FLOPS
+    assert report.arithmetic_intensity == report.total_flops / 10.0
     assert 'pure data movement' not in str(report)
     assert 'memory-bound' in str(report)
 

--- a/tests/test_profiling.py
+++ b/tests/test_profiling.py
@@ -1,0 +1,202 @@
+import jax
+import jax.numpy as jnp
+import numpy as np
+import pytest
+
+from furax import DiagonalOperator, IdentityOperator
+from furax.obs.stokes import StokesIQU
+from furax.profiling import (
+    DeviceBalance,
+    ProfileReport,
+    _normalize_cost_analysis,
+    _real_float_dtype,
+    format_bytes,
+    measure_balance,
+)
+from furax.tree import nbytes
+
+_F32 = jnp.float32
+
+
+def _diagonal_operator(n: int, dtype: type = _F32) -> DiagonalOperator:
+    structure = jax.ShapeDtypeStruct((n,), dtype)
+    return DiagonalOperator(jnp.ones(n, dtype), in_structure=structure)
+
+
+@pytest.mark.parametrize('n', [16, 1024])
+def test_diagonal_counts_are_exact(n: int) -> None:
+    report = _diagonal_operator(n).profile(measure=False)
+    assert report.flops == n  # one multiply per element
+    assert report.bytes_accessed == 3 * n * 4  # input, diagonal, output
+    assert report.transcendentals == 0
+    assert report.cost_available
+
+
+def test_operator_arrays_are_counted_as_traffic() -> None:
+    """The operator's own arrays must be traced arguments, not closed-over XLA constants.
+
+    Lowering `op.mv` instead of `lambda op, x: op.mv(x)` drops the diagonal from the byte count and
+    lets constant-folding delete the multiply outright, which silently halves every intensity this
+    module reports.
+    """
+    n = 1024
+    op = _diagonal_operator(n)
+    report = op.profile(measure=False)
+
+    passthrough_bytes = nbytes(op.in_structure) + nbytes(op.out_structure)
+    assert report.bytes_accessed > passthrough_bytes
+    assert report.bytes_accessed == passthrough_bytes + nbytes(op.diagonal)
+    assert report.argument_bytes > nbytes(op.in_structure)
+
+
+def test_identity_reports_zero_flops() -> None:
+    # a kernel that only moves data has no 'flops' key in the cost analysis at all
+    report = IdentityOperator(in_structure=jax.ShapeDtypeStruct((256,), _F32)).profile(
+        measure=False
+    )
+    assert report.cost_available
+    assert report.flops == 0.0
+    assert report.bytes_accessed > 0
+    assert report.arithmetic_intensity == 0.0
+
+
+@pytest.mark.parametrize(
+    'structure',
+    [
+        pytest.param(
+            {'a': jax.ShapeDtypeStruct((4,), _F32), 'b': jax.ShapeDtypeStruct((2, 3), _F32)},
+            id='dict',
+        ),
+        pytest.param(
+            [jax.ShapeDtypeStruct((4,), _F32), jax.ShapeDtypeStruct((5,), _F32)], id='list'
+        ),
+        pytest.param(StokesIQU.structure_for((8,), _F32), id='StokesIQU'),
+    ],
+)
+def test_pytree_structures_need_no_special_casing(structure: object) -> None:
+    report = IdentityOperator(in_structure=structure).profile(measure=False)
+    assert report.bytes_accessed > 0
+    assert str(report)
+
+
+def test_report_without_balance_leaves_the_bound_unknown() -> None:
+    report = _diagonal_operator(64).profile(measure=False)
+    assert report.balance is None
+    assert report.is_memory_bound is None
+    assert report.attainable_flops is None
+    assert report.efficiency is None
+    assert 'unknown' in str(report)
+
+
+def test_arithmetic_intensity_of_an_empty_computation() -> None:
+    report = ProfileReport(0.0, 0.0, 0.0, 0, 0, 0, 0)
+    assert report.arithmetic_intensity == 0.0
+
+
+def _report(flops: float, bytes_accessed: float, balance: DeviceBalance) -> ProfileReport:
+    return ProfileReport(flops, 0.0, bytes_accessed, 0, 0, 0, 0, balance=balance)
+
+
+@pytest.fixture
+def balance() -> DeviceBalance:
+    # ridge = 1000 / 100 = 10 flop/byte
+    return DeviceBalance('test-device', np.dtype(np.float32), 1000.0, 100.0)
+
+
+def test_ridge_point(balance: DeviceBalance) -> None:
+    assert balance.ridge == 10.0
+    assert 'test-device' in str(balance)
+
+
+def test_roofline_below_the_ridge(balance: DeviceBalance) -> None:
+    report = _report(10.0, 10.0, balance)  # intensity 1 flop/byte
+    assert report.arithmetic_intensity == 1.0
+    assert report.is_memory_bound
+    assert report.attainable_flops == 100.0  # bandwidth-limited: 1 flop/byte x 100 byte/s
+    assert report.efficiency == 0.1
+    assert 'memory-bound' in str(report)
+
+
+def test_a_computation_without_arithmetic_is_not_reported_as_inefficient(
+    balance: DeviceBalance,
+) -> None:
+    report = _report(0.0, 10.0, balance)
+    assert report.is_memory_bound
+    assert 'pure data movement' in str(report)
+    assert '0.0% of peak' not in str(report)
+
+
+def test_roofline_above_the_ridge(balance: DeviceBalance) -> None:
+    report = _report(1000.0, 10.0, balance)  # intensity 100 flop/byte
+    assert report.arithmetic_intensity == 100.0
+    assert not report.is_memory_bound
+    assert report.attainable_flops == 1000.0  # clamped at peak, not 100 x 100
+    assert report.efficiency == 1.0
+    assert 'compute-bound' in str(report)
+
+
+@pytest.mark.parametrize(
+    'cost, expected, available',
+    [
+        pytest.param({'flops': 2.0}, {'flops': 2.0}, True, id='dict'),
+        pytest.param([{'flops': 2.0}, {'flops': 8.0}], {'flops': 2.0}, True, id='list'),
+        pytest.param(None, {}, False, id='unsupported-backend'),
+        pytest.param([], {}, False, id='empty-list'),
+    ],
+)
+def test_normalize_cost_analysis(cost: object, expected: dict[str, float], available: bool) -> None:
+    # the shape of `cost_analysis()` varies with the backend and the jax version
+    assert _normalize_cost_analysis(cost) == (expected, available)
+
+
+def test_unavailable_cost_analysis_is_flagged() -> None:
+    # zeros from a backend that declines to report must not read as a free computation
+    report = ProfileReport(0.0, 0.0, 0.0, 0, 0, 0, 0, cost_available=False)
+    assert 'unavailable' in str(report)
+
+
+@pytest.mark.parametrize(
+    'n, expected',
+    [
+        (0, '0.00B'),
+        (512, '512.00B'),
+        (1536, '1.50KiB'),
+        (1024**2, '1.00MiB'),
+        (3 * 1024**3, '3.00GiB'),
+        (1024**5, '1.00PiB'),
+    ],
+)
+def test_format_bytes(n: int, expected: str) -> None:
+    assert format_bytes(n) == expected
+
+
+@pytest.mark.parametrize(
+    'dtype, expected',
+    [
+        (np.float32, np.float32),
+        (np.float64, np.float64),  # the test session enables x64
+        (np.complex64, np.float32),  # measured with the component dtype
+        (np.complex128, np.float64),
+        (np.int32, np.float32),  # the microbenchmarks measure floating-point throughput
+    ],
+)
+def test_real_float_dtype(dtype: type, expected: type) -> None:
+    assert _real_float_dtype(dtype) == np.dtype(expected)
+
+
+# the mapmaking pipeline runs with x64 disabled when `double_precision=False`, where a float64
+# array cannot be allocated at all; the autouse fixture forces x64 on, hence the subprocess
+@pytest.mark.insubprocess
+def test_real_float_dtype_downgrades_float64_without_x64() -> None:
+    jax.config.update('jax_enable_x64', False)
+    assert _real_float_dtype(np.float64) == np.dtype(np.float32)
+    assert _real_float_dtype(np.complex128) == np.dtype(np.float32)
+
+
+@pytest.mark.slow
+def test_measure_balance_is_positive_and_cached() -> None:
+    balance = measure_balance(dtype=_F32)
+    assert balance.peak_flops > 0
+    assert balance.peak_bandwidth > 0
+    assert balance.ridge > 0
+    assert measure_balance(dtype=_F32) is balance  # cached, not re-measured

--- a/zensical.toml
+++ b/zensical.toml
@@ -51,6 +51,7 @@ nav = [
           "api/io.md",
           "api/interfaces.md",
           "api/tree.md",
+          "api/profiling.md",
           "api/distributed.md",
           "api/exceptions.md",
       ] },


### PR DESCRIPTION
## Summary

Add `op.profile()` and the `furax.profiling` module.

Changes:

- `furax.profiling` module relying on XLA statistics
  - `profile` to get statistics forf any jittable callable
  - `measure_balance` to estimate a device's peak throughputs (flops and bytes per second)
  - `ProfileReport` / `DeviceBalance` / `Bound` for results
- `AbstractLinearOperator.profile()` reports flops, transcendentals, memory traffic and buffer sizes for one `mv` call
  - The operator is lowered as a traced argument, not captured, so its arrays are not folded into XLA constants
  - `op.profile(measure=True)` performs peak flop/s and byte/s microbenchmarks so the report can make a memory- vs compute-bound diagnostic

## Checklist

- [x] Tests added/updated for new or changed behavior
- [x] `uvx prek run -a` passes (ruff, mypy, etc.)
- [x] Added a changelog entry under `[Unreleased]` in `docs/development/changelog.md`, or this PR doesn't need one (e.g. internal refactor, CI-only change)
- [x] Updated docs for user-facing changes (docstrings, `docs/`)
