### PR TITLE
Assign observations to processes by balanced cost

### DIFF
--- a/docs/api/mapmaking/observation.md
+++ b/docs/api/mapmaking/observation.md
@@ -8,7 +8,7 @@ Observation data model and reader.
 ::: furax.mapmaking.AbstractSatelliteObservation
 ::: furax.mapmaking.FileBackedLazyObservation
 ::: furax.mapmaking.HashedObservationMetadata
-::: furax.mapmaking.ObservationBufferShapes
+::: furax.mapmaking.ObservationBufferShape
 ::: furax.mapmaking.ReaderField
 ::: furax.mapmaking.ObservationReader
 ::: furax.mapmaking.logger

--- a/src/furax/interfaces/sotodlib/observation.py
+++ b/src/furax/interfaces/sotodlib/observation.py
@@ -24,7 +24,7 @@ from furax.mapmaking import (
     AbstractGroundObservation,
     AbstractLazyObservation,
     FileBackedLazyObservation,
-    ObservationBufferShapes,
+    ObservationBufferShape,
     ReaderField,
 )
 from furax.mapmaking.config import SotodlibConfig
@@ -568,7 +568,7 @@ class LazyPreprocSOTODLibObservation(AbstractLazyObservation[AxisManager]):
             sotodlib_config=self._sotodlib_config,
         )
 
-    def probe_shape(self, intervals: bool = False) -> ObservationBufferShapes:
+    def probe_shape(self, intervals: bool = False) -> ObservationBufferShape:
         """Returns an upper bound on the variable padded-buffer dimensions for ``fields``.
 
         All values are read from the init preprocess metadata: no heavy I/O work is done.
@@ -586,7 +586,7 @@ class LazyPreprocSOTODLibObservation(AbstractLazyObservation[AxisManager]):
         _, context = pu.get_preprocess_context(self.init_config.as_posix())
         meta = context.get_meta(self.observation_id, dets=self.detector_selection)
         n_samps_ub = -(-meta.samps.count // self.downsample)  # ceil, matches downsample_obs
-        return ObservationBufferShapes(
+        return ObservationBufferShape(
             meta.dets.count,
             n_samps_ub,
             meta.subscans.count if intervals else 0,

--- a/src/furax/mapmaking/__init__.py
+++ b/src/furax/mapmaking/__init__.py
@@ -6,7 +6,7 @@ from ._observation import (
     AbstractSatelliteObservation,
     FileBackedLazyObservation,
     HashedObservationMetadata,
-    ObservationBufferShapes,
+    ObservationBufferShape,
     ReaderField,
 )
 from ._reader import ObservationReader
@@ -30,6 +30,6 @@ __all__ = [
     'MapMakingConfig',
     'MapMakingResults',
     'MultiObservationMapMaker',
-    'ObservationBufferShapes',
+    'ObservationBufferShape',
     'logger',
 ]

--- a/src/furax/mapmaking/_observation.py
+++ b/src/furax/mapmaking/_observation.py
@@ -397,10 +397,26 @@ class AbstractGroundObservation[T](AbstractObservation[T]):
         return alpha, delta
 
 
-class ObservationBufferShapes(NamedTuple):
+class ObservationBufferShape(NamedTuple):
+    """Sizes of the buffers one observation is read into.
+
+    Attributes:
+        detector_count: Number of detectors.
+        sample_count: Number of time samples per detector.
+        interval_count: Number of scanning intervals; 0 when they were not requested.
+    """
+
     detector_count: int
     sample_count: int
     interval_count: int = 0
+
+    @property
+    def volume(self) -> int:
+        """Number of time-ordered elements, ``detector_count * sample_count``.
+
+        Scanning intervals are metadata rather than samples, so the interval axis does not count.
+        """
+        return self.detector_count * self.sample_count
 
 
 class AbstractLazyObservation[T](ABC):
@@ -428,7 +444,7 @@ class AbstractLazyObservation[T](ABC):
         """Human-readable identifier, used e.g. to report observations that failed to load."""
         return type(self).__name__
 
-    def probe_shape(self, intervals: bool = False) -> ObservationBufferShapes:
+    def probe_shape(self, intervals: bool = False) -> ObservationBufferShape:
         """Returns the buffer dimensions for this observation.
 
         The default opens the observation with a minimal field set request; subclasses may
