### PR TITLE
Add cross-process sky reduction for per-process execution

### DIFF
--- a/src/furax/mapmaking/_distributed.py
+++ b/src/furax/mapmaking/_distributed.py
@@ -1,0 +1,55 @@
+"""Cross-process collectives for the mapmaking pipeline."""
+
+import jax
+import numpy as np
+from jax.sharding import Mesh, NamedSharding
+from jax.sharding import PartitionSpec as P
+from jaxtyping import Array, PyTree
+
+
+def _cross_process_mesh() -> Mesh:
+    """A ``(proc, dev)`` mesh over every device in the job, grouped by owning process.
+
+    Assumes every process contributes the same number of devices, so that row ``p`` holds exactly
+    the devices of process ``p``.
+    """
+    devices = sorted(jax.devices(), key=lambda d: (d.process_index, d.id))
+    n_proc = jax.process_count()
+    return Mesh(np.array(devices).reshape(n_proc, -1), ('proc', 'dev'))
+
+
+def cross_process_sum(tree: PyTree[Array]) -> PyTree[Array]:
+    """Sum a process-local pytree across all processes, returning the total on every process.
+
+    Each leaf must be process-local (not a global sharded array) and identically shaped on every
+    process. Leaves are replicated across a process's local devices rather than split over them,
+    so those copies carry the same row and do not contribute to the sum. Single-process runs
+    return the input untouched.
+
+    Args:
+        tree: Pytree of process-local arrays holding this process's partial sums.
+
+    Returns:
+        A pytree of the same structure where every leaf is the sum over all processes, replicated
+        on every device.
+    """
+    if jax.process_count() == 1:
+        return tree
+
+    mesh = _cross_process_mesh()
+    n_proc = jax.process_count()
+    # One shard per *local* device is required, but the partial is replicated within the process,
+    # so every local device contributes the same slice of this process's row.
+    local_devices = sorted(jax.local_devices(), key=lambda d: d.id)
+
+    def reduce_leaf(x: Array) -> Array:
+        sharding = NamedSharding(mesh, P('proc'))
+        stacked = jax.make_array_from_single_device_arrays(
+            (n_proc, *x.shape),
+            sharding,
+            [jax.device_put(x.reshape(1, *x.shape), d) for d in local_devices],
+        )
+        total: Array = jax.jit(lambda s: s.sum(axis=0))(stacked)
+        return total
+
+    return jax.tree.map(reduce_leaf, tree)

--- a/tests/mapmaking/test_distributed.py
+++ b/tests/mapmaking/test_distributed.py
@@ -1,0 +1,57 @@
+import os
+import subprocess
+import sys
+
+import numpy as np
+import pytest
+
+NPIX = 5
+# deliberately unequal: no global padding is involved, each process owns what it owns
+GROUP_SIZES = [3, 7, 2, 9]
+
+
+def _expected_total(n_proc: int) -> np.ndarray:
+    total = np.zeros(NPIX, np.float64)
+    for proc_id, size in enumerate(GROUP_SIZES[:n_proc]):
+        total += (np.arange(size * NPIX, dtype=np.float64).reshape(size, NPIX) + proc_id).sum(0)
+    return total
+
+
+def _child(proc_id: int, n_proc: int, port: int, n_local: int) -> int:
+    os.environ['JAX_PLATFORMS'] = 'cpu'
+    os.environ['XLA_FLAGS'] = f'--xla_force_host_platform_device_count={n_local}'
+    import jax
+    import jax.numpy as jnp
+
+    jax.config.update('jax_enable_x64', True)
+    jax.distributed.initialize(
+        coordinator_address=f'localhost:{port}', num_processes=n_proc, process_id=proc_id
+    )
+    from furax.mapmaking._distributed import cross_process_sum
+
+    size = GROUP_SIZES[proc_id]
+    group = jnp.arange(size * NPIX, dtype=jnp.float64).reshape(size, NPIX) + proc_id
+    partial = jax.device_put(group.sum(axis=0), jax.local_devices()[0])
+
+    total = cross_process_sum({'map': partial, 'hits': partial * 2})
+    expected = _expected_total(n_proc)
+    ok = np.allclose(np.asarray(total['map']), expected) and np.allclose(
+        np.asarray(total['hits']), 2 * expected
+    )
+    return 0 if ok else 1
+
+
+@pytest.mark.distributed
+@pytest.mark.parametrize('n_proc, n_local', [(3, 1), (2, 2)])
+def test_cross_process_sum_over_heterogeneous_groups(n_proc: int, n_local: int) -> None:
+    port = 54400 + 10 * n_proc + n_local
+    procs = [
+        subprocess.Popen([sys.executable, __file__, str(i), str(n_proc), str(port), str(n_local)])
+        for i in range(n_proc)
+    ]
+    codes = [p.wait(timeout=180) for p in procs]
+    assert codes == [0] * n_proc, f'child exit codes {codes}'
+
+
+if __name__ == '__main__':  # spawned child, not collected by pytest
+    sys.exit(_child(int(sys.argv[1]), int(sys.argv[2]), int(sys.argv[3]), int(sys.argv[4])))


### PR DESCRIPTION
Under per-process ownership no global array spans the observations, so the sky map needs an explicit collective.

This PR adds a new `_distributed.py` module that provides `cross_process_sum` to sum process partials. It is wired to the mapmaker higher up the stack.