@@ -443,7 +459,7 @@ class AbstractLazyObservation[T](ABC):
         else:
             data = self.get_data([])
             n_intervals = 0
-        return ObservationBufferShapes(data.n_detectors, data.n_samples, n_intervals)
+        return ObservationBufferShape(data.n_detectors, data.n_samples, n_intervals)
 
 
 class FileBackedLazyObservation[T](AbstractLazyObservation[T]):

--- a/src/furax/mapmaking/_partition.py
+++ b/src/furax/mapmaking/_partition.py
@@ -1,0 +1,187 @@
+"""Assign observations to processes, keeping buffer padding down.
+
+Observations read together are padded to a common shape, the per-axis maximum over the group, so
+a short observation grouped with a long one is padded up to the long one. That padding costs
+compute and memory, so the grouping decides how much of a run is wasted on it.
+
+[`partition_balanced`][] splits the observations into one group per process.
+[`PaddingReport`][] measures what a grouping costs.
+"""
+
+from collections.abc import Sequence
+from typing import NamedTuple, Self
+
+import numpy as np
+
+from ._observation import ObservationBufferShape
+
+
+def real_volume(shapes: Sequence[ObservationBufferShape]) -> int:
+    """Total volume of the observations, before any padding."""
+    return sum(s.volume for s in shapes)
+
+
+def group_padded_volume(shapes: Sequence[ObservationBufferShape], group: Sequence[int]) -> int:
+    """Volume one group occupies once its observations are padded to a common shape.
+
+    Every observation is padded to the largest detector count and the largest sample count in the
+    group, so the group holds that many elements per observation.
+    """
+    if len(group) == 0:
+        return 0
+    envelope = ObservationBufferShape(
+        max(shapes[i].detector_count for i in group),
+        max(shapes[i].sample_count for i in group),
+    )
+    return len(group) * envelope.volume
+
+
+def padded_volume(shapes: Sequence[ObservationBufferShape], groups: Sequence[Sequence[int]]) -> int:
+    """Total padded volume of a partition, summed over its groups."""
+    return sum(group_padded_volume(shapes, g) for g in groups)
+
+
+class PaddingReport(NamedTuple):
+    """Padding cost of a grouping, relative to zero-padding.
+
+    Attributes:
+        n_groups: Number of groups in the partition.
+        real: Volume before padding.
+        padded: Volume after padding, which is what gets processed.
+    """
+
+    n_groups: int
+    real: int
+    padded: int
+
+    @classmethod
+    def create(
+        cls, shapes: Sequence[ObservationBufferShape], groups: Sequence[Sequence[int]]
+    ) -> Self:
+        """Measure what a partition of the observations costs in padding.
+
+        Args:
+            shapes: Per-observation buffer shapes.
+            groups: Partition of observation indices into groups.
+
+        Returns:
+            The padding cost of that partition.
+
+        Examples:
+            Grouping everything together pads every observation to the largest one:
+
+            >>> from furax.mapmaking import ObservationBufferShape as Shape
+            >>> shapes = [Shape(2, 100), Shape(2, 100), Shape(2, 10)]
+            >>> PaddingReport.create(shapes, [[0, 1, 2]]).overhead  # padded 600 vs real 420
+            0.4285714285714286
+        """
+        return cls(len(groups), real_volume(shapes), padded_volume(shapes, groups))
+
+    @property
+    def overhead(self) -> float:
+        """Fraction of wasted work, ``padded / real - 1``; 0.0 means no padding."""
+        return (self.padded / self.real - 1.0) if self.real > 0 else 0.0
+
+
+def partition_balanced(
+    shapes: Sequence[ObservationBufferShape], n_groups: int, min_group: int = 1
+) -> list[list[int]]:
+    r"""Split observations into ``n_groups`` groups of comparable cost.
+
+    Observations in a group $b$ are padded to a common shape, so the group occupies
+    $|b| \cdot \max_{i \in b} d_i \cdot \max_{i \in b} s_i$ elements, where observation $i$ has
+    $d_i$ detectors and $s_i$ samples. Processing cost is roughly proportional to that volume, and
+    the groups minimise the largest of them.
+
+    Candidate groups are runs of the observations sorted by shape, so the partition is not always
+    the best possible.
+
+    Args:
+        shapes: Per-observation buffer shapes.
+        n_groups: Desired number of groups (typically the process count; reduced if the dataset
+            is too small to fill that many at ``min_group`` each).
+        min_group: Minimum observations per group.
+
+    Returns:
+        A list of groups. Each group is a sorted list of original observation indices. The groups
+        are ordered by increasing detector count, then sample count, and together they cover
+        ``range(len(shapes))``.
+
+    Raises:
+        ValueError: If ``n_groups < 1``, ``min_group < 1``, or the dataset cannot fill even one
+            group of ``min_group`` observations.
+
+    Examples:
+        Three short scans, one long scan:
+
+        >>> from furax.mapmaking import ObservationBufferShape as Shape
+        >>> shapes = [Shape(2, 10), Shape(2, 10), Shape(2, 10), Shape(2, 90)]
+        >>> partition_balanced(shapes, n_groups=2)
+        [[0, 1, 2], [3]]
+
+        Observations are grouped by detector count first, so the wide observation is not padded
+        onto the narrow ones:
+
+        >>> shapes = [Shape(1, 10), Shape(10, 20), Shape(1, 30)]
+        >>> partition_balanced(shapes, n_groups=2)
+        [[0, 2], [1]]
+    """
+    if n_groups < 1:
+        raise ValueError(f'n_groups must be >= 1, got {n_groups}')
+    if min_group < 1:
+        raise ValueError(f'min_group must be >= 1, got {min_group}')
+    n = len(shapes)
+    if n < min_group:
+        raise ValueError(f'need at least min_group={min_group} observations, got {n}')
+
+    n_groups = min(n_groups, n // min_group)
+
+    if n_groups == 1:
+        return [list(range(n))]
+
+    # Sort by detector count first, then by sample count. Observations with the same detector
+    # count stay together, so a group usually pads along the sample axis only. When every
+    # observation has the same detector count, this is just sorting by length. Considering only
+    # consecutive runs keeps the search polynomial; the unrestricted problem is NP-hard.
+    order = sorted(range(n), key=lambda i: (shapes[i].detector_count, shapes[i].sample_count))
+    det_s = [shapes[i].detector_count for i in order]
+    samp_s = [shapes[i].sample_count for i in order]
+
+    # dp[b][j] is the lowest cost the most expensive group can have when the first j
+    # observations are split into b groups of at least min_group each. cut[b][j] records where
+    # the last of those groups starts.
+    inf = np.iinfo(np.int64).max
+    dp = np.full((n_groups + 1, n + 1), inf, dtype=np.int64)
+    cut = np.zeros((n_groups + 1, n + 1), dtype=np.int64)
+    dp[0, 0] = 0
+
+    for b in range(1, n_groups + 1):
+        for j in range(b * min_group, n + 1):
+            best = inf
+            best_i = -1
+            # Try every start i for the last group [i, j), tracking the shape it pads to.
+            run_det = 0
+            run_samp = 0
+            for i in range(j - 1, (b - 1) * min_group - 1, -1):
+                run_det = max(run_det, det_s[i])
+                run_samp = max(run_samp, samp_s[i])
+                if j - i < min_group:
+                    continue
+                prev = dp[b - 1, i]
+                if prev == inf:
+                    continue
+                bottleneck = max(int(prev), (j - i) * run_det * run_samp)
+                if bottleneck < best:
+                    best = bottleneck
+                    best_i = i
+            dp[b, j] = best
+            cut[b, j] = best_i
+
+    groups: list[list[int]] = []
+    j = n
+    for b in range(n_groups, 0, -1):
+        i = int(cut[b, j])
+        groups.append(sorted(order[i:j]))
+        j = i
+    groups.reverse()
+    return groups

--- a/tests/mapmaking/helpers.py
+++ b/tests/mapmaking/helpers.py
@@ -11,7 +11,7 @@ from furax.mapmaking import (
     AbstractGroundObservation,
     AbstractLazyObservation,
     AbstractObservation,
-    ObservationBufferShapes,
+    ObservationBufferShape,
 )
 from furax.mapmaking.noise import AtmosphericNoiseModel, NoiseModel
 from furax.obs.landscapes import ProjectionType, StokesLandscape
@@ -171,11 +171,11 @@ class FailingLazyObservation(FakeLazyObservation):
     def name(self) -> str:
         return 'failing_obs'
 
-    def probe_shape(self, intervals: bool = False) -> ObservationBufferShapes:
+    def probe_shape(self, intervals: bool = False) -> ObservationBufferShape:
         # get_data raises, so build the shape directly. Non-ground obs -> no scanning intervals.
         del intervals
         obs = FakeObservation(**self._kwargs)
-        return ObservationBufferShapes(obs.n_detectors, obs.n_samples, 0)
+        return ObservationBufferShape(obs.n_detectors, obs.n_samples, 0)
 
     def get_data(self, requested_fields=None) -> FakeObservation:
         raise RuntimeError('simulated preprocessing failure')

--- a/tests/mapmaking/test_partition.py
+++ b/tests/mapmaking/test_partition.py
@@ -1,0 +1,115 @@
+from itertools import combinations
+
+import pytest
+
+from furax.mapmaking import ObservationBufferShape as Shape
+from furax.mapmaking._partition import (
+    PaddingReport,
+    group_padded_volume,
+    padded_volume,
+    partition_balanced,
+    real_volume,
+)
+
+
+def test_volume_helpers():
+    shapes = [Shape(2, 100), Shape(3, 10)]
+    assert real_volume(shapes) == 2 * 100 + 3 * 10
+    assert group_padded_volume(shapes, [0, 1]) == 2 * 3 * 100  # count * max_det * max_samp
+    assert group_padded_volume(shapes, []) == 0
+    assert padded_volume(shapes, [[0], [1]]) == real_volume(shapes)  # singletons never pad
+    assert padded_volume(shapes, [[0, 1]]) == 2 * 3 * 100  # grouped, both pad to (3, 100)
+
+
+def test_interval_axis_is_not_charged_for():
+    # Scanning intervals are metadata, not time-ordered samples.
+    assert Shape(2, 100, 7).volume == Shape(2, 100).volume
+
+
+def test_single_group_pads_to_the_largest_observation():
+    shapes = [Shape(2, 100), Shape(2, 100), Shape(2, 10)]
+    report = PaddingReport.create(shapes, [[0, 1, 2]])
+    assert report.n_groups == 1
+    assert report.real == 420
+    assert report.padded == 600  # 3 * 2 * 100
+    assert report.overhead == pytest.approx(600 / 420 - 1)
+
+
+def _brute_force_makespan(shapes, n_groups, min_group):
+    """Reference min largest-group padded volume over runs of the lexicographic order."""
+    order = sorted(
+        range(len(shapes)), key=lambda i: (shapes[i].detector_count, shapes[i].sample_count)
+    )
+    n = len(shapes)
+    best = None
+    for cuts in combinations(range(1, n), n_groups - 1):
+        bounds = [0, *cuts, n]
+        segs = [order[bounds[k] : bounds[k + 1]] for k in range(n_groups)]
+        if any(len(s) < min_group for s in segs):
+            continue
+        makespan = _group_makespan(shapes, segs)
+        best = makespan if best is None else min(best, makespan)
+    return best
+
+
+def _group_makespan(shapes, groups):
+    """The cost of the busiest process: what it pads to, times how many slots it carries."""
+    return max(group_padded_volume(shapes, s) for s in groups)
+
+
+def test_partition_respects_the_return_contract():
+    shapes = [Shape(2, s) for s in (10, 50, 12, 90, 11, 88, 49)]
+    groups = partition_balanced(shapes, n_groups=3)
+    assert len(groups) == 3  # as many groups as asked for
+    assert min(len(s) for s in groups) >= 1  # none of them empty
+    assert sorted(i for s in groups for i in s) == list(range(len(shapes)))  # exhaustive, no dupes
+    assert groups == [sorted(s) for s in groups]  # each group sorted
+    keys = [max((shapes[i].detector_count, shapes[i].sample_count) for i in s) for s in groups]
+    assert keys == sorted(keys)  # groups ordered by increasing shape
+
+
+def test_partition_favours_volume_not_count():
+    # Three short + one long: volume balance puts all shorts in one group, the long alone.
+    shapes = [Shape(2, 10), Shape(2, 10), Shape(2, 10), Shape(2, 90)]
+    assert partition_balanced(shapes, n_groups=2) == [[0, 1, 2], [3]]
+
+
+@pytest.mark.parametrize('n_groups', [1, 2, 3, 4])
+@pytest.mark.parametrize('min_group', [1, 2])
+def test_partition_matches_brute_force(n_groups, min_group):
+    shapes = [
+        Shape(2, 10),
+        Shape(2, 90),
+        Shape(3, 12),
+        Shape(2, 88),
+        Shape(3, 50),
+        Shape(2, 49),
+        Shape(2, 30),
+    ]
+    if len(shapes) < n_groups * min_group:
+        pytest.skip('dataset too small for this group count')
+    groups = partition_balanced(shapes, n_groups, min_group)
+    assert all(len(s) >= min_group for s in groups)
+    assert _group_makespan(shapes, groups) == _brute_force_makespan(shapes, n_groups, min_group)
+
+
+def test_partition_groups_on_detector_count_before_length():
+    # Sorting on length alone would put the wide observation next to a narrow one and pad it onto
+    # the group; leading with the detector count keeps the two narrow ones together instead.
+    shapes = [Shape(1, 10), Shape(10, 20), Shape(1, 30)]
+    groups = partition_balanced(shapes, n_groups=2)
+    assert groups == [[0, 2], [1]]
+    by_length = [[0, 1], [2]]  # what the sample-sorted order yields
+    assert _group_makespan(shapes, groups) < _group_makespan(shapes, by_length)
+
+
+def test_partition_caps_and_validates():
+    shapes = [Shape(2, s) for s in (10, 20, 30, 40, 50)]
+    # Ask for 5 groups but require >=2 each: only 2 groups fit (5 // 2).
+    assert len(partition_balanced(shapes, n_groups=5, min_group=2)) == 2
+    with pytest.raises(ValueError, match='n_groups must be'):
+        partition_balanced(shapes, n_groups=0)
+    with pytest.raises(ValueError, match='min_group must be'):
+        partition_balanced(shapes, n_groups=2, min_group=0)
+    with pytest.raises(ValueError, match='at least min_group'):
+        partition_balanced(shapes, n_groups=1, min_group=99)


### PR DESCRIPTION
This PR adds a new module to group observations based on their shapes and minimise padding. The long-term idea is that, in distributed context, each process can work its own group of observations independently (no global padded shape, only per-process), so grouping avoids excessive padding.

- Add `mapmaking/_partition.py`.
- `ObservationBufferShapes` renamed to the singular `ObservationBufferShape` and gains a `volume` property.