### PR TITLE
Replace PerDetectorTemplate with TemplateOperator and StokesTemplateOperator

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -47,6 +47,7 @@ Use Google-style docstrings. Docs site renders via mkdocstrings/griffe, so a few
 - Section bodies must be indented **under** the header (`Args:` at 4 → entries at 8). `name (type): description`.
 - Use `Examples:` (plural) for code examples. Singular `Example:` becomes an admonition with no `pycon` syntax highlighting.
 - A `>>>` console block must be preceded by a **blank line** when prose comes before it, but **not** directly after the section header (ruff `D412`).
+- Code spans take single backticks: `n_blocks`, not ``n_blocks``. Docstrings render as markdown, so the reST double-backtick form buys nothing.
 - Math: `$inline$` / `$$display$$`. Cross-reference symbols with autorefs: ``[`OtherClass`][]``.
 
 ```python

--- a/docs/api/mapmaking/templates.md
+++ b/docs/api/mapmaking/templates.md
@@ -1,0 +1,5 @@
+# Templates
+
+::: furax.mapmaking.templates
+    options:
+      show_root_heading: false

--- a/docs/development/changelog.md
+++ b/docs/development/changelog.md
@@ -12,6 +12,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `StreamOperator.block_row`/`block_column`: fuse several streams into one, evaluating a joint system in a single pass over the data (#190)
 - API reference page for `furax.mapmaking.streaming` (#190)
 - `AbstractLinearOperator.profile()` and a new `furax.profiling` module for estimated cost analysis (#193)
+- `furax.mapmaking.templates.Basis.per_detector_stack()` to stack per-detector templates into a single basis (#214)
+- Mapmaking config entry for T-to-P leakage deprojection (#214)
 
 ### Changed
 
@@ -21,6 +23,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Breaking:** `AbstractLinearOperator.__call__`, `BJPreconditioner.create`, and the `LBSObservation`/`ToastObservation` pointing helpers now raise `TypeError` (previously `ValueError`/`RuntimeError`) for invalid argument/operator/landscape types (#194)
 - Bumped ruff to 0.16.1 and updated rule selection accordingly (#194)
 - Fixed detection of templates usage in map-making configuration (#225)
+- Template algebra code overhaul, replacing `PerDetectorTemplate` with `(Stokes)TemplateOperator` (#214)
+- **Breaking**: template configuration keys are now spelled out (`binaz_synchronous` → `binned_azimuth_synchronous`, `azhwp_synchronous` → `azimuth_hwp_synchronous`, `binazhwp_synchronous` → `binned_azimuth_hwp_synchronous`, `spline_hwpss` → `spline_hwp_synchronous`) (#214)
+
+### Removed
+
+- "Two-step" single-observation mapmakers (the `TwoStep` method and `TwoStepMapmaker` class) (#214)
 
 ## [0.12.0] - 2026-07-24
 

--- a/docs/development/changelog.md
+++ b/docs/development/changelog.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `StreamOperator.block_row`/`block_column`: fuse several streams into one, evaluating a joint system in a single pass over the data (#190)
 - API reference page for `furax.mapmaking.streaming` (#190)
+- API reference page for `furax.mapmaking.templates` (#214)
 - `AbstractLinearOperator.profile()` and a new `furax.profiling` module for estimated cost analysis (#193)
 - `furax.mapmaking.templates.Basis.per_detector_stack()` to stack per-detector templates into a single basis (#214)
 - Mapmaking config entry for T-to-P leakage deprojection (#214)

--- a/src/furax/mapmaking/config.py
+++ b/src/furax/mapmaking/config.py
@@ -458,7 +458,11 @@ class BinAzHWPSynchronousConfig:
 
 @dataclass
 class SplineHWPSSConfig:
-    """HWP-synchronous signal on a cubic B-spline basis in HWP angle."""
+    """HWP-synchronous signal whose harmonic amplitudes vary slowly with time.
+
+    The template is built from harmonics of the HWP angle, each carried by a cubic B-spline in
+    *time*: `n_knots` (or `samples_per_knot`) sets how fast the amplitude is allowed to vary.
+    """
 
     n_knots: int | None = None
     """Number of spline knots. If set, takes precedence over `samples_per_knot`."""
@@ -565,7 +569,7 @@ class TemplatesConfig:
     """Joint azimuth/HWP-synchronous template, binned azimuth times Fourier in HWP angle."""
 
     spline_hwpss: SplineHWPSSConfig | None = None
-    """HWP-synchronous template on a cubic B-spline basis in HWP angle."""
+    """HWP-synchronous template whose harmonic amplitudes follow a cubic B-spline in time."""
 
     t2p: T2PConfig | None = None
     """Temperature-to-polarization leakage template (demodulated data only)."""

--- a/src/furax/mapmaking/config.py
+++ b/src/furax/mapmaking/config.py
@@ -871,11 +871,6 @@ class MapMakingConfig:
             raise ValueError(f'Unknown method: {method}')
 
     @classmethod
-    def full_defaults(cls) -> 'MapMakingConfig':
-        """Create a config with default values for all fields including optional ones."""
-        return cls(templates=TemplatesConfig.full_defaults(), sotodlib=SotodlibConfig())
-
-    @classmethod
     def load_yaml(cls, path: str | Path) -> 'MapMakingConfig':
         """Load and instantiate a ``MapMakingConfig`` from a YAML file."""
         data = yaml.safe_load(Path(path).read_text())

--- a/src/furax/mapmaking/config.py
+++ b/src/furax/mapmaking/config.py
@@ -47,6 +47,7 @@ __all__ = [
     'AzHWPSynchronousConfig',
     'BinAzHWPSynchronousConfig',
     'SplineHWPSSConfig',
+    'T2PConfig',
     'GroundConfig',
     'SotodlibConfig',
 ]
@@ -63,9 +64,6 @@ class Methods(Enum):
 
     MAXL = 'ML'
     """Classic maximum-likelihood mapmaking solve via conjugate gradient iteration."""
-
-    TWOSTEP = 'TwoStep'
-    """Two-step mapmaking (destriper-like)."""
 
     ATOP = 'ATOP'
     """Polarisation (QU only) estimator using deprojection of short baselines.
@@ -375,6 +373,14 @@ class PolynomialConfig:
 
     legendre: PolynomialOrders = field(default_factory=lambda: PolynomialOrders(0, 3))
     """Legendre orders for the polynomial drift template."""
+    legendre_qu: PolynomialOrders | None = None
+    """Legendre orders for the Q/U legs, demodulated data only.
+
+    Overrides ``legendre`` for the Q and U legs (fitted independently from each other and
+    from I). ``None`` reuses ``legendre`` for every leg. Requires ``demodulated=True``.
+    """
+    explicit: bool = False
+    """If True, amplitudes are solved jointly and returned; if False, deprojected into W."""
 
 
 @dataclass
@@ -387,6 +393,9 @@ class ScanSynchronousConfig:
     legendre: PolynomialOrders = field(default_factory=lambda: PolynomialOrders(3, 7))
     """Legendre orders for the azimuth-dependent basis."""
 
+    explicit: bool = False
+    """If True, amplitudes are solved jointly and returned; if False, deprojected into W."""
+
 
 @dataclass
 class BinAzSynchronousConfig:
@@ -398,6 +407,9 @@ class BinAzSynchronousConfig:
     bins: BinsConfig = field(default_factory=BinsConfig)
     """Azimuth binning."""
 
+    explicit: bool = False
+    """If True, amplitudes are solved jointly and returned; if False, deprojected into W."""
+
 
 @dataclass
 class HWPSynchronousConfig:
@@ -405,6 +417,9 @@ class HWPSynchronousConfig:
 
     n_harmonics: int = 3
     """Number of HWP harmonics to fit."""
+
+    explicit: bool = False
+    """If True, amplitudes are solved jointly and returned; if False, deprojected into W."""
 
 
 @dataclass
@@ -420,6 +435,9 @@ class AzHWPSynchronousConfig:
     split_scans: bool = False
     """Fit independent coefficients per subscan instead of shared ones."""
 
+    explicit: bool = False
+    """If True, amplitudes are solved jointly and returned; if False, deprojected into W."""
+
 
 @dataclass
 class BinAzHWPSynchronousConfig:
@@ -434,6 +452,9 @@ class BinAzHWPSynchronousConfig:
     n_harmonics: int = 4
     """Number of HWP harmonics to fit."""
 
+    explicit: bool = False
+    """If True, amplitudes are solved jointly and returned; if False, deprojected into W."""
+
 
 @dataclass
 class SplineHWPSSConfig:
@@ -445,6 +466,9 @@ class SplineHWPSSConfig:
     """Number of samples per knot."""
     harmonics: tuple[int, ...] = (4,)
     """HWP harmonics to fit with splines."""
+
+    explicit: bool = False
+    """If True, amplitudes are solved jointly and returned; if False, deprojected into W."""
 
     def __post_init__(self) -> None:
         if self.n_knots is None and self.samples_per_knot is None:
@@ -462,6 +486,24 @@ class SplineHWPSSConfig:
 
 
 @dataclass
+class T2PConfig:
+    """Temperature-to-polarization leakage template (demodulated data only)."""
+
+    fit_band: tuple[float, float] | None = None
+    """Frequency band (in Hz) used to fit the leakage coefficients. `None` uses the full band."""
+
+    decimate: int = 1
+    """Decimation factor applied to the I template before fitting."""
+
+    explicit: bool = True
+    """T2P templates are always solved explicitly; deprojection is not supported."""
+
+    def __post_init__(self) -> None:
+        if not self.explicit:
+            raise ValueError('T2P template filtering requires explicit=True')
+
+
+@dataclass
 class GroundConfig:
     """Ground pickup template: binned in (azimuth, elevation)."""
 
@@ -476,6 +518,13 @@ class GroundConfig:
 
     Defaults to 0.05 (~3 deg).
     """
+
+    explicit: bool = True
+    """Ground templates are always solved explicitly; deprojection is not supported."""
+
+    def __post_init__(self) -> None:
+        if not self.explicit:
+            raise ValueError('Ground template filtering requires explicit=True')
 
 
 @dataclass
@@ -518,6 +567,9 @@ class TemplatesConfig:
     spline_hwpss: SplineHWPSSConfig | None = None
     """HWP-synchronous template on a cubic B-spline basis in HWP angle."""
 
+    t2p: T2PConfig | None = None
+    """Temperature-to-polarization leakage template (demodulated data only)."""
+
     ground: GroundConfig | None = None
     """Ground pickup template, binned in (azimuth, elevation)."""
 
@@ -534,6 +586,7 @@ class TemplatesConfig:
             hwp_synchronous=HWPSynchronousConfig(),
             azhwp_synchronous=AzHWPSynchronousConfig(),
             binazhwp_synchronous=BinAzHWPSynchronousConfig(),
+            t2p=T2PConfig(),
             spline_hwpss=SplineHWPSSConfig(),
             ground=GroundConfig(),
         )
@@ -741,13 +794,31 @@ class MapMakingConfig:
     sotodlib: SotodlibConfig | None = None
     """Options specific to the sotodlib interface. `None` when not using sotodlib data."""
 
+    def __post_init__(self) -> None:
+        """Validate cross-field constraints that hold regardless of which mapmaker runs."""
+        if (templates := self.templates) is not None:
+            if templates.t2p is not None:
+                if not self.demodulated:
+                    raise ValueError('The T2P template requires demodulated=True.')
+                if 'I' not in self.landscape.stokes:
+                    raise ValueError(
+                        "The T2P template requires an 'I' leg in landscape.stokes (got "
+                        f'{self.landscape.stokes!r}).'
+                    )
+            if (
+                templates.polynomial is not None
+                and templates.polynomial.legendre_qu is not None
+                and not self.demodulated
+            ):
+                raise ValueError('templates.polynomial.legendre_qu requires demodulated=True.')
+
     @classmethod
     def for_method(cls, method: 'Methods | str') -> 'MapMakingConfig':
         """Return a default MapMakingConfig pre-configured for the given method.
 
         Args:
             method: A ``Methods`` enum value or its string name (e.g. ``'binned'``,
-                ``'ml'``, ``'twostep'``, ``'atop'``), case-insensitive.
+                ``'ml'``, ``'atop'``), case-insensitive.
         """
         if isinstance(method, str):
             upper = method.upper()
@@ -780,19 +851,6 @@ class MapMakingConfig:
                 ),
                 templates=None,
             )
-        elif method == Methods.TWOSTEP:
-            return cls(
-                method=Methods.TWOSTEP,
-                weighting=WeightingConfig(),
-                solver=SolverConfig(
-                    rtol=1e-6,
-                    atol=0,
-                    max_steps=1_000,
-                ),
-                templates=TemplatesConfig(
-                    polynomial=PolynomialConfig(),
-                ),
-            )
         elif method == Methods.ATOP:
             return cls(
                 method=Methods.ATOP,
@@ -811,7 +869,7 @@ class MapMakingConfig:
     @classmethod
     def full_defaults(cls) -> 'MapMakingConfig':
         """Create a config with default values for all fields including optional ones."""
-        return cls(templates=TemplatesConfig.full_defaults())
+        return cls(templates=TemplatesConfig.full_defaults(), sotodlib=SotodlibConfig())
 
     @classmethod
     def load_yaml(cls, path: str | Path) -> 'MapMakingConfig':

--- a/src/furax/mapmaking/config.py
+++ b/src/furax/mapmaking/config.py
@@ -42,11 +42,11 @@ __all__ = [
     'PolynomialConfig',
     'ScanSynchronousConfig',
     'BinsConfig',
-    'BinAzSynchronousConfig',
+    'BinnedAzimuthSynchronousConfig',
     'HWPSynchronousConfig',
-    'AzHWPSynchronousConfig',
-    'BinAzHWPSynchronousConfig',
-    'SplineHWPSSConfig',
+    'AzimuthHWPSynchronousConfig',
+    'BinnedAzimuthHWPSynchronousConfig',
+    'SplineHWPSynchronousConfig',
     'T2PConfig',
     'GroundConfig',
     'SotodlibConfig',
@@ -398,7 +398,7 @@ class ScanSynchronousConfig:
 
 
 @dataclass
-class BinAzSynchronousConfig:
+class BinnedAzimuthSynchronousConfig:
     """Binned azimuth-synchronous signal, no HWP coupling.
 
     The binned counterpart of [`ScanSynchronousConfig`][].
@@ -423,7 +423,7 @@ class HWPSynchronousConfig:
 
 
 @dataclass
-class AzHWPSynchronousConfig:
+class AzimuthHWPSynchronousConfig:
     """Joint azimuth/HWP-synchronous signal: Legendre in azimuth times Fourier in HWP angle."""
 
     legendre: PolynomialOrders = field(default_factory=lambda: PolynomialOrders(0, 3))
@@ -440,10 +440,10 @@ class AzHWPSynchronousConfig:
 
 
 @dataclass
-class BinAzHWPSynchronousConfig:
+class BinnedAzimuthHWPSynchronousConfig:
     """Joint azimuth/HWP-synchronous signal: azimuth binning times Fourier in HWP angle.
 
-    The binned-azimuth counterpart of [`AzHWPSynchronousConfig`][].
+    The binned-azimuth counterpart of [`AzimuthHWPSynchronousConfig`][].
     """
 
     bins: BinsConfig = field(default_factory=BinsConfig)
@@ -457,7 +457,7 @@ class BinAzHWPSynchronousConfig:
 
 
 @dataclass
-class SplineHWPSSConfig:
+class SplineHWPSynchronousConfig:
     """HWP-synchronous signal whose harmonic amplitudes vary slowly with time.
 
     The template is built from harmonics of the HWP angle, each carried by a cubic B-spline in
@@ -496,7 +496,7 @@ class T2PConfig:
     fit_band: tuple[float, float] | None = None
     """Frequency band (in Hz) used to fit the leakage coefficients. `None` uses the full band."""
 
-    decimate: int = 1
+    decimation_factor: int = 1
     """Decimation factor applied to the I template before fitting."""
 
     explicit: bool = True
@@ -556,19 +556,19 @@ class TemplatesConfig:
     scan_synchronous: ScanSynchronousConfig | None = None
     """Scan-synchronous (azimuth-only) template on a global Legendre basis."""
 
-    binaz_synchronous: BinAzSynchronousConfig | None = None
+    binned_azimuth_synchronous: BinnedAzimuthSynchronousConfig | None = None
     """Scan-synchronous (azimuth-only) template on a binned azimuth basis."""
 
     hwp_synchronous: HWPSynchronousConfig | None = None
     """HWP-synchronous template on a global Fourier (harmonic) basis."""
 
-    azhwp_synchronous: AzHWPSynchronousConfig | None = None
+    azimuth_hwp_synchronous: AzimuthHWPSynchronousConfig | None = None
     """Joint azimuth/HWP-synchronous template, Legendre in azimuth times Fourier in HWP angle."""
 
-    binazhwp_synchronous: BinAzHWPSynchronousConfig | None = None
+    binned_azimuth_hwp_synchronous: BinnedAzimuthHWPSynchronousConfig | None = None
     """Joint azimuth/HWP-synchronous template, binned azimuth times Fourier in HWP angle."""
 
-    spline_hwpss: SplineHWPSSConfig | None = None
+    spline_hwp_synchronous: SplineHWPSynchronousConfig | None = None
     """HWP-synchronous template whose harmonic amplitudes follow a cubic B-spline in time."""
 
     t2p: T2PConfig | None = None
@@ -586,12 +586,12 @@ class TemplatesConfig:
         return cls(
             polynomial=PolynomialConfig(),
             scan_synchronous=ScanSynchronousConfig(),
-            binaz_synchronous=BinAzSynchronousConfig(),
+            binned_azimuth_synchronous=BinnedAzimuthSynchronousConfig(),
             hwp_synchronous=HWPSynchronousConfig(),
-            azhwp_synchronous=AzHWPSynchronousConfig(),
-            binazhwp_synchronous=BinAzHWPSynchronousConfig(),
+            azimuth_hwp_synchronous=AzimuthHWPSynchronousConfig(),
+            binned_azimuth_hwp_synchronous=BinnedAzimuthHWPSynchronousConfig(),
             t2p=T2PConfig(),
-            spline_hwpss=SplineHWPSSConfig(),
+            spline_hwp_synchronous=SplineHWPSynchronousConfig(),
             ground=GroundConfig(),
         )
 

--- a/src/furax/mapmaking/mapmaker.py
+++ b/src/furax/mapmaking/mapmaker.py
@@ -28,14 +28,13 @@ import furax.linalg
 import furax.tree
 from furax import (
     AbstractLinearOperator,
-    Config,
     DiagonalOperator,
     IdentityOperator,
     MaskOperator,
     OperatorTag,
     SymmetricBandToeplitzOperator,
 )
-from furax.core import BlockDiagonalOperator, BlockRowOperator, IndexOperator
+from furax.core import IndexOperator
 from furax.interfaces.lineax import as_lineax_operator
 from furax.obs.landscapes import (
     AstropyWCSLandscape,
@@ -48,7 +47,6 @@ from furax.obs.pointing import PointingOperator
 from furax.obs.stokes import Stokes, StokesI, StokesIQU, StokesType, ValidStokesLiteral
 from furax.profiling import format_bytes
 
-from . import templates
 from ._geometry import minimum_enclosing_arc
 from ._logger import logger as furax_logger
 from ._model import ObservationModel
@@ -73,7 +71,7 @@ from .noise import AtmosphericNoiseModel, NoiseModel, WhiteNoiseModel
 from .preconditioner import BJPreconditioner
 from .results import MapMakingResults
 from .streaming import StreamOperator
-from .templates import PerDetectorTemplate
+from .templates import ATOPProjectionOperator
 from .weight import WeightOperator
 
 
@@ -655,7 +653,6 @@ class MapMaker:
         maker = {
             Methods.BINNED: BinnedMapMaker,
             Methods.MAXL: MLMapmaker,
-            Methods.TWOSTEP: TwoStepMapmaker,
             Methods.ATOP: ATOPMapMaker,
         }[config.method]
 
@@ -874,138 +871,6 @@ class MapMaker:
         )
         return IndexOperator((..., *jnp.where(valid)), in_structure=landscape.structure)
 
-    def get_template_operator(
-        self, observation: AbstractGroundObservation[Any]
-    ) -> BlockRowOperator:
-        """Create a template operator from the provided name and configuration."""
-        config = self.config
-        assert config.templates is not None
-        blocks: dict[str, AbstractLinearOperator] = {}
-
-        if poly := config.templates.polynomial:
-            blocks['polynomial'] = PerDetectorTemplate.polynomial(
-                max_poly_order=poly.legendre.max_order,
-                intervals=jnp.asarray(observation.get_scanning_intervals()),
-                times=jnp.asarray(observation.get_elapsed_times()),
-                n_dets=observation.n_detectors,
-                dtype=config.dtype,
-            )
-        if sss := config.templates.scan_synchronous:
-            blocks['scan_synchronous'] = PerDetectorTemplate.scan_synchronous(
-                legendre=sss.legendre,
-                azimuth=jnp.asarray(observation.get_azimuth()),
-                n_dets=observation.n_detectors,
-                dtype=config.dtype,
-            )
-        if baz := config.templates.binaz_synchronous:
-            blocks['binaz_synchronous'] = PerDetectorTemplate.binaz_synchronous(
-                bins=baz.bins,
-                azimuth=jnp.asarray(observation.get_azimuth()),
-                n_dets=observation.n_detectors,
-                dtype=config.dtype,
-            )
-        if hwpss := config.templates.hwp_synchronous:
-            blocks['hwp_synchronous'] = PerDetectorTemplate.hwp_synchronous(
-                n_harmonics=hwpss.n_harmonics,
-                hwp_angles=jnp.asarray(observation.get_hwp_angles()),
-                n_dets=observation.n_detectors,
-                dtype=config.dtype,
-            )
-        if azhwpss := config.templates.azhwp_synchronous:
-            azimuth = jnp.asarray(observation.get_azimuth())
-            hwp_angles = jnp.asarray(observation.get_hwp_angles())
-            if azhwpss.split_scans:
-                blocks['azhwp_synchronous_left'] = PerDetectorTemplate.azhwp_synchronous(
-                    legendre=azhwpss.legendre,
-                    n_harmonics=azhwpss.n_harmonics,
-                    azimuth=azimuth,
-                    hwp_angles=hwp_angles,
-                    n_dets=observation.n_detectors,
-                    dtype=config.dtype,
-                    scan_mask=jnp.asarray(observation.get_left_scan_mask()),
-                )
-                blocks['azhwp_synchronous_right'] = PerDetectorTemplate.azhwp_synchronous(
-                    legendre=azhwpss.legendre,
-                    n_harmonics=azhwpss.n_harmonics,
-                    azimuth=azimuth,
-                    hwp_angles=hwp_angles,
-                    n_dets=observation.n_detectors,
-                    dtype=config.dtype,
-                    scan_mask=jnp.asarray(observation.get_right_scan_mask()),
-                )
-            else:
-                blocks['azhwp_synchronous'] = PerDetectorTemplate.azhwp_synchronous(
-                    legendre=azhwpss.legendre,
-                    n_harmonics=azhwpss.n_harmonics,
-                    azimuth=azimuth,
-                    hwp_angles=hwp_angles,
-                    n_dets=observation.n_detectors,
-                    dtype=config.dtype,
-                )
-        if binazhwpss := config.templates.binazhwp_synchronous:
-            blocks['binazhwp_synchronous'] = PerDetectorTemplate.binazhwp_synchronous(
-                bins=binazhwpss.bins,
-                n_harmonics=binazhwpss.n_harmonics,
-                azimuth=jnp.asarray(observation.get_azimuth()),
-                hwp_angles=jnp.asarray(observation.get_hwp_angles()),
-                n_dets=observation.n_detectors,
-                dtype=config.dtype,
-            )
-        if shwpss := config.templates.spline_hwpss:
-            times = jnp.asarray(observation.get_elapsed_times())
-            blocks['spline_hwpss'] = PerDetectorTemplate.bspline_hwpss(
-                times=times,
-                hwp_angles=jnp.asarray(observation.get_hwp_angles()),
-                n_dets=observation.n_detectors,
-                n_knots=shwpss.resolve_n_knots(times.size),
-                harmonics=shwpss.harmonics,
-                dtype=config.dtype,
-            )
-        if ground := config.templates.ground:
-            azimuth = jnp.asarray(observation.get_azimuth())
-            elevation = jnp.asarray(observation.get_elevation())
-            detector_quaternions = jnp.asarray(observation.get_detector_quaternions())
-            self._ground_landscape = templates.GroundTemplateOperator.get_landscape(
-                azimuth_resolution=ground.azimuth_resolution,
-                elevation_resolution=ground.elevation_resolution,
-                boresight_azimuth=azimuth,
-                boresight_elevation=elevation,
-                detector_quaternions=detector_quaternions,
-                stokes='IQU',
-                dtype=config.dtype,
-            )
-            ground_op = templates.GroundTemplateOperator.create(
-                azimuth_resolution=ground.azimuth_resolution,
-                elevation_resolution=ground.elevation_resolution,
-                boresight_azimuth=azimuth,
-                boresight_elevation=elevation,
-                boresight_rotation=jnp.zeros_like(azimuth),
-                detector_quaternions=detector_quaternions,
-                hwp_angles=jnp.asarray(observation.get_hwp_angles()),
-                stokes='IQU',
-                dtype=config.dtype,
-                landscape=self._ground_landscape,
-                batch_size=config.pointing.batch_size,
-            )
-            ones_tod = jnp.ones(
-                (observation.n_detectors, observation.n_samples), dtype=config.dtype
-            )
-            self._ground_coverage = ground_op.T(ones_tod)
-            nonzero_hits = jnp.argwhere(self._ground_coverage.i > 0)
-            indexer = IndexOperator(
-                (..., nonzero_hits[:, 0], nonzero_hits[:, 1]),
-                in_structure=furax.tree.as_structure(self._ground_coverage),
-            )
-            flattener = furax.asoperator(
-                lambda s: jnp.concatenate([s.i, s.q, s.u]),
-                in_structure=indexer.out_structure,
-            )
-            self._ground_selector = flattener @ indexer
-
-            blocks['ground'] = ground_op @ self._ground_selector.T
-
-        return BlockRowOperator(blocks=blocks)
-
 
 class BinnedMapMaker(MapMaker):
     """Class for mapmaking with diagonal noise covariance."""
@@ -1178,52 +1043,7 @@ class MLMapmaker(MapMaker):
         # Preconditioner
         # We use the approximate diagonal system matrix before the mask update
         preconditioner = selector @ diag_system.inverse() @ selector.T
-
-        # Templates (optional)
-        if config.use_templates:
-            template_op = self.get_template_operator(observation)
-            logger_info('Built template operators')
-            REGVAL = config.templates.regularization  # type: ignore[union-attr]
-            tmpl_inv_sys = {}
-            regs = {}
-            # Pass the operator as an explicit argument so JAX traces its arrays as inputs
-            # rather than hashing it as the jit fun (operators carry unhashable leaves).
-            apply = jax.jit(lambda op, v: op(v))
-            for tmpl, tmpl_op in template_op.blocks.items():
-                tmpl_sys = (tmpl_op.T @ diag_inv_noise @ masker @ tmpl_op).reduce()
-                # Approximation to the diagonal of the matrix
-                norm_sys = jnp.abs(apply(tmpl_sys, furax.tree.ones_like(tmpl_op.in_structure)))
-                # Regualrisation value is REGVAL times the smallest non-zero eigenvalue
-                regs[tmpl] = REGVAL * jnp.min(norm_sys[norm_sys > 0])
-                tmpl_inv_sys[tmpl] = DiagonalOperator(
-                    (norm_sys + regs[tmpl]),
-                    in_structure=tmpl_op.in_structure,
-                ).inverse()
-            template_preconditioner = BlockDiagonalOperator(tmpl_inv_sys)
-            logger_info('Built template preconditioner')
-            template_reg_op = BlockDiagonalOperator(
-                [
-                    DiagonalOperator(jnp.array([0.0]), in_structure=selector.out_structure),
-                    {
-                        tmpl: regs[tmpl]
-                        * IdentityOperator(in_structure=template_op.blocks[tmpl].in_structure)
-                        for tmpl in template_op.blocks
-                    },
-                ]
-            )
-            logger_info('Built template regularizer')
-            logger_info(f'Template operator input structure: {template_op.in_structure}')
-
-        # Mapmaking operator
-        p: AbstractLinearOperator
-        h: AbstractLinearOperator
-        if config.use_templates:
-            p = BlockDiagonalOperator([preconditioner, template_preconditioner])
-            h = BlockRowOperator([acquisition @ selector.T, template_op])
-            reg = template_reg_op
-        else:
-            p = preconditioner
-            h = acquisition @ selector.T
+        h = acquisition @ selector.T
 
         if config.gaps.treatment != GapTreatment.NESTED:
             M = masker @ inv_noise @ masker
@@ -1244,11 +1064,8 @@ class MLMapmaker(MapMaker):
             logger_info('Set up nested PCG for the noise inverse')
 
         solver = lineax.CG(**config.solver.options)
-        options = {'solver': solver, 'preconditioner': p}
-        if config.use_templates:
-            mapmaking_operator = (h.T @ M @ h + reg).I(**options) @ h.T @ M
-        else:
-            mapmaking_operator = (h.T @ M @ h).I(**options) @ h.T @ M
+        options = {'solver': solver, 'preconditioner': preconditioner}
+        mapmaking_operator = (h.T @ M @ h).I(**options) @ h.T @ M
 
         @jax.jit
         def process(d):  # type: ignore[no-untyped-def]
@@ -1257,10 +1074,7 @@ class MLMapmaker(MapMaker):
         logger_info('Completed setting up the solver')
 
         # Run mapmaking
-        if config.use_templates:
-            rec_map, tmpl_ampl = process(data)
-        else:
-            rec_map = process(data)
+        rec_map = process(data)
         result_map = selector.T(rec_map)
         result_map.i.block_until_ready()
         logger_info('Finished mapmaking computation')
@@ -1284,136 +1098,9 @@ class MLMapmaker(MapMaker):
             and config.weighting.mode != WeightingMode.IDENTITY
         ):
             output['noise_fit'] = noise_model.to_array()
-        if config.use_templates:
-            for key in tmpl_ampl:
-                output[f'template_{key}'] = tmpl_ampl[key]
-                output[f'template_reg_{key}'] = np.array(regs[key])
-            if 'ground' in tmpl_ampl:
-                output['ground_landscape'] = self._ground_landscape
-                output['ground_coverage'] = self._ground_coverage
-                output['ground_map'] = self._ground_selector.T(tmpl_ampl['ground'])
         if config.debug:
             proj_map = (masker @ acquisition)(result_map)
-            if config.use_templates:
-                projs = {
-                    'proj_map': proj_map,
-                    **{
-                        f'proj_{tmpl}': (masker @ template_op.blocks[tmpl])(tmpl_ampl[tmpl])
-                        for tmpl in tmpl_ampl
-                    },
-                }
-            else:
-                projs = {'proj_map': proj_map}
-            output['projs'] = projs
-
-        return output
-
-
-class TwoStepMapmaker(MapMaker):
-    """Class for binned mapmaking with templates, using the two-step estimation method."""
-
-    def __post_init__(self) -> None:
-        super().__post_init__()
-
-        # Validation on config
-        if not self.config.binned:
-            raise ValueError('Two-Step Mapmaker is incompatible with binned=False')
-        if self.config.demodulated:
-            raise ValueError('Two-Step Mapmaker is incompatible with demodulated=True')
-        if not self.config.use_templates:
-            raise ValueError('Two-Step Mapmaker is incompatible with no templates')
-
-    def make_map(self, observation: AbstractGroundObservation[Any]) -> dict[str, Any]:
-        config = self.config
-        logger_info = lambda msg: self.logger.info(f'Two-Step Mapmaker: {msg}')
-
-        # Data and landscape
-        data = jnp.asarray(observation.get_tods(), dtype=config.dtype)
-        data_struct = ShapeDtypeStruct(data.shape, data.dtype)
-        landscape = self.get_landscape(observation)
-
-        # Acquisition (I, Q, U Maps -> TOD)
-        acquisition = self.get_acquisition(observation, landscape=landscape)
-        logger_info('Created acquisition operator')
-
-        # Optional mask for scanning
-        masker = self.get_scanning_mask_projector(observation)
-        logger_info('Created scanning mask operator')
-
-        # Noise
-        noise_model = self.get_or_fit_noise_model(observation)
-        inv_noise = noise_model.inverse_operator(data_struct)
-        logger_info('Created inverse noise covariance operator')
-
-        # System matrix
-        system = BJPreconditioner.create(acquisition.T @ masker @ inv_noise @ masker @ acquisition)
-        logger_info('Created system matrix')
-
-        # Map pixel selection
-        blocks = system.blocks
-        selector = self.get_pixel_selector(blocks, landscape)
-        logger_info(
-            f'Selected {prod(selector.out_structure.shape)}\
-                            /{prod(landscape.shape)} pixels'
-        )
-
-        # Templates
-        template_op = self.get_template_operator(observation)
-        logger_info('Built template operators')
-
-        # Define operators
-        system_inv = selector @ system.inverse() @ selector.T
-        A = acquisition @ selector.T
-        M = inv_noise
-        mp = masker
-        FA = M - M @ mp @ A @ system_inv @ A.T @ mp @ M
-
-        solver = lineax.CG(**config.solver.options)
-        with Config(solver=solver):
-            template_estimator = (
-                (template_op.T @ mp @ FA @ mp @ template_op).I @ template_op.T @ mp @ FA @ mp
-            )
-        map_estimator = system_inv @ A.T @ mp @ M @ mp
-
-        @jax.jit
-        def process(d):  # type: ignore[no-untyped-def]
-            x = template_estimator(d)  # Template amplitude estimates
-            s = map_estimator(d - template_op(x))  # Map estimates
-            return s, x
-
-        logger_info('Completed setting up the solver')
-
-        # Run mapmaking
-        rec_map, tmpl_ampl = process(data)
-        result_map = selector.T(rec_map)
-        result_map.i.block_until_ready()
-        logger_info('Finished mapmaking computation')
-
-        # Format output and compute auxiliary data
-        final_map = np.array([result_map.i, result_map.q, result_map.u])
-
-        output = {'map': final_map, 'weights': blocks}
-        for key in tmpl_ampl:
-            output[f'template_{key}'] = tmpl_ampl[key]
-        if isinstance(landscape, WCSLandscape):
-            output['wcs'] = landscape.to_wcs()
-        elif isinstance(landscape, AstropyWCSLandscape):
-            output['wcs'] = landscape.wcs
-        if (
-            config.weighting.source == NoiseSource.FIT
-            and config.weighting.mode != WeightingMode.IDENTITY
-        ):
-            output['noise_fit'] = noise_model.to_array()
-        if config.debug:
-            proj_map = (mp @ acquisition)(result_map)
-            projs = {
-                'proj_map': proj_map,
-                **{
-                    f'proj_{tmpl}': (mp @ template_op.blocks[tmpl])(tmpl_ampl[tmpl])
-                    for tmpl in tmpl_ampl
-                },
-            }
-            output['projs'] = projs
+            output['projs'] = {'proj_map': proj_map}
 
         return output
 
@@ -1446,9 +1133,7 @@ class ATOPMapMaker(MapMaker):
         logger_info('Created acquisition operator')
 
         # ATOP projector
-        atop_projector = templates.ATOPProjectionOperator(
-            self.config.atop_tau, in_structure=data_struct
-        )
+        atop_projector = ATOPProjectionOperator(self.config.atop_tau, in_structure=data_struct)
 
         # Optional mask for scanning
         masker = self.get_mask_projector(observation)

--- a/src/furax/mapmaking/mapmaker.py
+++ b/src/furax/mapmaking/mapmaker.py
@@ -606,6 +606,8 @@ class MapMaker:
                 'solver ignores the off-diagonal pixel coupling that interpolation introduces and '
                 'would return a biased map. Use the ML mapmaker (method=ML) instead.'
             )
+        if self.config.use_templates:
+            raise NotImplementedError(f'{type(self).__name__} does not support templates.')
 
     @abstractmethod
     def make_map(self, observation: AbstractGroundObservation[Any]) -> dict[str, Any]: ...

--- a/src/furax/mapmaking/templates.py
+++ b/src/furax/mapmaking/templates.py
@@ -1,19 +1,19 @@
 """Template operators for fitting structured nuisance signals out of the data.
 
-A template turns a small set of per-detector amplitudes into a time stream, so the
-mapmaker can fit and remove unwanted but predictable signals (slow drifts,
-scan-synchronous pickup, HWP-synchronous lines, T-to-P leakage).
+A template turns a small set of per-detector amplitudes into a time stream, so the mapmaker can fit
+and remove unwanted but predictable signals (slow drifts, scan-synchronous pickup, HWP-synchronous
+lines, T-to-P leakage).
 
-The building block is a [`Basis`][]: a small set of functions of time (Legendre polynomials,
-HWP harmonics, ...). Going from amplitudes to a signal is ``expand``; the reverse is
-``project``. A [`TemplateOperator`][] combines every enabled template into one operator, keyed
-by template name, giving each detector its own amplitudes;
-[`StokesTemplateOperator`][] does the same for a [`Stokes`][] TOD, one amplitude set per leg.
+The building block is a [`Basis`][]: a small set of functions of time (Legendre polynomials, HWP
+harmonics, ...). Going from amplitudes to a signal is `expand`; the reverse is `project`. A
+[`TemplateOperator`][] combines every enabled template into one operator, keyed by template name,
+giving each detector its own amplitudes; [`StokesTemplateOperator`][] does the same for a
+[`Stokes`][] TOD, one amplitude set per leg.
 
 A few [`Basis`][] flavours trade memory for structure:
 
 - [`TensorBasis`][]: stores every basis function value directly, as a dense array
-  (optionally on a coarser time grid, ``q > 1``, to trade resolution for memory).
+  (optionally on a coarser time grid, `q > 1`, to trade resolution for memory).
 - [`KroneckerBasis`][]: a product of independent factors (e.g. azimuth x HWP), stored
   factored to save memory.
 - [`SegmentedBasis`][]: each sample belongs to one segment (e.g. one scan interval),
@@ -21,9 +21,9 @@ A few [`Basis`][] flavours trade memory for structure:
 - [`WindowedBasis`][]: each sample reads a fixed window of overlapping blocks, the
   overlapping generalisation of [`SegmentedBasis`][].
 
-A basis is normally shared by every detector. When the functions differ from detector to
-detector, as for the T-to-P leakage template, [`Basis.per_detector_stack`][] stacks one basis per
-detector into a single [`Basis`][] of any flavour.
+A basis is normally shared by every detector. When the functions differ from detector to detector,
+as for the T-to-P leakage template, [`Basis.per_detector_stack`][] stacks one basis per detector
+into a single [`Basis`][] of any flavour.
 """
 
 from abc import abstractmethod
@@ -79,11 +79,10 @@ StokesLeg = Literal['i', 'q', 'u', 'v']
 class Basis(AbstractLinearOperator):
     """A set of template functions of time used to model a structured signal.
 
-    The basis functions `b_k` are each evaluated at the same `n_points` time samples.
-    Conceptually, we can think of them as columns of a matrix `B`. The modelled signal
-    is then a linear combination `s = B a`, i.e. `s(t) = Σ_k a_k b_k(t)` where each
-    `a_k` is the amplitude of the template function `b_k`. The index `k` may be multi
-    dimensional.
+    The basis functions `b_k` are each evaluated at the same `n_points` time samples. Conceptually,
+    we can think of them as columns of a matrix `B`. The modelled signal is then a linear
+    combination `s = B a`, i.e. `s(t) = Σ_k a_k b_k(t)` where each `a_k` is the amplitude of the
+    template function `b_k`. The index `k` may be multi dimensional.
 
     Two main operations:
 
@@ -105,15 +104,15 @@ class Basis(AbstractLinearOperator):
         """Dtype of the stored basis values."""
 
     def __post_init__(self) -> None:
-        # ``in_structure`` is derived, never passed: it can then never disagree with the arrays.
+        # `in_structure` is derived, never passed: it can then never disagree with the arrays.
         if self.in_structure is not None:
             raise ValueError('in_structure is derived from the basis arrays; do not pass it')
-        # ``per_detector_stack`` marks its result after unflattening, which does not run this,
-        # so reaching here with the marker set means a stack built by hand: ``shape`` would
+        # `per_detector_stack` marks its result after unflattening, which does not run this,
+        # so reaching here with the marker set means a stack built by hand: `shape` would
         # describe one detector while the arrays hold many.
         if self.per_detector:
             raise ValueError('per_detector is set by per_detector_stack, not by the constructor')
-        # Construction is the only caller, so ``_index_shape`` always sees one detector's arrays.
+        # Construction is the only caller, so `_index_shape` always sees one detector's arrays.
         object.__setattr__(
             self, 'in_structure', ShapeDtypeStruct(self._index_shape, self._array_dtype)
         )
@@ -124,14 +123,14 @@ class Basis(AbstractLinearOperator):
         """One basis per detector, stacked into a single basis.
 
         Use this for a template whose functions differ from detector to detector, such as the
-        temperature-to-polarization leakage template, whose basis is each detector's own
-        temperature stream. Available on every flavour.
+        temperature-to-polarization leakage template, whose basis is each detector's own temperature
+        stream. Available on every flavour.
 
-        Call it as you would the constructor, with every array argument carrying a leading
-        detector axis. All detectors then share one index shape, dtype and static metadata,
-        read off detector 0, and differ only in their array values. The result keeps that
-        single-detector metadata, so `shape` and `in_structure` still describe one detector's
-        amplitudes, which is what the template operators map over.
+        Call it as you would the constructor, with every array argument carrying a leading detector
+        axis. All detectors then share one index shape, dtype and static metadata, read off detector
+        0, and differ only in their array values. The result keeps that single-detector metadata, so
+        `shape` and `in_structure` still describe one detector's amplitudes, which is what the
+        template operators map over.
 
         Args:
             attributes: The constructor arguments. Array arguments carry a leading detector
@@ -213,17 +212,17 @@ class _BasisTranspose(TransposeOperator):
 class TensorBasis(Basis):
     """Dense basis: the matrix `B` is stored explicitly.
 
-    Holds `values[k, t] = b_k(t)` as a single dense array, with no assumed structure.
-    When `B` factorises over independent variables, `KroneckerBasis`
-    represents the same map with less memory; when each sample belongs to one interval,
-    `SegmentedBasis` avoids storing the mostly-zero per-interval blocks.
+    Holds `values[k, t] = b_k(t)` as a single dense array, with no assumed structure. When `B`
+    factorises over independent variables, `KroneckerBasis` represents the same map with less
+    memory; when each sample belongs to one interval, `SegmentedBasis` avoids storing the
+    mostly-zero per-interval blocks.
 
-    With `q > 1` the values are stored on a `q`-times coarser time grid to save memory:
-    synthesis (`expand`) holds each coarse value over its block of `q` samples and analysis
-    (`project`) sums each block back down. The two are exact transposes. Hold/block-sum is a
-    zeroth-order resampler, exact only for content well below the coarse-grid Nyquist
-    frequency `sample_rate / 2q`, so choose `q` to keep that above the template's band edge.
-    The default `q = 1` is the plain dense basis with no resampling.
+    With `q > 1` the values are stored on a `q`-times coarser time grid to save memory: synthesis
+    (`expand`) holds each coarse value over its block of `q` samples and analysis (`project`) sums
+    each block back down. The two are exact transposes. Hold/block-sum is a zeroth-order resampler,
+    exact only for content well below the coarse-grid Nyquist frequency `sample_rate / 2q`, so
+    choose `q` to keep that above the template's band edge. The default `q = 1` is the plain dense
+    basis with no resampling.
     """
 
     values: Float[Array, '*shape samp_dec']
@@ -286,11 +285,11 @@ class TensorBasis(Basis):
 class KroneckerBasis(Basis):
     """Basis whose functions factorise over independent variables.
 
-    Built from factor matrices `F_i` (e.g. an azimuth-polynomial set and an HWP-harmonic
-    set), whose rows are the factor's functions of time. The basis function for
-    multi-index `k = (k_0, ...)` is the elementwise product `b_k(t) = Π_i F_i[k_i, t]`.
-    Equivalent to a `TensorBasis` holding the full outer product, but kept factored:
-    memory scales as `Σ_i d_i` rather than `Π_i d_i` columns of length `n_points`.
+    Built from factor matrices `F_i` (e.g. an azimuth-polynomial set and an HWP-harmonic set), whose
+    rows are the factor's functions of time. The basis function for multi-index `k = (k_0, ...)` is
+    the elementwise product `b_k(t) = Π_i F_i[k_i, t]`. Equivalent to a `TensorBasis` holding the
+    full outer product, but kept factored: memory scales as `Σ_i d_i` rather than `Π_i d_i` columns
+    of length `n_points`.
 
     Use when the basis cleanly separates over independent variables.
     """
@@ -330,18 +329,18 @@ class KroneckerBasis(Basis):
 class SegmentedBasis(Basis):
     """Basis partitioned into segments, each sample belonging to exactly one.
 
-    The amplitude index is `(j, k)` = segment `j` × shared sub-basis function `k`, with
-    `b_{j,k}(t) = [segment(t) = j] · v_k(t)`. Since every sample lies in a single
-    segment, only that segment's amplitudes contribute to it.
+    The amplitude index is `(j, k)` = segment `j` × shared sub-basis function `k`, with `b_{j,k}(t)
+    = [segment(t) = j] · v_k(t)`. Since every sample lies in a single segment, only that segment's
+    amplitudes contribute to it.
 
-    Stored sparsely as one segment id per sample plus one shared table `v_k(t)`, instead
-    of the equivalent dense per-segment array (segments × functions × samples) that would
-    be almost all zeros. The right choice when the segments form a partition (e.g. per-scan-interval
-    Legendre polynomials); `KroneckerBasis` does not help here, as it assumes every
-    factor is dense at every sample.
+    Stored sparsely as one segment id per sample plus one shared table `v_k(t)`, instead of the
+    equivalent dense per-segment array (segments × functions × samples) that would be almost all
+    zeros. The right choice when the segments form a partition (e.g. per-scan-interval Legendre
+    polynomials); `KroneckerBasis` does not help here, as it assumes every factor is dense at every
+    sample.
 
-    Samples in no segment must have their `values` column pre-zeroed by the builder;
-    their segment id is then irrelevant.
+    Samples in no segment must have their `values` column pre-zeroed by the builder; their segment
+    id is then irrelevant.
     """
 
     segment: Int[Array, ' samp']
@@ -378,17 +377,17 @@ class WindowedBasis(Basis):
 
     The amplitude index is a pair (block, sub-basis function). Every sample falls under a fixed
     number of consecutive blocks, weighting each by how far the sample sits inside it and each
-    sub-basis function by its value there. The typical case is a cubic B-spline, where every
-    sample lies under four consecutive knots.
+    sub-basis function by its value there. The typical case is a cubic B-spline, where every sample
+    lies under four consecutive knots.
 
-    Stored sparsely as, per sample, the index of its first block, the window weights, and the
-    shared sub-basis values, instead of the equivalent dense `TensorBasis` whose columns would
-    be almost all zeros. The right choice when blocks overlap by a fixed amount;
-    `SegmentedBasis` is the non-overlapping single-block-per-sample special case, kept separate
-    to avoid storing its trivial unit window.
+    Stored sparsely as, per sample, the index of its first block, the window weights, and the shared
+    sub-basis values, instead of the equivalent dense `TensorBasis` whose columns would be almost
+    all zeros. The right choice when blocks overlap by a fixed amount; `SegmentedBasis` is the
+    non-overlapping single-block-per-sample special case, kept separate to avoid storing its trivial
+    unit window.
 
-    The builder must keep every window inside the block range, pre-zeroing the weights of any
-    sample whose window overhangs the ends.
+    The builder must keep every window inside the block range, pre-zeroing the weights of any sample
+    whose window overhangs the ends.
     """
 
     offset: Int[Array, ' samp']
@@ -447,11 +446,10 @@ def _bin_weights(
 ) -> Float[Array, '{n_bins} samp']:
     """Assign each sample to a bin of `x`.
 
-    Splits the range of `x` into `n_bins` equal bins. Entry `[j, s]` is how much sample
-    `s` belongs to bin `j`. With `interpolate=False` this is one-hot: 1 for the bin the
-    sample falls in, 0 elsewhere. With `interpolate=True` a sample near a bin edge is
-    shared with its neighbour (triangular weights, or sin² hats if `smooth`), each
-    sample's weights summing to 1.
+    Splits the range of `x` into `n_bins` equal bins. Entry `[j, s]` is how much sample `s` belongs
+    to bin `j`. With `interpolate=False` this is one-hot: 1 for the bin the sample falls in, 0
+    elsewhere. With `interpolate=True` a sample near a bin edge is shared with its neighbour
+    (triangular weights, or sin² hats if `smooth`), each sample's weights summing to 1.
 
     Each row is then one basis function of a binned template (a bin's time profile).
     """
@@ -467,7 +465,7 @@ def _bin_weights(
         return bins.astype(dtype)
 
     # Soft assignment: triangular weights peaking at each bin centre, falling
-    # linearly to zero one bin-width (``delta``) away. Shape (n_bins, n_samps).
+    # linearly to zero one bin-width (`delta`) away. Shape (n_bins, n_samps).
     centres = 0.5 * (edges[:-1] + edges[1:])
     delta = (hi - lo) / n_bins
     triangular = jnp.clip(1 - jnp.abs(x[None, :] - centres[:, None]) / delta, min=0)
@@ -522,8 +520,8 @@ def _harmonics(
 
     Optionally prepended with a constant (DC) row when `dc` is set.
 
-    `harmonics` is either an int `n` (the harmonics `1..n`) or an explicit sequence of
-    harmonic orders.
+    `harmonics` is either an int `n` (the harmonics `1..n`) or an explicit sequence of harmonic
+    orders.
     """
     h = jnp.arange(1, harmonics + 1) if isinstance(harmonics, int) else jnp.asarray(harmonics)
     sines = jnp.sin(h[:, None] * angles[None, :])
@@ -541,13 +539,12 @@ def polynomial_basis(
 ) -> Basis:
     """Basis for a polynomial drift template, one polynomial per scanning interval.
 
-    Each sample belongs to one interval and is fitted with Legendre orders
-    `0..max_poly_order` over that interval.
+    Each sample belongs to one interval and is fitted with Legendre orders `0..max_poly_order` over
+    that interval.
 
-    Assumes `intervals` are sorted, non-overlapping `[start, end)` rows. Samples in
-    gaps or past the last interval get a zero basis column. `valid_mask` optionally
-    zeroes flagged samples (1 = keep, 0 = drop) so they neither carry template
-    signal nor constrain the fitted amplitudes.
+    Assumes `intervals` are sorted, non-overlapping `[start, end)` rows. Samples in gaps or past the
+    last interval get a zero basis column. `valid_mask` optionally zeroes flagged samples (1 = keep,
+    0 = drop) so they neither carry template signal nor constrain the fitted amplitudes.
     """
     n_samps = times.size
     n_intervals = intervals.shape[0]
@@ -556,7 +553,7 @@ def polynomial_basis(
 
     s = jnp.arange(n_samps)
     # interval id per sample: last interval whose start <= s (intervals sorted),
-    # clamped into range. Gaps/out-of-range are caught by ``in_range`` below.
+    # clamped into range. Gaps/out-of-range are caught by `in_range` below.
     segment = jnp.clip(jnp.searchsorted(starts, s, side='right') - 1, 0, n_intervals - 1)
     seg_start = starts[segment]
     seg_end = ends[segment]
@@ -565,7 +562,7 @@ def polynomial_basis(
     t0 = times[seg_start]
     span = jnp.where(seg_end > seg_start + 1, times[seg_end - 1] - t0, 1.0)
     # rescale each sample to [-1, 1] within its own interval; out-of-range
-    # samples sit at 0 and are zeroed by ``in_range`` below.
+    # samples sit at 0 and are zeroed by `in_range` below.
     u = jnp.where(in_range, -1.0 + 2.0 * (times - t0) / span, 0.0)
     legs = _legendre_values(u, 0, max_poly_order, dtype)  # (k, n_samps)
     legs = legs * in_range[None, :]
@@ -584,20 +581,19 @@ def t2p_basis(
 ) -> Basis:
     """Per-detector basis for a temperature-to-polarization leakage template.
 
-    Each detector's basis is just its own temperature stream, so fitting one amplitude
-    per detector estimates how much temperature leaks into its polarization.
+    Each detector's basis is just its own temperature stream, so fitting one amplitude per detector
+    estimates how much temperature leaks into its polarization.
 
-    `fit_band=(f0, f1)` restricts the temperature basis to that frequency band (Hz), so
-    the leakage is both estimated and removed only there, keeping the template a clean
-    linear operator.
+    `fit_band=(f0, f1)` restricts the temperature basis to that frequency band (Hz), so the leakage
+    is both estimated and removed only there, keeping the template a clean linear operator.
 
     `decimation_factor=q` stores the basis on a `q`-times coarser grid to cut memory; the
-    coarse-grid Nyquist frequency `sample_rate / 2q` must stay above `f1`. As a rule of
-    thumb keep it at a few times `f1` (`q ≲ sample_rate / 6·f1`): the fractional error on
-    the fitted amplitude grows like `(f1 / (sample_rate / 2q))²`.
+    coarse-grid Nyquist frequency `sample_rate / 2q` must stay above `f1`. As a rule of thumb keep
+    it at a few times `f1` (`q ≲ sample_rate / 6·f1`): the fractional error on the fitted amplitude
+    grows like `(f1 / (sample_rate / 2q))²`.
 
-    Assumes `temperature` is already deglitched/gap-filled upstream: a glitch left in it
-    would smear across the band and bias the fitted amplitude.
+    Assumes `temperature` is already deglitched/gap-filled upstream: a glitch left in it would smear
+    across the band and bias the fitted amplitude.
     """
     t = temperature
     if fit_band is not None:
@@ -609,8 +605,8 @@ def t2p_basis(
     q = decimation_factor
     if q > 1:
         # Block-average onto a q-times coarser grid: pad the tail to a whole block,
-        # reshape (..., n_dec, q) and mean. ``TensorBasis`` hold-upsamples back to
-        # ``n_full`` in synthesis (band-limits above sample_rate / 2q).
+        # reshape (..., n_dec, q) and mean. `TensorBasis` hold-upsamples back to
+        # `n_full` in synthesis (band-limits above sample_rate / 2q).
         n_dec = -(-n_full // q)  # ceil
         pad = n_dec * q - n_full
         tp = jnp.pad(t, [(0, 0), (0, pad)])
@@ -693,9 +689,9 @@ def spline_hwp_synchronous_basis(
 ) -> Basis:
     """Spline-based HWP synchronous basis.
 
-    A cubic B-spline models the slowly time-varying amplitude of the HWP-synchronous
-    signal: knot `j` carries a `(sin kχ, cos kχ)` pair for each harmonic `k`, so the
-    amplitudes have shape `(K, 2*n_harmonics)` with `K = n_knots + 2`.
+    A cubic B-spline models the slowly time-varying amplitude of the HWP-synchronous signal: knot
+    `j` carries a `(sin kχ, cos kχ)` pair for each harmonic `k`, so the amplitudes have shape `(K,
+    2*n_harmonics)` with `K = n_knots + 2`.
     """
     offset, weights = bspline.spline_window(times, n_knots)  # weights (samp, 4)
     sub_values = _harmonics(hwp_angles, harmonics, dtype, dc=False).astype(dtype)
@@ -711,7 +707,7 @@ class AbstractTemplateOperator(AbstractLinearOperator):
     n_dets: int = field(metadata={'static': True})
 
     def __post_init__(self) -> None:
-        # ``in_structure`` is derived, never passed: it can then never disagree with the bases.
+        # `in_structure` is derived, never passed: it can then never disagree with the bases.
         if self.in_structure is not None:
             raise ValueError('in_structure is derived from the bases; do not pass it')
         object.__setattr__(self, 'in_structure', self._amplitude_structure())
@@ -720,7 +716,7 @@ class AbstractTemplateOperator(AbstractLinearOperator):
     # ---- amplitude side -------------------------------------------------------------------------
     @abstractmethod
     def _amplitude_structure(self) -> PyTree[jax.ShapeDtypeStruct]:
-        """``bases`` with each basis replaced by the amplitudes it takes (``_amplitude_leaf``)."""
+        """`bases` with each basis replaced by the amplitudes it takes (`_amplitude_leaf`)."""
 
     def _amplitude_leaf(self, basis: Basis) -> jax.ShapeDtypeStruct:
         return jax.ShapeDtypeStruct((self.n_dets, *basis.shape), basis.dtype)
@@ -758,16 +754,16 @@ class AbstractTemplateOperator(AbstractLinearOperator):
     # ---- adjoint --------------------------------------------------------------------------------
     @abstractmethod
     def project(self, tod: PyTree[Array]) -> PyTree[Array]:
-        """Every template's amplitudes, from a TOD. This is the transpose's ``mv``."""
+        """Every template's amplitudes, from a TOD. This is the transpose's `mv`."""
 
     def transpose(self) -> AbstractLinearOperator:
         return _TemplateOperatorTranspose(self)
 
 
 class TemplateOperator(AbstractTemplateOperator):
-    """Templates over a TOD with no Stokes axis, producing one ``(n_dets, n_points)`` array.
+    """Templates over a TOD with no Stokes axis, producing one `(n_dets, n_points)` array.
 
-    Each template contributes ``(n_dets, *basis.shape)`` amplitudes, and the TOD is their summed
+    Each template contributes `(n_dets, *basis.shape)` amplitudes, and the TOD is their summed
     expansion.
     """
 
@@ -794,11 +790,11 @@ class TemplateOperator(AbstractTemplateOperator):
 
 
 class StokesTemplateOperator(AbstractTemplateOperator):
-    """Templates over a [`Stokes`][] TOD, each leg one ``(n_dets, n_points)`` array.
+    """Templates over a [`Stokes`][] TOD, each leg one `(n_dets, n_points)` array.
 
-    A Stokes-valued TOD carries one differently filtered stream per leg (as demodulation
-    produces), so a template fits an independent set of amplitudes on each leg it covers. It need
-    not cover them all: temperature-to-polarization leakage is fitted on Q and U only.
+    A Stokes-valued TOD carries one differently filtered stream per leg (as demodulation produces),
+    so a template fits an independent set of amplitudes on each leg it covers. It need not cover
+    them all: temperature-to-polarization leakage is fitted on Q and U only.
 
     Raises:
         TypeError: If a template is given as a bare basis rather than keyed by leg.
@@ -809,7 +805,7 @@ class StokesTemplateOperator(AbstractTemplateOperator):
     stokes: ValidStokesLiteral = field(metadata={'static': True})
 
     def __post_init__(self) -> None:
-        # ``stokes`` declares the leg axis: every template must be keyed by a subset of it.
+        # `stokes` declares the leg axis: every template must be keyed by a subset of it.
         for name, legged in self.bases.items():
             if isinstance(legged, Basis):
                 msg = f'template {name!r} needs one basis per Stokes leg of {self.stokes!r}'
@@ -870,10 +866,9 @@ class _TemplateOperatorTranspose(TransposeOperator):
 class GroundTemplateOperator(AbstractLinearOperator):
     """Operator for ground signal templates.
 
-    The template amplitudes form a two-dimensional (elevation, azimuth) IQU map of the
-    ground observed that is shared across detectors for the observation range.
-    This class only contains a factory method.
-    All argument angles should be provided in radians.
+    The template amplitudes form a two-dimensional (elevation, azimuth) IQU map of the ground
+    observed that is shared across detectors for the observation range. This class only contains a
+    factory method. All argument angles should be provided in radians.
     """
 
     @classmethod

--- a/src/furax/mapmaking/templates.py
+++ b/src/furax/mapmaking/templates.py
@@ -1,39 +1,42 @@
 """Template operators for fitting structured nuisance signals out of the data.
 
-A template turns a small set of per-detector amplitudes into a time stream, so
-the mapmaker can fit and remove unwanted but predictable signals (slow drifts,
+A template turns a small set of per-detector amplitudes into a time stream, so the
+mapmaker can fit and remove unwanted but predictable signals (slow drifts,
 scan-synchronous pickup, HWP-synchronous lines, T-to-P leakage).
 
-The building block is a `Basis`: a small set of functions of time (Legendre
-polynomials, HWP harmonics, ...). Going from amplitudes to a signal is `expand`;
-the reverse is `project`. A `PerDetectorTemplate` then gives every detector its
-own copy (or its own basis), so each detector fits its own amplitudes.
+The building block is a [`Basis`][]: a small set of functions of time (Legendre polynomials,
+HWP harmonics, ...). Going from amplitudes to a signal is ``expand``; the reverse is
+``project``. A [`TemplateOperator`][] combines every enabled template into one operator, keyed
+by template name, giving each detector its own amplitudes;
+[`StokesTemplateOperator`][] does the same for a [`Stokes`][] TOD, one amplitude set per leg.
 
-A few `Basis` flavours trade memory for structure:
-- `TensorBasis`: stores every basis function value directly, as a dense array
-  (optionally on a coarser time grid, `q > 1`, to trade resolution for memory).
-- `KroneckerBasis`: a product of independent factors (e.g. azimuth x HWP), stored
+A few [`Basis`][] flavours trade memory for structure:
+
+- [`TensorBasis`][]: stores every basis function value directly, as a dense array
+  (optionally on a coarser time grid, ``q > 1``, to trade resolution for memory).
+- [`KroneckerBasis`][]: a product of independent factors (e.g. azimuth x HWP), stored
   factored to save memory.
-- `SegmentedBasis`: each sample belongs to one segment (e.g. one scan interval),
+- [`SegmentedBasis`][]: each sample belongs to one segment (e.g. one scan interval),
   stored sparsely instead of as a mostly-zero dense array.
-- `WindowedBasis`: each sample reads a fixed window of overlapping blocks, the
-  overlapping generalisation of `SegmentedBasis`.
+- [`WindowedBasis`][]: each sample reads a fixed window of overlapping blocks, the
+  overlapping generalisation of [`SegmentedBasis`][].
 
-Build several templates and combine them by wrapping each in a
-`PerDetectorTemplate` and stacking with `BlockRowOperator`.
+A basis is normally shared by every detector. When the functions differ from detector to
+detector, as for the T-to-P leakage template, [`Basis.per_detector_stack`][] stacks one basis per
+detector into a single [`Basis`][] of any flavour.
 """
 
 from abc import abstractmethod
 from collections.abc import Sequence
-from dataclasses import field
+from dataclasses import field, fields
 from itertools import chain
 from math import prod
-from typing import Any, Self
+from typing import Any, Literal, Self, cast
 
 import jax
+import jax.numpy as jnp
 import numpy as np
 from jax import Array, ShapeDtypeStruct
-from jax import numpy as jnp
 from jaxtyping import DTypeLike, Float, Int, PyTree
 
 from furax import AbstractLinearOperator, square
@@ -42,9 +45,35 @@ from furax.math import bspline, quaternion
 from furax.obs import HWPOperator, LinearPolarizerOperator
 from furax.obs.landscapes import HorizonLandscape
 from furax.obs.pointing import PointingOperator
-from furax.obs.stokes import ValidStokesLiteral
+from furax.obs.stokes import Stokes, ValidStokesLiteral
 
 from .config import BinsConfig, PolynomialOrders
+
+__all__ = [
+    'StokesLeg',
+    'Basis',
+    'TensorBasis',
+    'KroneckerBasis',
+    'SegmentedBasis',
+    'WindowedBasis',
+    'polynomial_basis',
+    'temperature_basis',
+    'scan_synchronous_basis',
+    'binaz_synchronous_basis',
+    'hwp_synchronous_basis',
+    'azhwp_synchronous_basis',
+    'binazhwp_synchronous_basis',
+    'bspline_hwpss_basis',
+    'AbstractTemplateOperator',
+    'TemplateOperator',
+    'StokesTemplateOperator',
+    'GroundTemplateOperator',
+    'ATOPProjectionOperator',
+]
+
+
+StokesLeg = Literal['i', 'q', 'u', 'v']
+"""One Stokes component, lower case."""
 
 
 class Basis(AbstractLinearOperator):
@@ -62,9 +91,83 @@ class Basis(AbstractLinearOperator):
     - `project` (analysis, signal to amplitudes): `a = B.T(s)`.
     """
 
+    per_detector: bool = field(metadata={'static': True}, default=False, kw_only=True)
+    """Whether the stored arrays carry a leading detector axis."""
+
+    @property
+    @abstractmethod
+    def _index_shape(self) -> tuple[int, ...]:
+        """Single-detector amplitude index shape, read off the stored arrays."""
+
+    @property
+    @abstractmethod
+    def _array_dtype(self) -> DTypeLike:
+        """Dtype of the stored basis values."""
+
+    def __post_init__(self) -> None:
+        # ``in_structure`` is derived, never passed: it can then never disagree with the arrays.
+        if self.in_structure is not None:
+            raise ValueError('in_structure is derived from the basis arrays; do not pass it')
+        # ``per_detector_stack`` marks its result after unflattening, which does not run this,
+        # so reaching here with the marker set means a stack built by hand: ``shape`` would
+        # describe one detector while the arrays hold many.
+        if self.per_detector:
+            raise ValueError('per_detector is set by per_detector_stack, not by the constructor')
+        # Construction is the only caller, so ``_index_shape`` always sees one detector's arrays.
+        object.__setattr__(
+            self, 'in_structure', ShapeDtypeStruct(self._index_shape, self._array_dtype)
+        )
+        super().__post_init__()
+
+    @classmethod
+    def per_detector_stack(cls, **attributes: Any) -> Self:
+        """One basis per detector, stacked into a single basis.
+
+        Use this for a template whose functions differ from detector to detector, such as the
+        temperature-to-polarization leakage template, whose basis is each detector's own
+        temperature stream. Available on every flavour.
+
+        Call it as you would the constructor, with every array argument carrying a leading
+        detector axis. All detectors then share one index shape, dtype and static metadata,
+        read off detector 0, and differ only in their array values. The result keeps that
+        single-detector metadata, so `shape` and `in_structure` still describe one detector's
+        amplitudes, which is what the template operators map over.
+
+        Args:
+            attributes: The constructor arguments. Array arguments carry a leading detector
+                axis; static ones (`q`, `n_segments`, ...) are passed as usual.
+
+        Returns:
+            A basis whose arrays carry a leading detector axis.
+
+        Raises:
+            ValueError: If an array argument is missing, or they disagree on the detector count.
+
+        Examples:
+            >>> temperature = jnp.arange(6.0).reshape(3, 2)  # 3 detectors, 2 samples
+            >>> basis = TensorBasis.per_detector_stack(values=temperature[:, None])
+            >>> basis.shape, basis.values.shape, basis.per_detector
+            ((1,), (3, 1, 2), True)
+        """
+        array_names = [f.name for f in fields(cls) if not f.metadata.get('static', False)]
+        if missing := [name for name in array_names if name not in attributes]:
+            raise ValueError(f'{cls.__name__} needs a detector-stacked {", ".join(missing)}')
+
+        stacked = [attributes[name] for name in array_names]
+        if len(n_dets := {leaf.shape[0] for leaf in jax.tree.leaves(stacked)}) != 1:
+            raise ValueError(f'detector axes disagree: {sorted(n_dets)}')
+
+        # Detector 0 fixes the metadata; unflatten then carries it over to the stack untouched,
+        # which is the point: the single-detector index shape must survive the stacking.
+        first = lambda x: jax.tree.map(lambda leaf: leaf[0], x)
+        proto = cls(**{k: first(v) if k in array_names else v for k, v in attributes.items()})
+        basis: Self = jax.tree.unflatten(jax.tree.structure(proto), jax.tree.leaves(stacked))
+        object.__setattr__(basis, 'per_detector', True)
+        return basis
+
     @property
     def shape(self) -> tuple[int, ...]:
-        """Shape of the basis index."""
+        """Shape of the basis index, for a single detector."""
         return self.in_structure.shape  # type: ignore[no-any-return]
 
     @property
@@ -127,7 +230,18 @@ class TensorBasis(Basis):
     q: int = field(metadata={'static': True}, default=1)
     n_full: int = field(metadata={'static': True}, default=0)
 
+    @property
+    def _index_shape(self) -> tuple[int, ...]:
+        return self.values.shape[:-1]
+
+    @property
+    def _array_dtype(self) -> DTypeLike:
+        return self.values.dtype
+
     def __post_init__(self) -> None:
+        if self.n_full == 0:
+            # q == 1: the stored grid is already the full grid.
+            object.__setattr__(self, 'n_full', self.values.shape[-1])
         super().__post_init__()
         if self.q < 1:
             raise ValueError(f'q must be >= 1, got {self.q}.')
@@ -135,24 +249,6 @@ class TensorBasis(Basis):
         # the coarse grid must be the q-block count covering n_full, i.e. n_dec = ceil(n_full / q).
         if not (n_dec - 1) * self.q < self.n_full <= n_dec * self.q:
             raise ValueError(f'n_dec={n_dec} inconsistent with n_full={self.n_full}, q={self.q}.')
-
-    @classmethod
-    def create(
-        cls,
-        values: Float[Array, '*shape samp_dec'],
-        q: int = 1,
-        n_full: int | None = None,
-    ) -> Self:
-        shape = values.shape[:-1]
-        if n_full is None:
-            # q == 1: the stored grid is already the full grid.
-            n_full = values.shape[-1]
-        return cls(
-            values=values,
-            q=q,
-            n_full=n_full,
-            in_structure=ShapeDtypeStruct(shape, values.dtype),
-        )
 
     @property
     def n_points(self) -> int:
@@ -201,14 +297,13 @@ class KroneckerBasis(Basis):
 
     factors: tuple[Float[Array, 'd samp'], ...]
 
-    @classmethod
-    def create(cls, factors: tuple[Float[Array, 'd samp'], ...]) -> Self:
-        shape = tuple(f.shape[0] for f in factors)
-        dtype = factors[0].dtype
-        return cls(
-            factors=factors,
-            in_structure=ShapeDtypeStruct(shape, dtype),
-        )
+    @property
+    def _index_shape(self) -> tuple[int, ...]:
+        return tuple(f.shape[0] for f in self.factors)
+
+    @property
+    def _array_dtype(self) -> DTypeLike:
+        return self.factors[0].dtype
 
     @property
     def n_points(self) -> int:
@@ -251,20 +346,15 @@ class SegmentedBasis(Basis):
 
     segment: Int[Array, ' samp']
     values: Float[Array, 'k samp']
+    n_segments: int = field(metadata={'static': True})
 
-    @classmethod
-    def create(
-        cls,
-        segment: Int[Array, ' samp'],
-        values: Float[Array, 'k samp'],
-        n_segments: int,
-    ) -> Self:
-        k = values.shape[0]
-        return cls(
-            segment=segment,
-            values=values,
-            in_structure=ShapeDtypeStruct((n_segments, k), values.dtype),
-        )
+    @property
+    def _index_shape(self) -> tuple[int, ...]:
+        return (self.n_segments, self.values.shape[0])
+
+    @property
+    def _array_dtype(self) -> DTypeLike:
+        return self.values.dtype
 
     @property
     def n_points(self) -> int:
@@ -304,34 +394,31 @@ class WindowedBasis(Basis):
     offset: Int[Array, ' samp']
     block_weights: Float[Array, 'O samp']
     sub_values: Float[Array, 'k samp']
+    n_blocks: int = field(metadata={'static': True})
 
-    @classmethod
-    def create(
-        cls,
-        offset: Int[Array, ' samp'],
-        block_weights: Float[Array, 'O samp'],
-        sub_values: Float[Array, 'k samp'],
-        n_blocks: int,
-    ) -> Self:
-        n_window, n_points = block_weights.shape
-        k = sub_values.shape[0]
-        if offset.shape != (n_points,) or sub_values.shape[1] != n_points:
-            raise ValueError(
-                f'sample axes disagree: offset {offset.shape}, block_weights {block_weights.shape}'
-                f', sub_values {sub_values.shape}'
+    @property
+    def _index_shape(self) -> tuple[int, ...]:
+        return (self.n_blocks, self.sub_values.shape[0])
+
+    @property
+    def _array_dtype(self) -> DTypeLike:
+        return self.sub_values.dtype
+
+    def __post_init__(self) -> None:
+        super().__post_init__()
+        n_window, n_points = self.block_weights.shape
+        if self.offset.shape != (n_points,) or self.sub_values.shape[1] != n_points:
+            msg = (
+                f'sample axes disagree: offset {self.offset.shape}, block_weights '
+                f'{self.block_weights.shape}, sub_values {self.sub_values.shape}'
             )
-        if n_window > n_blocks:
-            raise ValueError(f'window ({n_window}) wider than block count ({n_blocks})')
-        return cls(
-            offset=offset,
-            block_weights=block_weights,
-            sub_values=sub_values,
-            in_structure=ShapeDtypeStruct((n_blocks, k), sub_values.dtype),
-        )
+            raise ValueError(msg)
+        if n_window > self.n_blocks:
+            raise ValueError(f'window ({n_window}) wider than block count ({self.n_blocks})')
 
     @property
     def n_points(self) -> int:
-        return self.offset.shape[0]
+        return self.offset.shape[-1]
 
     def _block_indices(self) -> Int[Array, 'samp O']:
         # each sample's window: O consecutive block ids starting at its offset.
@@ -445,275 +532,339 @@ def _harmonics(
     return jnp.concatenate(parts, axis=0).astype(dtype)
 
 
-class PerDetectorTemplate(AbstractLinearOperator):
-    """Turn a single-detector `Basis` into a per-detector template operator.
+def polynomial_basis(
+    max_poly_order: int,
+    intervals: Float[Array, 'n_intervals 2'],
+    times: Float[Array, ' samp'],
+    dtype: DTypeLike,
+    valid_mask: Float[Array, ' samp'] | None = None,
+) -> Basis:
+    """Basis for a polynomial drift template, one polynomial per scanning interval.
 
-    Each detector is an independent block fitting its own amplitudes. Two modes:
+    Each sample belongs to one interval and is fitted with Legendre orders
+    `0..max_poly_order` over that interval.
 
-    - `shared_basis=True` (default): all detectors use the same basis. Used by templates
-      whose basis depends only on shared quantities (azimuth, HWP angle): polynomial,
-      scan- and HWP-synchronous.
-    - `shared_basis=False`: each detector has its own basis. Used by the T2P leakage
-      template, where detector `d`'s basis is its own temperature stream.
+    Assumes `intervals` are sorted, non-overlapping `[start, end)` rows. Samples in
+    gaps or past the last interval get a zero basis column. `valid_mask` optionally
+    zeroes flagged samples (1 = keep, 0 = drop) so they neither carry template
+    signal nor constrain the fitted amplitudes.
     """
+    n_samps = times.size
+    n_intervals = intervals.shape[0]
+    starts = intervals[:, 0]
+    ends = intervals[:, 1]
 
-    operator: AbstractLinearOperator
-    shared_basis: bool = field(default=True, metadata={'static': True})
+    s = jnp.arange(n_samps)
+    # interval id per sample: last interval whose start <= s (intervals sorted),
+    # clamped into range. Gaps/out-of-range are caught by ``in_range`` below.
+    segment = jnp.clip(jnp.searchsorted(starts, s, side='right') - 1, 0, n_intervals - 1)
+    seg_start = starts[segment]
+    seg_end = ends[segment]
+    in_range = (s >= seg_start) & (s < seg_end)
+
+    t0 = times[seg_start]
+    span = jnp.where(seg_end > seg_start + 1, times[seg_end - 1] - t0, 1.0)
+    # rescale each sample to [-1, 1] within its own interval; out-of-range
+    # samples sit at 0 and are zeroed by ``in_range`` below.
+    u = jnp.where(in_range, -1.0 + 2.0 * (times - t0) / span, 0.0)
+    legs = _legendre_values(u, 0, max_poly_order, dtype)  # (k, n_samps)
+    legs = legs * in_range[None, :]
+    if valid_mask is not None:
+        legs = legs * valid_mask[None, :].astype(dtype)
+
+    return SegmentedBasis(segment.astype(jnp.int32), legs, n_intervals)
+
+
+def temperature_basis(
+    temperature: Float[Array, 'det samp'],
+    dtype: DTypeLike,
+    fit_band: tuple[float, float] | None = None,
+    sample_rate: Float[Array, ''] | float = 1.0,
+    decimation_factor: int = 1,
+) -> Basis:
+    """Per-detector basis for a temperature-to-polarization leakage template.
+
+    Each detector's basis is just its own temperature stream, so fitting one amplitude
+    per detector estimates how much temperature leaks into its polarization.
+
+    `fit_band=(f0, f1)` restricts the temperature basis to that frequency band (Hz), so
+    the leakage is both estimated and removed only there, keeping the template a clean
+    linear operator.
+
+    `decimation_factor=q` stores the basis on a `q`-times coarser grid to cut memory; the
+    coarse-grid Nyquist frequency `sample_rate / 2q` must stay above `f1`. As a rule of
+    thumb keep it at a few times `f1` (`q ≲ sample_rate / 6·f1`): the fractional error on
+    the fitted amplitude grows like `(f1 / (sample_rate / 2q))²`.
+
+    Assumes `temperature` is already deglitched/gap-filled upstream: a glitch left in it
+    would smear across the band and bias the fitted amplitude.
+    """
+    t = temperature
+    if fit_band is not None:
+        f0, f1 = fit_band
+        freqs = jnp.fft.rfftfreq(t.shape[-1], d=1.0 / sample_rate)
+        band = (freqs > f0) & (freqs < f1)
+        t = jnp.fft.irfft(jnp.fft.rfft(t, axis=-1) * band, n=t.shape[-1], axis=-1)
+    n_dets, n_full = t.shape
+    q = decimation_factor
+    if q > 1:
+        # Block-average onto a q-times coarser grid: pad the tail to a whole block,
+        # reshape (..., n_dec, q) and mean. ``TensorBasis`` hold-upsamples back to
+        # ``n_full`` in synthesis (band-limits above sample_rate / 2q).
+        n_dec = -(-n_full // q)  # ceil
+        pad = n_dec * q - n_full
+        tp = jnp.pad(t, [(0, 0), (0, pad)])
+        t_dec = tp.reshape(n_dets, n_dec, q).mean(axis=-1)
+        values = t_dec[:, None, :].astype(dtype)  # (det, k=1, dec)
+        return TensorBasis.per_detector_stack(values=values, q=q, n_full=n_full)
+    values = t[:, None, :].astype(dtype)  # (det, k=1, samp)
+    return TensorBasis.per_detector_stack(values=values)
+
+
+def scan_synchronous_basis(
+    legendre: PolynomialOrders,
+    azimuth: Float[Array, ' samp'],
+    dtype: DTypeLike,
+) -> Basis:
+    """Scan-synchronous (azimuth-only) basis on a global Legendre basis."""
+    legs = _legendre(azimuth, legendre.min_order, legendre.max_order, dtype)
+    return TensorBasis(legs)
+
+
+def binaz_synchronous_basis(
+    bins: BinsConfig,
+    azimuth: Float[Array, ' samp'],
+    dtype: DTypeLike,
+) -> Basis:
+    """Binned azimuth-synchronous basis, no HWP coupling: one amplitude per azimuth bin."""
+    weights = _bin_weights(azimuth, bins.n_bins, bins.interpolate, bins.smooth, dtype)
+    return TensorBasis(weights)
+
+
+def hwp_synchronous_basis(
+    n_harmonics: int,
+    hwp_angles: Float[Array, ' samp'],
+    dtype: DTypeLike,
+) -> Basis:
+    """HWP-synchronous basis: harmonics of the HWP angle, `k = 1..n_harmonics`."""
+    matrix = _harmonics(hwp_angles, n_harmonics, dtype, dc=False)
+    return TensorBasis(matrix)
+
+
+def azhwp_synchronous_basis(
+    legendre: PolynomialOrders,
+    n_harmonics: int,
+    azimuth: Float[Array, ' samp'],
+    hwp_angles: Float[Array, ' samp'],
+    dtype: DTypeLike,
+    scan_mask: Float[Array, ' samp'] | None = None,
+) -> Basis:
+    """Azimuth-Legendre x HWP-harmonic basis (Kronecker product of the two).
+
+    `scan_mask` optionally zeroes the azimuth leg on flagged samples (e.g. to fit separate
+    amplitudes per scan direction).
+    """
+    poly = _legendre(azimuth, legendre.min_order, legendre.max_order, dtype)
+    if scan_mask is not None:
+        poly = scan_mask[None, :] * poly
+    harm = _harmonics(hwp_angles, n_harmonics, dtype, dc=True)
+    return KroneckerBasis((poly, harm))
+
+
+def binazhwp_synchronous_basis(
+    bins: BinsConfig,
+    n_harmonics: int,
+    azimuth: Float[Array, ' samp'],
+    hwp_angles: Float[Array, ' samp'],
+    dtype: DTypeLike,
+) -> Basis:
+    """Azimuth-binned x HWP-harmonic basis (azimuth is always binned)."""
+    bin_basis = _bin_weights(azimuth, bins.n_bins, bins.interpolate, bins.smooth, dtype)
+    harm = _harmonics(hwp_angles, n_harmonics, dtype, dc=True)
+    return KroneckerBasis((bin_basis, harm))
+
+
+def bspline_hwpss_basis(
+    times: Float[Array, ' samp'],
+    hwp_angles: Float[Array, ' samp'],
+    n_knots: int,
+    harmonics: int | Sequence[int],
+    dtype: DTypeLike,
+) -> Basis:
+    """Spline-based HWP synchronous basis.
+
+    A cubic B-spline models the slowly time-varying amplitude of the HWP-synchronous
+    signal: knot `j` carries a `(sin kχ, cos kχ)` pair for each harmonic `k`, so the
+    amplitudes have shape `(K, 2*n_harmonics)` with `K = n_knots + 2`.
+    """
+    offset, weights = bspline.spline_window(times, n_knots)  # weights (samp, 4)
+    sub_values = _harmonics(hwp_angles, harmonics, dtype, dc=False).astype(dtype)
+    return WindowedBasis(offset, weights.T.astype(dtype), sub_values, n_blocks=n_knots + 2)
+
+
+class AbstractTemplateOperator(AbstractLinearOperator):
+    """Every enabled template as one operator, from amplitudes keyed by template name to a TOD."""
+
+    # The bases must stay the only dynamic leaves: an operator then stacks under a scan over
+    # observations by gaining a leading axis on the basis arrays, everything else being static.
+    bases: dict[str, Any]
+    n_dets: int = field(metadata={'static': True})
+
+    def __post_init__(self) -> None:
+        # ``in_structure`` is derived, never passed: it can then never disagree with the bases.
+        if self.in_structure is not None:
+            raise ValueError('in_structure is derived from the bases; do not pass it')
+        object.__setattr__(self, 'in_structure', self._amplitude_structure())
+        super().__post_init__()
+
+    # ---- amplitude side -------------------------------------------------------------------------
+    @abstractmethod
+    def _amplitude_structure(self) -> PyTree[jax.ShapeDtypeStruct]:
+        """``bases`` with each basis replaced by the amplitudes it takes (``_amplitude_leaf``)."""
+
+    def _amplitude_leaf(self, basis: Basis) -> jax.ShapeDtypeStruct:
+        return jax.ShapeDtypeStruct((self.n_dets, *basis.shape), basis.dtype)
+
+    # ---- TOD side -------------------------------------------------------------------------------
+    @abstractmethod
+    def _a_basis(self) -> Basis:
+        """Any one of the bases: they agree on sample count and dtype."""
+
+    def _stream_structure(self) -> jax.ShapeDtypeStruct:
+        """One detector-by-sample stream, the shape every Stokes leg of the TOD takes."""
+        b = self._a_basis()
+        return jax.ShapeDtypeStruct((self.n_dets, b.n_points), b.dtype)
+
+    def _zero_stream(self) -> Array:
+        s = self._stream_structure()
+        return jnp.zeros(s.shape, s.dtype)
+
+    # ---- per-detector expand / project of one basis ---------------------------------------------
+    @staticmethod
+    def _in_axes(basis: Basis) -> tuple[int | None, int]:
+        # map over the basis's own detector axis when it has one, broadcast it when shared
+        return (0 if basis.per_detector else None, 0)
 
     @classmethod
-    def from_basis(cls, basis: Basis, n_dets: int, *, shared: bool = True) -> Self:
-        """Build the per-detector operator over `n_dets` detectors from a single `basis`.
+    def _expand(cls, basis: Basis, a: Array) -> Array:
+        vmapped = jax.vmap(lambda op, ai: op.expand(ai), in_axes=cls._in_axes(basis))
+        return vmapped(basis, a)  # type: ignore[no-any-return]
 
-        `shared=True` uses one basis for all detectors; `shared=False` expects a
-        per-detector basis, one per detector (see the class docstring).
-        """
-        return cls(
-            operator=basis,
-            shared_basis=shared,
-            in_structure=jax.ShapeDtypeStruct((n_dets, *basis.shape), basis.dtype),
-        )
+    @classmethod
+    def _project(cls, basis: Basis, s: Array) -> Array:
+        vmapped = jax.vmap(lambda op, si: op.project(si), in_axes=cls._in_axes(basis))
+        return vmapped(basis, s)  # type: ignore[no-any-return]
 
-    @property
-    def out_structure(self) -> jax.ShapeDtypeStruct:
-        n_dets = self.in_structure.shape[0]
-        out = self.operator.out_structure
-        return jax.ShapeDtypeStruct((n_dets, *out.shape), out.dtype)
-
-    def mv(self, x: Float[Array, ' det *shape']) -> Float[Array, 'det samp']:
-        if self.shared_basis:
-            # broadcast the shared operator across detectors.
-            return jax.vmap(self.operator.mv)(x)  # type: ignore[no-any-return]
-        # slice the basis values on the detector axis in lockstep with x
-        return jax.vmap(lambda op, xi: op.mv(xi), in_axes=(0, 0))(self.operator, x)  # type: ignore[no-any-return]
+    # ---- adjoint --------------------------------------------------------------------------------
+    @abstractmethod
+    def project(self, tod: PyTree[Array]) -> PyTree[Array]:
+        """Every template's amplitudes, from a TOD. This is the transpose's ``mv``."""
 
     def transpose(self) -> AbstractLinearOperator:
-        return PerDetectorTemplate(
-            self.operator.T, shared_basis=self.shared_basis, in_structure=self.out_structure
-        )
+        return _TemplateOperatorTranspose(self)
 
-    @classmethod
-    def scan_synchronous(
-        cls,
-        legendre: PolynomialOrders,
-        azimuth: Float[Array, ' samp'],
-        n_dets: int,
-        dtype: DTypeLike,
-    ) -> Self:
-        """Scan-synchronous (azimuth-only) template on a global Legendre basis."""
-        legs = _legendre(azimuth, legendre.min_order, legendre.max_order, dtype)
-        return cls.from_basis(TensorBasis.create(legs), n_dets=n_dets)
 
-    @classmethod
-    def binaz_synchronous(
-        cls,
-        bins: BinsConfig,
-        azimuth: Float[Array, ' samp'],
-        n_dets: int,
-        dtype: DTypeLike,
-    ) -> Self:
-        """Binned azimuth-synchronous template, no HWP coupling.
+class TemplateOperator(AbstractTemplateOperator):
+    """Templates over a TOD with no Stokes axis, producing one ``(n_dets, n_points)`` array.
 
-        One amplitude per azimuth bin per detector.
-        """
-        weights = _bin_weights(azimuth, bins.n_bins, bins.interpolate, bins.smooth, dtype)
-        return cls.from_basis(TensorBasis.create(weights), n_dets=n_dets)
+    Each template contributes ``(n_dets, *basis.shape)`` amplitudes, and the TOD is their summed
+    expansion.
+    """
 
-    @classmethod
-    def hwp_synchronous(
-        cls,
-        n_harmonics: int,
-        hwp_angles: Float[Array, ' samp'],
-        n_dets: int,
-        dtype: DTypeLike,
-    ) -> Self:
-        """HWP-synchronous template: harmonics of the HWP angle, `k = 1..n_harmonics`."""
-        matrix = _harmonics(hwp_angles, n_harmonics, dtype, dc=False)
-        return cls.from_basis(TensorBasis.create(matrix), n_dets=n_dets)
+    bases: dict[str, Basis]
 
-    @classmethod
-    def azhwp_synchronous(
-        cls,
-        legendre: PolynomialOrders,
-        n_harmonics: int,
-        azimuth: Float[Array, ' samp'],
-        hwp_angles: Float[Array, ' samp'],
-        n_dets: int,
-        dtype: DTypeLike,
-        scan_mask: Float[Array, ' samp'] | None = None,
-    ) -> Self:
-        """Azimuth-Legendre × HWP-harmonic template (Kronecker product of the two).
+    def _a_basis(self) -> Basis:
+        return next(iter(self.bases.values()))
 
-        `scan_mask` optionally zeroes the azimuth leg on flagged samples (e.g. to fit
-        separate amplitudes per scan direction).
-        """
-        poly = _legendre(azimuth, legendre.min_order, legendre.max_order, dtype)
-        if scan_mask is not None:
-            poly = scan_mask[None, :] * poly
-        harm = _harmonics(hwp_angles, n_harmonics, dtype, dc=True)
-        return cls.from_basis(KroneckerBasis.create((poly, harm)), n_dets=n_dets)
+    def _amplitude_structure(self) -> PyTree[jax.ShapeDtypeStruct]:
+        return {name: self._amplitude_leaf(basis) for name, basis in self.bases.items()}
 
-    @classmethod
-    def binazhwp_synchronous(
-        cls,
-        bins: BinsConfig,
-        n_harmonics: int,
-        azimuth: Float[Array, ' samp'],
-        hwp_angles: Float[Array, ' samp'],
-        n_dets: int,
-        dtype: DTypeLike,
-    ) -> Self:
-        """Azimuth-binned × HWP-harmonic template (azimuth is always binned)."""
-        bin_basis = _bin_weights(azimuth, bins.n_bins, bins.interpolate, bins.smooth, dtype)
-        harm = _harmonics(hwp_angles, n_harmonics, dtype, dc=True)
-        return cls.from_basis(KroneckerBasis.create((bin_basis, harm)), n_dets=n_dets)
+    @property
+    def out_structure(self) -> PyTree[jax.ShapeDtypeStruct]:
+        return self._stream_structure()
 
-    @classmethod
-    def polynomial(
-        cls,
-        max_poly_order: int,
-        intervals: Float[Array, 'n_intervals 2'],
-        times: Float[Array, ' samp'],
-        n_dets: int,
-        dtype: DTypeLike,
-        valid_mask: Float[Array, ' samp'] | None = None,
-    ) -> Self:
-        """A polynomial drift template, one polynomial per scanning interval.
+    def mv(self, x: PyTree[Array]) -> PyTree[Array]:
+        stream = self._zero_stream()
+        for name, basis in self.bases.items():
+            stream = stream + self._expand(basis, x[name])
+        return stream
 
-        Each sample belongs to one interval and is fitted with Legendre orders
-        `0..max_poly_order` over that interval.
+    def project(self, tod: PyTree[Array]) -> PyTree[Array]:
+        return {name: self._project(basis, tod) for name, basis in self.bases.items()}
 
-        Assumes `intervals` are sorted, non-overlapping `[start, end)` rows. Samples in
-        gaps or past the last interval get a zero basis column. `valid_mask` optionally
-        zeroes flagged samples (1 = keep, 0 = drop) so they neither carry template
-        signal nor constrain the fitted amplitudes.
-        """
-        n_samps = times.size
-        n_intervals = intervals.shape[0]
-        starts = intervals[:, 0]
-        ends = intervals[:, 1]
 
-        s = jnp.arange(n_samps)
-        # interval id per sample: last interval whose start <= s (intervals sorted),
-        # clamped into range. Gaps/out-of-range are caught by ``in_range`` below.
-        segment = jnp.clip(jnp.searchsorted(starts, s, side='right') - 1, 0, n_intervals - 1)
-        seg_start = starts[segment]
-        seg_end = ends[segment]
-        in_range = (s >= seg_start) & (s < seg_end)
+class StokesTemplateOperator(AbstractTemplateOperator):
+    """Templates over a [`Stokes`][] TOD, each leg one ``(n_dets, n_points)`` array.
 
-        t0 = times[seg_start]
-        span = jnp.where(seg_end > seg_start + 1, times[seg_end - 1] - t0, 1.0)
-        # rescale each sample to [-1, 1] within its own interval; out-of-range
-        # samples sit at 0 and are zeroed by ``in_range`` below.
-        u = jnp.where(in_range, -1.0 + 2.0 * (times - t0) / span, 0.0)
-        legs = _legendre_values(u, 0, max_poly_order, dtype)  # (k, n_samps)
-        legs = legs * in_range[None, :]
-        if valid_mask is not None:
-            legs = legs * valid_mask[None, :].astype(dtype)
+    A Stokes-valued TOD carries one differently filtered stream per leg (as demodulation
+    produces), so a template fits an independent set of amplitudes on each leg it covers. It need
+    not cover them all: temperature-to-polarization leakage is fitted on Q and U only.
 
-        basis = SegmentedBasis.create(segment.astype(jnp.int32), legs, n_intervals)
-        return cls.from_basis(basis, n_dets=n_dets)
+    Raises:
+        TypeError: If a template is given as a bare basis rather than keyed by leg.
+        ValueError: If a template names a leg outside `stokes`.
+    """
 
-    @classmethod
-    def temperature(
-        cls,
-        temperature: Float[Array, 'det samp'],
-        dtype: DTypeLike,
-        fit_band: tuple[float, float] | None = None,
-        sample_rate: Float[Array, ''] | float = 1.0,
-        decimation_factor: int = 1,
-    ) -> Self:
-        """Temperature-to-polarization leakage template.
+    bases: dict[str, dict[StokesLeg, Basis]]
+    stokes: ValidStokesLiteral = field(metadata={'static': True})
 
-        Each detector's basis is just its own temperature stream, so fitting one
-        amplitude per detector estimates how much temperature leaks into its
-        polarization.
+    def __post_init__(self) -> None:
+        # ``stokes`` declares the leg axis: every template must be keyed by a subset of it.
+        for name, legged in self.bases.items():
+            if isinstance(legged, Basis):
+                msg = f'template {name!r} needs one basis per Stokes leg of {self.stokes!r}'
+                raise TypeError(msg)
+            if extra := sorted(leg for leg in legged if leg not in self.legs):
+                msg = (
+                    f'template {name!r} has legs {extra} outside stokes={self.stokes!r} '
+                    f'(expected {list(self.legs)})'
+                )
+                raise ValueError(msg)
+        super().__post_init__()
 
-        `fit_band=(f0, f1)` restricts the temperature basis to that frequency band (Hz),
-        so the leakage is both estimated and removed only there, keeping the template a
-        clean linear operator.
+    @property
+    def legs(self) -> tuple[StokesLeg, ...]:
+        """The Stokes legs the TOD carries, as the bases and amplitudes key them."""
+        return cast(tuple[StokesLeg, ...], tuple(s.lower() for s in self.stokes))
 
-        `decimation_factor=q` stores the basis on a `q`-times coarser grid to cut memory; the
-        coarse-grid Nyquist frequency `sample_rate / 2q` must stay above `f1`. As a rule
-        of thumb keep it at a few times `f1` (`q ≲ sample_rate / 6·f1`): the fractional
-        error on the fitted amplitude grows like `(f1 / (sample_rate / 2q))²`.
+    def _a_basis(self) -> Basis:
+        return next(iter(next(iter(self.bases.values())).values()))
 
-        Assumes `temperature` is already deglitched/gap-filled upstream: a glitch left in
-        it would smear across the band and bias the fitted amplitude.
-        """
-        t = temperature
-        if fit_band is not None:
-            f0, f1 = fit_band
-            freqs = jnp.fft.rfftfreq(t.shape[-1], d=1.0 / sample_rate)
-            band = (freqs > f0) & (freqs < f1)
-            t = jnp.fft.irfft(jnp.fft.rfft(t, axis=-1) * band, n=t.shape[-1], axis=-1)
-        n_dets, n_full = t.shape
-        q = decimation_factor
-        if q > 1:
-            # Block-average onto a q-times coarser grid: pad the tail to a whole block,
-            # reshape (..., n_dec, q) and mean. ``TensorBasis`` hold-upsamples back to
-            # ``n_full`` in synthesis (band-limits above sample_rate / 2q).
-            n_dec = -(-n_full // q)  # ceil
-            pad = n_dec * q - n_full
-            tp = jnp.pad(t, [(0, 0), (0, pad)])
-            t_dec = tp.reshape(n_dets, n_dec, q).mean(axis=-1)
-            values = t_dec[:, None, :].astype(dtype)  # (det, k=1, dec)
-            # per-detector basis: values carry a leading det axis sliced by ``from_basis``,
-            # so ``in_structure`` is the single-detector shape (k=1,).
-            basis = TensorBasis(
-                values=values, q=q, n_full=n_full, in_structure=ShapeDtypeStruct((1,), dtype)
-            )
-        else:
-            values = t[:, None, :].astype(dtype)  # (det, k=1, samp)
-            basis = TensorBasis(
-                values=values, n_full=n_full, in_structure=ShapeDtypeStruct((1,), dtype)
-            )
-        return cls.from_basis(basis, n_dets=n_dets, shared=False)
+    def _amplitude_structure(self) -> PyTree[jax.ShapeDtypeStruct]:
+        return {
+            name: {leg: self._amplitude_leaf(basis) for leg, basis in legged.items()}
+            for name, legged in self.bases.items()
+        }
 
-    @classmethod
-    def none(cls, n_dets: int, n_samps: int, dtype: DTypeLike) -> Self:
-        """Empty template: no amplitudes, zero output.
+    @property
+    def out_structure(self) -> PyTree[jax.ShapeDtypeStruct]:
+        stream = self._stream_structure()
+        return Stokes.class_for(self.stokes).structure_for(stream.shape, stream.dtype)
 
-        Used to leave a Stokes leg untouched in a per-leg block (e.g. the I leg of the
-        T2P template, which acts on Q/U only).
-        """
-        # k-axis is 0, so this is a zero-size array; n_samps only sizes the einsum output.
-        values = jnp.zeros((n_dets, 0, n_samps), dtype)
-        basis = TensorBasis(
-            values=values, n_full=n_samps, in_structure=ShapeDtypeStruct((0,), dtype)
-        )
-        return cls.from_basis(basis, n_dets=n_dets, shared=False)
+    def _streams(self, tod: PyTree[Array]) -> dict[StokesLeg, Array]:
+        return dict(zip(self.legs, tod.data, strict=True))
 
-    @classmethod
-    def bspline_hwpss(
-        cls,
-        times: Float[Array, ' samp'],
-        hwp_angles: Float[Array, ' samp'],
-        n_dets: int,
-        n_knots: int,
-        harmonics: int | Sequence[int] = (4,),
-        dtype: DTypeLike = jnp.float32,
-    ) -> Self:
-        """Spline-based HWP synchronous template.
+    def mv(self, x: PyTree[Array]) -> PyTree[Array]:
+        streams = dict.fromkeys(self.legs, self._zero_stream())
+        for name, legged in self.bases.items():
+            for leg, basis in legged.items():
+                streams[leg] = streams[leg] + self._expand(basis, x[name][leg])
+        stacked = jnp.stack([streams[leg] for leg in self.legs], axis=0)
+        return Stokes.class_for(self.stokes).from_array(stacked)
 
-        A cubic B-spline models the slowly time-varying amplitude of the HWP-synchronous
-        signal: knot `j` carries a `(sin kχ, cos kχ)` pair for each harmonic `k`, so the
-        amplitudes have shape `(K, 2*n_harmonics)` with `K = n_knots + 2`.
+    def project(self, tod: PyTree[Array]) -> PyTree[Array]:
+        streams = self._streams(tod)
+        return {
+            name: {leg: self._project(basis, streams[leg]) for leg, basis in legged.items()}
+            for name, legged in self.bases.items()
+        }
 
-        Args:
-            times: Per-sample timestamps used to place the spline knots.
-            hwp_angles: Per-sample HWP angle `χ` (radians).
-            n_dets: Number of detectors; each fits its own amplitudes.
-            n_knots: Number of interior spline knots (see `SplineHWPSSConfig.resolve_n_knots`).
-            harmonics: HWP harmonics to model, either an int `n` (the harmonics `1..n`)
-                or an explicit sequence of orders.
-            dtype: Floating dtype of the basis values.
-        """
-        offset, weights = bspline.spline_window(times, n_knots)  # weights (samp, 4)
-        sub_values = _harmonics(hwp_angles, harmonics, dtype, dc=False).astype(dtype)
-        basis = WindowedBasis.create(
-            offset, weights.T.astype(dtype), sub_values, n_blocks=n_knots + 2
-        )
-        return cls.from_basis(basis, n_dets=n_dets, shared=True)
+
+class _TemplateOperatorTranspose(TransposeOperator):
+    operator: AbstractTemplateOperator
+
+    def mv(self, x: PyTree[Array]) -> PyTree[Array]:
+        return self.operator.project(x)
 
 
 class GroundTemplateOperator(AbstractLinearOperator):

--- a/src/furax/mapmaking/templates.py
+++ b/src/furax/mapmaking/templates.py
@@ -698,6 +698,10 @@ def spline_hwp_synchronous_basis(
     return WindowedBasis(offset, weights.T.astype(dtype), sub_values, n_blocks=n_knots + 2)
 
 
+def is_basis(x: Any) -> bool:
+    return isinstance(x, Basis)
+
+
 class AbstractTemplateOperator(AbstractLinearOperator):
     """Every enabled template as one operator, from amplitudes keyed by template name to a TOD."""
 
@@ -714,17 +718,17 @@ class AbstractTemplateOperator(AbstractLinearOperator):
         super().__post_init__()
 
     # ---- amplitude side -------------------------------------------------------------------------
-    @abstractmethod
     def _amplitude_structure(self) -> PyTree[jax.ShapeDtypeStruct]:
-        """`bases` with each basis replaced by the amplitudes it takes (`_amplitude_leaf`)."""
+        """`bases` with each basis replaced by the amplitudes it takes."""
+        return jax.tree.map(self._amplitude_leaf, self.bases, is_leaf=is_basis)
 
     def _amplitude_leaf(self, basis: Basis) -> jax.ShapeDtypeStruct:
         return jax.ShapeDtypeStruct((self.n_dets, *basis.shape), basis.dtype)
 
     # ---- TOD side -------------------------------------------------------------------------------
-    @abstractmethod
     def _a_basis(self) -> Basis:
         """Any one of the bases: they agree on sample count and dtype."""
+        return jax.tree.leaves(self.bases, is_leaf=is_basis)[0]  # type: ignore[no-any-return]
 
     def _stream_structure(self) -> jax.ShapeDtypeStruct:
         """One detector-by-sample stream, the shape every Stokes leg of the TOD takes."""
@@ -768,12 +772,6 @@ class TemplateOperator(AbstractTemplateOperator):
     """
 
     bases: dict[str, Basis]
-
-    def _a_basis(self) -> Basis:
-        return next(iter(self.bases.values()))
-
-    def _amplitude_structure(self) -> PyTree[jax.ShapeDtypeStruct]:
-        return {name: self._amplitude_leaf(basis) for name, basis in self.bases.items()}
 
     @property
     def out_structure(self) -> PyTree[jax.ShapeDtypeStruct]:
@@ -822,15 +820,6 @@ class StokesTemplateOperator(AbstractTemplateOperator):
     def legs(self) -> tuple[StokesLeg, ...]:
         """The Stokes legs the TOD carries, as the bases and amplitudes key them."""
         return cast(tuple[StokesLeg, ...], tuple(s.lower() for s in self.stokes))
-
-    def _a_basis(self) -> Basis:
-        return next(iter(next(iter(self.bases.values())).values()))
-
-    def _amplitude_structure(self) -> PyTree[jax.ShapeDtypeStruct]:
-        return {
-            name: {leg: self._amplitude_leaf(basis) for leg, basis in legged.items()}
-            for name, legged in self.bases.items()
-        }
 
     @property
     def out_structure(self) -> PyTree[jax.ShapeDtypeStruct]:

--- a/src/furax/mapmaking/templates.py
+++ b/src/furax/mapmaking/templates.py
@@ -57,13 +57,13 @@ __all__ = [
     'SegmentedBasis',
     'WindowedBasis',
     'polynomial_basis',
-    'temperature_basis',
+    't2p_basis',
     'scan_synchronous_basis',
-    'binaz_synchronous_basis',
+    'binned_azimuth_synchronous_basis',
     'hwp_synchronous_basis',
-    'azhwp_synchronous_basis',
-    'binazhwp_synchronous_basis',
-    'bspline_hwpss_basis',
+    'azimuth_hwp_synchronous_basis',
+    'binned_azimuth_hwp_synchronous_basis',
+    'spline_hwp_synchronous_basis',
     'AbstractTemplateOperator',
     'TemplateOperator',
     'StokesTemplateOperator',
@@ -575,7 +575,7 @@ def polynomial_basis(
     return SegmentedBasis(segment.astype(jnp.int32), legs, n_intervals)
 
 
-def temperature_basis(
+def t2p_basis(
     temperature: Float[Array, 'det samp'],
     dtype: DTypeLike,
     fit_band: tuple[float, float] | None = None,
@@ -631,7 +631,7 @@ def scan_synchronous_basis(
     return TensorBasis(legs)
 
 
-def binaz_synchronous_basis(
+def binned_azimuth_synchronous_basis(
     bins: BinsConfig,
     azimuth: Float[Array, ' samp'],
     dtype: DTypeLike,
@@ -651,7 +651,7 @@ def hwp_synchronous_basis(
     return TensorBasis(matrix)
 
 
-def azhwp_synchronous_basis(
+def azimuth_hwp_synchronous_basis(
     legendre: PolynomialOrders,
     n_harmonics: int,
     azimuth: Float[Array, ' samp'],
@@ -671,7 +671,7 @@ def azhwp_synchronous_basis(
     return KroneckerBasis((poly, harm))
 
 
-def binazhwp_synchronous_basis(
+def binned_azimuth_hwp_synchronous_basis(
     bins: BinsConfig,
     n_harmonics: int,
     azimuth: Float[Array, ' samp'],
@@ -684,7 +684,7 @@ def binazhwp_synchronous_basis(
     return KroneckerBasis((bin_basis, harm))
 
 
-def bspline_hwpss_basis(
+def spline_hwp_synchronous_basis(
     times: Float[Array, ' samp'],
     hwp_angles: Float[Array, ' samp'],
     n_knots: int,

--- a/tests/mapmaking/test_config.py
+++ b/tests/mapmaking/test_config.py
@@ -5,7 +5,18 @@ import yaml
 from apischema import deserialize
 
 from furax.mapmaking import config as config_module
-from furax.mapmaking.config import HWPSynchronousConfig, MapMakingConfig, TemplatesConfig
+from furax.mapmaking.config import (
+    GroundConfig,
+    HealpixConfig,
+    HWPSynchronousConfig,
+    LandscapeConfig,
+    MapMakingConfig,
+    PolynomialConfig,
+    PolynomialOrders,
+    SotodlibConfig,
+    T2PConfig,
+    TemplatesConfig,
+)
 
 # Every config class whose docstring carries an `Examples:` block.
 EXAMPLE_CLASSES = [
@@ -72,3 +83,51 @@ def test_docstring_example_parses_and_deserializes(cls: type, yaml_block: str):
 def test_use_templates_follows_the_enabled_templates(templates: TemplatesConfig, enabled: bool):
     assert templates.empty == (not enabled)
     assert MapMakingConfig(templates=templates).use_templates == enabled
+
+
+class TestExplicitOnlyTemplates:
+    """T2P and ground templates don't support implicit deprojection."""
+
+    @pytest.mark.parametrize('cls', [T2PConfig, GroundConfig])
+    def test_raises_if_not_explicit(self, cls):
+        with pytest.raises(ValueError, match='requires explicit=True'):
+            cls(explicit=False)
+
+    @pytest.mark.parametrize('cls', [T2PConfig, GroundConfig])
+    def test_accepts_explicit(self, cls):
+        cls(explicit=True)
+
+
+class TestT2PRequiresDemodulated:
+    def test_raises_without_demodulated(self):
+        with pytest.raises(ValueError, match='T2P template requires demodulated=True'):
+            MapMakingConfig(templates=TemplatesConfig(t2p=T2PConfig()))
+
+    def test_raises_without_i_leg(self):
+        with pytest.raises(ValueError, match="T2P template requires an 'I' leg"):
+            MapMakingConfig(
+                sotodlib=SotodlibConfig(demodulated=True),
+                landscape=LandscapeConfig(stokes='QU', healpix=HealpixConfig()),
+                templates=TemplatesConfig(t2p=T2PConfig()),
+            )
+
+    def test_accepts_demodulated_with_i_leg(self):
+        MapMakingConfig(
+            sotodlib=SotodlibConfig(demodulated=True),
+            landscape=LandscapeConfig(stokes='IQU', healpix=HealpixConfig()),
+            templates=TemplatesConfig(t2p=T2PConfig()),
+        )
+
+
+class TestPolynomialLegendreQURequiresDemodulated:
+    def test_raises_without_demodulated(self):
+        poly = PolynomialConfig(legendre_qu=PolynomialOrders(0, 2))
+        with pytest.raises(ValueError, match='legendre_qu requires demodulated=True'):
+            MapMakingConfig(templates=TemplatesConfig(polynomial=poly))
+
+    def test_accepts_demodulated(self):
+        poly = PolynomialConfig(legendre_qu=PolynomialOrders(0, 2))
+        MapMakingConfig(
+            sotodlib=SotodlibConfig(demodulated=True),
+            templates=TemplatesConfig(polynomial=poly),
+        )

--- a/tests/mapmaking/test_mapmaker.py
+++ b/tests/mapmaking/test_mapmaker.py
@@ -24,7 +24,6 @@ from furax.mapmaking.config import (
     PointingConfig,
     SkyPatch,
     SotodlibConfig,
-    TemplatesConfig,
     WCSConfig,
     WeightingConfig,
     WeightingMode,
@@ -34,7 +33,6 @@ from furax.mapmaking.mapmaker import (
     BinnedMapMaker,
     MapMaker,
     MLMapmaker,
-    TwoStepMapmaker,
     get_obs_distribution_to_process,
 )
 from furax.mapmaking.noise import WhiteNoiseModel
@@ -402,35 +400,6 @@ def _config(
     )
 
 
-class TestSingleObsTemplates:
-    """End-to-end coverage of the single-observation template path (MapMaker.make_map)."""
-
-    def test_ml_mapmaker_runs_with_templates(self) -> None:
-        # Regression: the template preconditioner build jits the template system operator;
-        # a composite furax operator carries unhashable leaves, so it must be wrapped in a
-        # lambda (mapmaker.py). Also locks the structured (n_dets, *shape) amplitude layout.
-        n_dets = 4
-        obs = FakeGroundObservation(n_dets=n_dets, n_samples=1024, sample_rate=100.0)
-
-        cfg = MapMakingConfig.for_method('ml')
-        cfg.weighting.source = NoiseSource.PRECOMPUTED  # use the obs noise model (finite)
-        cfg.landscape = LandscapeConfig(stokes='IQU', healpix=HealpixConfig(nside=8))
-        cfg.templates = TemplatesConfig.full_defaults()
-        cfg.templates.ground = None  # ground template needs pointing/landscape, out of scope here
-        cfg.templates.spline_hwpss.samples_per_knot = 256  # 1024 // 256 -> n_knots=4
-
-        res = MLMapmaker(config=cfg).make_map(obs)
-
-        assert bool(jnp.all(jnp.isfinite(res['map'])))
-        # amplitudes are structured (n_dets, *basis_shape), not flat
-        assert res['template_polynomial'].shape == (n_dets, 2, 4)  # intervals x (orders 0..3)
-        assert res['template_azhwp_synchronous'].shape == (n_dets, 4, 9)  # orders x (DC+2*4)
-        assert res['template_spline_hwpss'].shape == (n_dets, 6, 2)  # (n_knots + 2) x cos/sin
-        for key, value in res.items():
-            if key.startswith('template_') and not key.startswith('template_reg'):
-                assert bool(jnp.all(jnp.isfinite(value))), key
-
-
 class TestSingleObsSolverGuards:
     """Solver/weighting compatibility on the single-observation ``MapMaker`` path.
 
@@ -468,7 +437,7 @@ class TestSingleObsSolverGuards:
         res = MLMapmaker(config=cfg).make_map(obs)
         assert bool(jnp.all(jnp.isfinite(res['map'])))
 
-    @pytest.mark.parametrize('maker_cls', [BinnedMapMaker, TwoStepMapmaker, ATOPMapMaker])
+    @pytest.mark.parametrize('maker_cls', [BinnedMapMaker, ATOPMapMaker])
     def test_direct_solvers_reject_bilinear_pointing(self, maker_cls: type[MapMaker]) -> None:
         """The direct binned solvers refuse bilinear pointing at construction time."""
         cfg = self._config(WeightingMode.DIAGONAL, interpolation='bilinear', method=Methods.BINNED)

--- a/tests/mapmaking/test_template_operator.py
+++ b/tests/mapmaking/test_template_operator.py
@@ -1,0 +1,125 @@
+import jax
+import jax.numpy as jnp
+import jax.random as jr
+import pytest
+from numpy.testing import assert_allclose
+
+from furax.mapmaking.templates import (
+    SegmentedBasis,
+    StokesTemplateOperator,
+    TemplateOperator,
+    TensorBasis,
+)
+
+N_DETS = 3
+N_SAMPS = 64
+
+
+def _seg(n):
+    return jnp.repeat(jnp.arange(n), N_SAMPS // n).astype(jnp.int32)
+
+
+def _expand(basis, a):
+    """Per-detector reference: broadcast a shared basis's expand over the detector axis."""
+    return jax.vmap(basis.expand)(a)
+
+
+def _project(basis, s):
+    """Per-detector reference: broadcast a shared basis's project over the detector axis."""
+    return jax.vmap(basis.project)(s)
+
+
+def test_template_operator_forward():
+    # mv/transpose == the sum / per-template split of the equivalent per-detector
+    # expand/project.
+    k = jr.split(jr.key(0), 4)
+    b1 = TensorBasis(jr.normal(k[0], (3, N_SAMPS)))
+    b2 = SegmentedBasis(_seg(4), jr.normal(k[1], (2, N_SAMPS)), 4)
+    T = TemplateOperator({'scan': b1, 'poly': b2}, n_dets=N_DETS)
+
+    amps = {'scan': jr.normal(k[2], (N_DETS, 3)), 'poly': jr.normal(k[3], (N_DETS, 4, 2))}
+    ref = _expand(b1, amps['scan']) + _expand(b2, amps['poly'])
+    assert_allclose(T(amps), ref, rtol=1e-5, atol=1e-6)
+
+    tod = jr.normal(jr.key(1), (N_DETS, N_SAMPS))
+    got = T.T(tod)
+    assert_allclose(got['scan'], _project(b1, tod), rtol=1e-5, atol=1e-6)
+    assert_allclose(got['poly'], _project(b2, tod), rtol=1e-5, atol=1e-6)
+
+
+def test_stokes_template_operator_forward():
+    # Per-Stokes-leg templates (polynomial on i/q/u, T2P on q/u only): output is a Stokes
+    # pytree, each leg the sum of the templates enabled on it.
+    k = jr.split(jr.key(2), 8)
+    poly = {
+        leg: SegmentedBasis(_seg(4), jr.normal(k[i], (2, N_SAMPS)), 4)
+        for i, leg in enumerate('iqu')
+    }
+    t2p = {
+        'q': TensorBasis(jr.normal(k[3], (1, N_SAMPS))),
+        'u': TensorBasis(jr.normal(k[4], (1, N_SAMPS))),
+    }
+    T = StokesTemplateOperator({'poly': poly, 't2p': t2p}, n_dets=N_DETS, stokes='IQU')
+
+    amps = {
+        'poly': {
+            leg: jr.normal(jr.fold_in(k[5], i), (N_DETS, 4, 2)) for i, leg in enumerate('iqu')
+        },
+        't2p': {leg: jr.normal(jr.fold_in(k[6], i), (N_DETS, 1)) for i, leg in enumerate('qu')},
+    }
+    out = T(amps)
+    for leg in 'iqu':
+        ref = _expand(poly[leg], amps['poly'][leg])
+        if leg in ('q', 'u'):
+            ref = ref + _expand(t2p[leg], amps['t2p'][leg])
+        assert_allclose(getattr(out, leg), ref, rtol=1e-5, atol=1e-6)
+
+
+def test_template_operator_transpose_is_adjoint():
+    # <T(amps), tod> == <amps, T.T(tod)> for several templates, shared + per-detector mix.
+    k = jr.split(jr.key(4), 6)
+    shared = TensorBasis(jr.normal(k[0], (3, N_SAMPS)))
+    per_det = TensorBasis.per_detector_stack(values=jr.normal(k[1], (N_DETS, 2, N_SAMPS)))
+    T = TemplateOperator({'shared': shared, 'per_det': per_det}, n_dets=N_DETS)
+    amps = {
+        'shared': jr.normal(k[2], (N_DETS, 3)),
+        'per_det': jr.normal(k[3], (N_DETS, 2)),
+    }
+    tod = jr.normal(k[4], (N_DETS, N_SAMPS))
+    lhs = jnp.vdot(T(amps), tod)
+    back = T.T(tod)
+    rhs = jnp.vdot(amps['shared'], back['shared']) + jnp.vdot(amps['per_det'], back['per_det'])
+    assert_allclose(lhs, rhs, rtol=1e-5, atol=1e-6)
+
+
+def test_template_operator_stacks_under_vmap():
+    # Only the bases are dynamic, so obs-stacking gains a leading axis and vmaps cleanly — this is
+    # exactly how the multi-observation jax.lax.scan applies it.
+    k = jr.split(jr.key(3), 3)
+
+    def make(kk):
+        b = SegmentedBasis(_seg(4), jr.normal(kk, (2, N_SAMPS)), 4)
+        return TemplateOperator({'poly': b}, n_dets=N_DETS)
+
+    t0, t1 = make(k[0]), make(k[1])
+    stacked = jax.tree.map(lambda a, b: jnp.stack([a, b]), t0, t1)  # leading obs axis on the bases
+    amps = {'poly': jr.normal(k[2], (2, N_DETS, 4, 2))}
+    out = jax.vmap(lambda op, x: op(x))(stacked, amps)
+    assert out.shape == (2, N_DETS, N_SAMPS)
+    assert_allclose(out[0], t0({'poly': amps['poly'][0]}), rtol=1e-5, atol=1e-6)
+    assert_allclose(out[1], t1({'poly': amps['poly'][1]}), rtol=1e-5, atol=1e-6)
+
+
+def test_stokes_template_operator_rejects_legs_outside_stokes():
+    # `stokes` declares the leg axis once: a template keyed by anything else is caught at
+    # construction, rather than as a bare KeyError from inside mv.
+    b = TensorBasis(jnp.ones((2, N_SAMPS)))
+    with pytest.raises(ValueError, match=r"template 'p' has legs \['i'\] outside stokes='QU'"):
+        StokesTemplateOperator({'p': {'i': b}}, n_dets=N_DETS, stokes='QU')
+
+
+def test_stokes_template_operator_rejects_a_basis_that_is_not_keyed_by_leg():
+    # a Stokes-valued operator needs one basis per leg, never a single shared one
+    b = TensorBasis(jnp.ones((2, N_SAMPS)))
+    with pytest.raises(TypeError, match="template 'poly' needs one basis per Stokes leg"):
+        StokesTemplateOperator({'poly': b}, n_dets=N_DETS, stokes='QU')

--- a/tests/mapmaking/test_templates.py
+++ b/tests/mapmaking/test_templates.py
@@ -7,7 +7,7 @@ from jax import Array
 from jaxtyping import Float
 from numpy.testing import assert_allclose, assert_array_equal
 
-from furax.mapmaking.config import BinsConfig, PolynomialOrders, SplineHWPSSConfig
+from furax.mapmaking.config import BinsConfig, PolynomialOrders, SplineHWPSynchronousConfig
 from furax.mapmaking.templates import (
     ATOPProjectionOperator,
     Basis,
@@ -19,14 +19,14 @@ from furax.mapmaking.templates import (
     _bin_weights,
     _harmonics,
     _legendre,
-    azhwp_synchronous_basis,
-    binaz_synchronous_basis,
-    binazhwp_synchronous_basis,
-    bspline_hwpss_basis,
+    azimuth_hwp_synchronous_basis,
+    binned_azimuth_hwp_synchronous_basis,
+    binned_azimuth_synchronous_basis,
     hwp_synchronous_basis,
     polynomial_basis,
     scan_synchronous_basis,
-    temperature_basis,
+    spline_hwp_synchronous_basis,
+    t2p_basis,
 )
 from furax.math import bspline
 from furax.tree import as_structure
@@ -38,12 +38,12 @@ def _wrap(basis: Basis, n_dets: int) -> TemplateOperator:
     return TemplateOperator({'t': basis}, n_dets)
 
 
-def spline_4f_hwpss_basis(
+def spline_4f_hwp_basis(
     times: Float[Array, ' samp'],
     hwp_angles: Float[Array, ' samp'],
     n_knots: int,
 ) -> Float[Array, '2k samp']:
-    """Dense reference for `bspline_hwpss_basis`'s `WindowedBasis`.
+    """Dense reference for `spline_hwp_synchronous_basis`'s `WindowedBasis`.
 
     Returns:
         B: (2K, N) basis matrix, interleaved rows [phi_j sin(4χ), phi_j cos(4χ)].
@@ -566,11 +566,11 @@ class TestSynchronousTemplates:
         legs = _legendre(azimuth, legendre.min_order, legendre.max_order, jnp.float64)
         assert_allclose(basis(coeffs), coeffs @ legs, rtol=TOL)
 
-    def test_binaz_synchronous_one_amplitude_per_bin(self) -> None:
+    def test_binned_azimuth_synchronous_one_amplitude_per_bin(self) -> None:
         n_samps = 200
         azimuth, _ = _geometry(n_samps)
         bins = BinsConfig(n_bins=6, interpolate=False, smooth=False)
-        basis = binaz_synchronous_basis(bins, azimuth, jnp.float64)
+        basis = binned_azimuth_synchronous_basis(bins, azimuth, jnp.float64)
         assert basis.shape == (bins.n_bins,)
         coeffs = jr.normal(jr.key(911), basis.shape)
         signal = jr.normal(jr.key(912), basis.out_structure.shape)
@@ -587,11 +587,11 @@ class TestSynchronousTemplates:
         matrix = _harmonics(hwp, n_harm, jnp.float64, dc=False)
         assert_allclose(basis(coeffs), coeffs @ matrix, rtol=TOL)
 
-    def test_azhwp_synchronous_is_kronecker_shaped(self) -> None:
+    def test_azimuth_hwp_synchronous_is_kronecker_shaped(self) -> None:
         n_samps, n_harm = 200, 3
         azimuth, hwp = _geometry(n_samps)
         legendre = PolynomialOrders(0, 2)
-        basis = azhwp_synchronous_basis(legendre, n_harm, azimuth, hwp, jnp.float64)
+        basis = azimuth_hwp_synchronous_basis(legendre, n_harm, azimuth, hwp, jnp.float64)
         # azimuth Legendre orders x HWP harmonics with DC (2*n_harm + 1)
         assert basis.shape == (legendre.n_orders, 2 * n_harm + 1)
         coeffs = jr.normal(jr.key(931), basis.shape)
@@ -600,23 +600,23 @@ class TestSynchronousTemplates:
             jnp.vdot(basis(coeffs), signal), jnp.vdot(coeffs, basis.T(signal)), rtol=TOL
         )
 
-    def test_azhwp_scan_mask_zeroes_flagged_samples(self) -> None:
+    def test_azimuth_hwp_scan_mask_zeroes_flagged_samples(self) -> None:
         # zeroing the azimuth leg kills every basis function there -> zero synthesis.
         n_samps, n_harm = 200, 3
         azimuth, hwp = _geometry(n_samps)
         scan_mask = (jnp.arange(n_samps) % 3 != 0).astype(jnp.float64)
-        basis = azhwp_synchronous_basis(
+        basis = azimuth_hwp_synchronous_basis(
             PolynomialOrders(0, 2), n_harm, azimuth, hwp, jnp.float64, scan_mask=scan_mask
         )
         coeffs = jr.normal(jr.key(941), basis.shape)
         out = basis(coeffs)
         assert_allclose(out[scan_mask == 0], 0.0, atol=TOL)
 
-    def test_binazhwp_synchronous_is_kronecker_shaped(self) -> None:
+    def test_binned_azimuth_hwp_synchronous_is_kronecker_shaped(self) -> None:
         n_samps, n_harm = 200, 3
         azimuth, hwp = _geometry(n_samps)
         bins = BinsConfig(n_bins=5, interpolate=False, smooth=False)
-        basis = binazhwp_synchronous_basis(bins, n_harm, azimuth, hwp, jnp.float64)
+        basis = binned_azimuth_hwp_synchronous_basis(bins, n_harm, azimuth, hwp, jnp.float64)
         assert basis.shape == (bins.n_bins, 2 * n_harm + 1)
         coeffs = jr.normal(jr.key(951), basis.shape)
         signal = jr.normal(jr.key(952), basis.out_structure.shape)
@@ -695,7 +695,7 @@ class TestPolynomialMask:
 
 
 # ---------------------------------------------------------------------------
-# temperature_basis (T2P leakage template's per-detector basis)
+# t2p_basis (T2P leakage template's per-detector basis)
 # ---------------------------------------------------------------------------
 
 
@@ -704,7 +704,7 @@ class TestTemperatureTemplate:
         # each detector's basis is its own temperature stream -> mv(lambda) = lambda * T_d
         n_dets, n_samps = 4, 200
         T = jr.normal(jr.key(40), (n_dets, n_samps))
-        op = _wrap(temperature_basis(T, jnp.float64), n_dets)
+        op = _wrap(t2p_basis(T, jnp.float64), n_dets)
         assert op.in_structure['t'].shape == (n_dets, 1)  # one amplitude per detector
         lam = jr.normal(jr.key(41), (n_dets, 1))
         assert_allclose(op({'t': lam}), lam * T, rtol=TOL)
@@ -712,14 +712,14 @@ class TestTemperatureTemplate:
     def test_projection_is_per_detector_inner_product(self) -> None:
         n_dets, n_samps = 4, 200
         T = jr.normal(jr.key(42), (n_dets, n_samps))
-        op = _wrap(temperature_basis(T, jnp.float64), n_dets)
+        op = _wrap(t2p_basis(T, jnp.float64), n_dets)
         x = jr.normal(jr.key(43), (n_dets, n_samps))
         assert_allclose(op.T(x)['t'], jnp.sum(T * x, axis=-1)[:, None], rtol=TOL)
 
     def test_adjoint(self) -> None:
         n_dets, n_samps = 4, 200
         T = jr.normal(jr.key(44), (n_dets, n_samps))
-        op = _wrap(temperature_basis(T, jnp.float64), n_dets)
+        op = _wrap(t2p_basis(T, jnp.float64), n_dets)
         lam = jr.normal(jr.key(45), (n_dets, 1))
         x = jr.normal(jr.key(46), (n_dets, n_samps))
         assert_allclose(jnp.vdot(op({'t': lam}), x), jnp.vdot(lam, op.T(x)['t']), rtol=TOL)
@@ -729,7 +729,7 @@ class TestTemperatureTemplate:
         n_obs, n_dets, n_samps = 3, 4, 200
         Ts = jr.normal(jr.key(47), (n_obs, n_dets, n_samps))
         _, stack = jax.lax.scan(
-            lambda _, Ti: (None, _wrap(temperature_basis(Ti, jnp.float64), n_dets)),
+            lambda _, Ti: (None, _wrap(t2p_basis(Ti, jnp.float64), n_dets)),
             None,
             Ts,
         )
@@ -742,7 +742,7 @@ class TestTemperatureTemplate:
         n_dets, n_samps, fs = 2, 1024, 10.0
         f0, f1 = 0.5, 2.0
         T = jr.normal(jr.key(49), (n_dets, n_samps))
-        basis = temperature_basis(T, jnp.float64, fit_band=(f0, f1), sample_rate=fs)
+        basis = t2p_basis(T, jnp.float64, fit_band=(f0, f1), sample_rate=fs)
         op = _wrap(basis, n_dets)
         out = op({'t': jnp.ones((n_dets, 1))})  # = bandpass(T) since lambda = 1
         spec = jnp.abs(jnp.fft.rfft(out, axis=-1))
@@ -755,7 +755,7 @@ class TestTemperatureTemplate:
         # block-averaged temperature, held over each block.
         n_dets, n_samps, q = 2, 60, 4
         T = jr.normal(jr.key(970), (n_dets, n_samps))
-        op = _wrap(temperature_basis(T, jnp.float64, decimation_factor=q), n_dets)
+        op = _wrap(t2p_basis(T, jnp.float64, decimation_factor=q), n_dets)
         assert op.in_structure['t'].shape == (n_dets, 1)
         out = op({'t': jnp.ones((n_dets, 1))})
         assert out.shape == (n_dets, n_samps)
@@ -831,11 +831,11 @@ class TestATOPProjectionOperator:
 
 
 # ---------------------------------------------------------------------------
-# SplineHWPSS basis functions and template
+# Spline HWP-synchronous basis functions and template
 # ---------------------------------------------------------------------------
 
 
-class TestSplineHWPSSConfig:
+class TestSplineHWPSynchronousConfig:
     @pytest.mark.parametrize(
         ('n_knots', 'samples_per_knot', 'expected'),
         [
@@ -849,20 +849,20 @@ class TestSplineHWPSSConfig:
     def test_resolve_n_knots(
         self, n_knots: int | None, samples_per_knot: int | None, expected: int
     ) -> None:
-        config = SplineHWPSSConfig(n_knots=n_knots, samples_per_knot=samples_per_knot)
+        config = SplineHWPSynchronousConfig(n_knots=n_knots, samples_per_knot=samples_per_knot)
         assert config.resolve_n_knots(100) == expected
 
     def test_requires_one_of_n_knots_or_samples_per_knot(self) -> None:
         with pytest.raises(ValueError, match='one of'):
-            SplineHWPSSConfig(n_knots=None, samples_per_knot=None)
+            SplineHWPSynchronousConfig(n_knots=None, samples_per_knot=None)
 
 
-class TestSplineHWPSSTemplate:
+class TestSplineHWPSynchronousTemplate:
     def test_4f_basis_structure(self) -> None:
         t = jnp.linspace(0, 10, 100)
         hwp = jnp.linspace(0, 2 * jnp.pi, 100)
         n_knots = 3
-        B = spline_4f_hwpss_basis(t, hwp, n_knots=n_knots)
+        B = spline_4f_hwp_basis(t, hwp, n_knots=n_knots)
         K = n_knots + 2
         # 2K because cos and sin blocks
         assert B.shape == (2 * K, 100)
@@ -870,7 +870,7 @@ class TestSplineHWPSSTemplate:
     def test_4f_modulation_nonzero(self) -> None:
         t = jnp.linspace(0, 10, 100)
         hwp = jnp.linspace(0, 2 * jnp.pi, 100)
-        B = spline_4f_hwpss_basis(t, hwp, n_knots=3)
+        B = spline_4f_hwp_basis(t, hwp, n_knots=3)
         sin_part = B[0]
         cos_part = B[1]
         # should not be identical
@@ -880,7 +880,7 @@ class TestSplineHWPSSTemplate:
         n_samps, n_knots = 100, 3
         t = jnp.linspace(0, 10, n_samps)
         hwp = jnp.linspace(0, 2 * jnp.pi, n_samps)
-        basis = bspline_hwpss_basis(t, hwp, n_knots, (4,), jnp.float64)
+        basis = spline_hwp_synchronous_basis(t, hwp, n_knots, (4,), jnp.float64)
 
         K = n_knots + 2
         # WindowedBasis amplitudes: (K knots, 2 = cos/sin)
@@ -888,12 +888,12 @@ class TestSplineHWPSSTemplate:
         assert basis.out_structure.shape == (n_samps,)
 
     def test_equivalent_to_dense_4f_basis(self) -> None:
-        # WindowedBasis spline_hwpss reproduces the dense (2K, N) interleaved basis.
+        # WindowedBasis spline_hwp_synchronous reproduces the dense (2K, N) interleaved basis.
         n_samps, n_knots = 120, 5
         t = jnp.linspace(0, 10, n_samps)
         hwp = jnp.linspace(0, 6 * jnp.pi, n_samps)
-        basis = bspline_hwpss_basis(t, hwp, n_knots, (4,), jnp.float64)
-        dense = TensorBasis(spline_4f_hwpss_basis(t, hwp, n_knots))  # rows 2j=sin, 2j+1=cos
+        basis = spline_hwp_synchronous_basis(t, hwp, n_knots, (4,), jnp.float64)
+        dense = TensorBasis(spline_4f_hwp_basis(t, hwp, n_knots))  # rows 2j=sin, 2j+1=cos
 
         K = n_knots + 2
         a = jr.normal(jr.key(1010), (K, 2))  # WindowedBasis amplitudes a[j] = (sin amp, cos amp)
@@ -904,7 +904,7 @@ class TestSplineHWPSSTemplate:
         n_samps, n_knots = 100, 3
         t = jnp.linspace(0, 10, n_samps)
         hwp = jnp.linspace(0, 2 * jnp.pi, n_samps)
-        basis = bspline_hwpss_basis(t, hwp, n_knots, (4,), jnp.float64)
+        basis = spline_hwp_synchronous_basis(t, hwp, n_knots, (4,), jnp.float64)
 
         coeffs = jr.normal(jr.key(1001), basis.shape)
         signal = jr.normal(jr.key(1002), basis.out_structure.shape)
@@ -913,22 +913,22 @@ class TestSplineHWPSSTemplate:
             jnp.vdot(basis(coeffs), signal), jnp.vdot(coeffs, basis.T(signal)), rtol=TOL
         )
 
-    def test_spline_hwpss_multiple_harmonics(self) -> None:
+    def test_spline_hwp_synchronous_multiple_harmonics(self) -> None:
         n_samps = 100
         t = jnp.linspace(0, 10, n_samps)
         hwp = jnp.linspace(0, 2 * jnp.pi, n_samps)
         harmonics = [2, 4]
-        basis = bspline_hwpss_basis(t, hwp, 4, harmonics, jnp.float64)
+        basis = spline_hwp_synchronous_basis(t, hwp, 4, harmonics, jnp.float64)
         # amplitudes: (K, 2 * n_harm)
         # K = n_knots + 2 = 4 + 2 = 6
         # 2 * n_harm = 2 * 2 = 4
         assert basis.shape == (6, 4)
 
-    def test_spline_hwpss_int_harmonics(self) -> None:
+    def test_spline_hwp_synchronous_int_harmonics(self) -> None:
         # an int n is the harmonics 1..n, matching `_harmonics`' convention.
         n_samps = 100
         t = jnp.linspace(0, 10, n_samps)
         hwp = jnp.linspace(0, 2 * jnp.pi, n_samps)
-        basis = bspline_hwpss_basis(t, hwp, 4, 3, jnp.float64)
+        basis = spline_hwp_synchronous_basis(t, hwp, 4, 3, jnp.float64)
         # 1..3 -> 3 harmonics -> 2 * 3 = 6 columns; K = 4 + 2 = 6
         assert basis.shape == (6, 6)

--- a/tests/mapmaking/test_templates.py
+++ b/tests/mapmaking/test_templates.py
@@ -10,17 +10,32 @@ from numpy.testing import assert_allclose, assert_array_equal
 from furax.mapmaking.config import BinsConfig, PolynomialOrders, SplineHWPSSConfig
 from furax.mapmaking.templates import (
     ATOPProjectionOperator,
+    Basis,
     KroneckerBasis,
-    PerDetectorTemplate,
     SegmentedBasis,
+    TemplateOperator,
     TensorBasis,
     WindowedBasis,
     _bin_weights,
     _harmonics,
     _legendre,
+    azhwp_synchronous_basis,
+    binaz_synchronous_basis,
+    binazhwp_synchronous_basis,
+    bspline_hwpss_basis,
+    hwp_synchronous_basis,
+    polynomial_basis,
+    scan_synchronous_basis,
+    temperature_basis,
 )
 from furax.math import bspline
 from furax.tree import as_structure
+
+
+def _wrap(basis: Basis, n_dets: int) -> TemplateOperator:
+    """Wrap a bare basis as a single-template TemplateOperator: amplitudes are {'t': ...},
+    output is a bare (n_dets, samp) array."""
+    return TemplateOperator({'t': basis}, n_dets)
 
 
 def spline_4f_hwpss_basis(
@@ -28,7 +43,7 @@ def spline_4f_hwpss_basis(
     hwp_angles: Float[Array, ' samp'],
     n_knots: int,
 ) -> Float[Array, '2k samp']:
-    """Dense reference for `PerDetectorTemplate.spline_hwpss`'s `WindowedBasis`.
+    """Dense reference for `bspline_hwpss_basis`'s `WindowedBasis`.
 
     Returns:
         B: (2K, N) basis matrix, interleaved rows [phi_j sin(4χ), phi_j cos(4χ)].
@@ -75,7 +90,7 @@ class TestTensorBasis:
     def test_create_structure(self, shape: tuple[int, ...]) -> None:
         n_points = 7
         values = jr.normal(jr.key(0), (*shape, n_points))
-        basis = TensorBasis.create(values)
+        basis = TensorBasis(values)
         assert basis.shape == shape
         assert basis.size == np.prod(shape)
         assert basis.n_points == n_points
@@ -87,7 +102,7 @@ class TestTensorBasis:
         n_points = 6
         values = jr.normal(jr.key(1), (*shape, n_points))
         coeffs = jr.normal(jr.key(2), shape)
-        basis = TensorBasis.create(values)
+        basis = TensorBasis(values)
 
         axes = 'abcdefg'[: len(shape)]
         expected = jnp.einsum(f'{axes},{axes}s->s', coeffs, values)
@@ -100,7 +115,7 @@ class TestTensorBasis:
         n_points = 6
         values = jr.normal(jr.key(3), (*shape, n_points))
         signal = jr.normal(jr.key(4), (n_points,))
-        basis = TensorBasis.create(values)
+        basis = TensorBasis(values)
 
         axes = 'abcdefg'[: len(shape)]
         expected = jnp.einsum(f'{axes}s,s->{axes}', values, signal)
@@ -114,19 +129,19 @@ class TestTensorBasis:
         values = jr.normal(jr.key(5), (*shape, n_points))
         coeffs = jr.normal(jr.key(6), shape)
         signal = jr.normal(jr.key(7), (n_points,))
-        basis = TensorBasis.create(values)
+        basis = TensorBasis(values)
         assert _adjoint_residual(basis, coeffs, signal) < TOL
 
     @pytest.mark.parametrize('shape', [(4,), (3, 5)])
     def test_transpose_as_matrix(self, shape: tuple[int, ...]) -> None:
         n_points = 5
         values = jr.normal(jr.key(8), (*shape, n_points))
-        basis = TensorBasis.create(values)
+        basis = TensorBasis(values)
         assert_allclose(basis.T.as_matrix().T, basis.as_matrix(), rtol=TOL)
 
     def test_out_structure_roundtrip(self) -> None:
         values = jr.normal(jr.key(9), (3, 5))
-        basis = TensorBasis.create(values)
+        basis = TensorBasis(values)
         coeffs = jr.normal(jr.key(10), (3,))
         assert as_structure(basis.expand(coeffs)) == basis.out_structure
 
@@ -145,7 +160,7 @@ class TestKroneckerBasis:
     def test_create_structure(self, shape: tuple[int, ...]) -> None:
         n_points = 7
         factors = _factors(shape, n_points, 100)
-        basis = KroneckerBasis.create(factors)
+        basis = KroneckerBasis(factors)
         assert basis.shape == shape
         assert basis.n_points == n_points
         assert basis.in_structure == jax.ShapeDtypeStruct(shape, factors[0].dtype)
@@ -156,8 +171,8 @@ class TestKroneckerBasis:
         """KroneckerBasis == TensorBasis whose values are the outer product of factors."""
         n_points = 6
         factors = _factors(shape, n_points, 200)
-        kron = KroneckerBasis.create(factors)
-        dense = TensorBasis.create(_dense_from_factors(factors))
+        kron = KroneckerBasis(factors)
+        dense = TensorBasis(_dense_from_factors(factors))
 
         coeffs = jr.normal(jr.key(210), shape)
         signal = jr.normal(jr.key(211), (n_points,))
@@ -168,7 +183,7 @@ class TestKroneckerBasis:
     def test_expand_project_adjoint(self, shape: tuple[int, ...]) -> None:
         n_points = 6
         factors = _factors(shape, n_points, 300)
-        basis = KroneckerBasis.create(factors)
+        basis = KroneckerBasis(factors)
         coeffs = jr.normal(jr.key(310), shape)
         signal = jr.normal(jr.key(311), (n_points,))
         assert _adjoint_residual(basis, coeffs, signal) < TOL
@@ -177,7 +192,7 @@ class TestKroneckerBasis:
     def test_transpose_as_matrix(self, shape: tuple[int, ...]) -> None:
         n_points = 5
         factors = _factors(shape, n_points, 400)
-        basis = KroneckerBasis.create(factors)
+        basis = KroneckerBasis(factors)
         assert_allclose(basis.T.as_matrix().T, basis.as_matrix(), rtol=TOL)
 
 
@@ -188,7 +203,7 @@ class TestKroneckerBasis:
 
 def _decimated(shape: tuple[int, ...], n_dec: int, q: int, n_full: int, seed: int):
     values = jr.normal(jr.key(seed), (*shape, n_dec))
-    return TensorBasis.create(values, q=q, n_full=n_full)
+    return TensorBasis(values, q=q, n_full=n_full)
 
 
 class TestDecimatedTensorBasis:
@@ -235,8 +250,8 @@ class TestDecimatedTensorBasis:
     def test_q_one_matches_plain_dense_basis(self) -> None:
         # q=1 stores the full grid: decimation collapses to the plain dense basis.
         values = jr.normal(jr.key(509), (4, 18))
-        decimated = TensorBasis.create(values, q=1, n_full=18)
-        plain = TensorBasis.create(values)
+        decimated = TensorBasis(values, q=1, n_full=18)
+        plain = TensorBasis(values)
         coeffs = jr.normal(jr.key(510), (4,))
         signal = jr.normal(jr.key(511), (18,))
         assert_allclose(decimated.expand(coeffs), plain.expand(coeffs), rtol=TOL)
@@ -244,12 +259,12 @@ class TestDecimatedTensorBasis:
 
     def test_create_rejects_bad_q(self) -> None:
         with pytest.raises(ValueError, match='q must be >= 1'):
-            TensorBasis.create(jr.normal(jr.key(512), (4, 5)), q=0)
+            TensorBasis(jr.normal(jr.key(512), (4, 5)), q=0)
 
     @pytest.mark.parametrize('n_full', [4, 21])  # 5*4=20: n_full must be in (16, 20]
     def test_create_rejects_inconsistent_n_full(self, n_full: int) -> None:
         with pytest.raises(ValueError, match='inconsistent'):
-            TensorBasis.create(jr.normal(jr.key(513), (4, 5)), q=4, n_full=n_full)
+            TensorBasis(jr.normal(jr.key(513), (4, 5)), q=4, n_full=n_full)
 
 
 # ---------------------------------------------------------------------------
@@ -260,7 +275,7 @@ class TestDecimatedTensorBasis:
 def _segmented(n_segments: int, k: int, n_points: int, seed: int):
     segment = jr.randint(jr.key(seed), (n_points,), 0, n_segments)
     values = jr.normal(jr.key(seed + 1), (k, n_points))
-    return SegmentedBasis.create(segment.astype(jnp.int32), values, n_segments), segment, values
+    return SegmentedBasis(segment.astype(jnp.int32), values, n_segments), segment, values
 
 
 class TestSegmentedBasis:
@@ -275,7 +290,7 @@ class TestSegmentedBasis:
         n_seg, k, n_points = 3, 4, 50
         basis, segment, values = _segmented(n_seg, k, n_points, 610)
         onehot = (segment[None, :] == jnp.arange(n_seg)[:, None]).astype(values.dtype)
-        dense = TensorBasis.create(onehot[:, None, :] * values[None, :, :])
+        dense = TensorBasis(onehot[:, None, :] * values[None, :, :])
         coeffs = jr.normal(jr.key(611), (n_seg, k))
         signal = jr.normal(jr.key(612), (n_points,))
         assert_allclose(basis.expand(coeffs), dense.expand(coeffs), rtol=TOL)
@@ -308,7 +323,7 @@ def _windowed(n_blocks: int, n_window: int, k: int, n_points: int, seed: int):
     offset = jr.randint(jr.key(seed), (n_points,), 0, n_blocks - n_window + 1)
     block_weights = jr.normal(jr.key(seed + 1), (n_window, n_points))
     sub_values = jr.normal(jr.key(seed + 2), (k, n_points))
-    basis = WindowedBasis.create(offset.astype(jnp.int32), block_weights, sub_values, n_blocks)
+    basis = WindowedBasis(offset.astype(jnp.int32), block_weights, sub_values, n_blocks)
     return basis, offset, block_weights, sub_values
 
 
@@ -334,7 +349,7 @@ class TestWindowedBasis:
     def test_equivalent_to_dense_tensor_basis(self, n_window: int, k: int) -> None:
         n_blocks, n_points = 6, 50
         basis, offset, bw, sv = _windowed(n_blocks, n_window, k, n_points, 810)
-        dense = TensorBasis.create(_windowed_dense_values(offset, bw, sv, n_blocks))
+        dense = TensorBasis(_windowed_dense_values(offset, bw, sv, n_blocks))
         coeffs = jr.normal(jr.key(811), (n_blocks, k))
         signal = jr.normal(jr.key(812), (n_points,))
         assert_allclose(basis.expand(coeffs), dense.expand(coeffs), rtol=TOL)
@@ -345,8 +360,8 @@ class TestWindowedBasis:
         n_seg, k, n_points = 4, 3, 50
         segment = jr.randint(jr.key(820), (n_points,), 0, n_seg)
         values = jr.normal(jr.key(821), (k, n_points))
-        segmented = SegmentedBasis.create(segment.astype(jnp.int32), values, n_seg)
-        windowed = WindowedBasis.create(
+        segmented = SegmentedBasis(segment.astype(jnp.int32), values, n_seg)
+        windowed = WindowedBasis(
             segment.astype(jnp.int32),
             jnp.ones((1, n_points), values.dtype),
             values,
@@ -378,6 +393,109 @@ class TestWindowedBasis:
         diff = basis.expand(bumped) - basis.expand(coeffs)
         covers = (offset <= target) & (target < offset + n_window)
         assert_allclose(diff[~covers], 0.0, atol=TOL)
+
+
+# ---------------------------------------------------------------------------
+# Basis.per_detector_stack
+# ---------------------------------------------------------------------------
+
+
+def _stacked_and_singles(flavour: str, n_dets: int, seed: int) -> tuple[Basis, list[Basis]]:
+    """A per-detector stack and the equivalent list of single-detector bases, same arrays."""
+    n_points = 30
+    k = jr.split(jr.key(seed), 4)
+    if flavour == 'tensor':
+        values = jr.normal(k[0], (n_dets, 2, n_points))
+        return TensorBasis.per_detector_stack(values=values), [TensorBasis(v) for v in values]
+    if flavour == 'kronecker':
+        f0 = jr.normal(k[0], (n_dets, 2, n_points))
+        f1 = jr.normal(k[1], (n_dets, 3, n_points))
+        return (
+            KroneckerBasis.per_detector_stack(factors=(f0, f1)),
+            [KroneckerBasis((a, b)) for a, b in zip(f0, f1, strict=True)],
+        )
+    if flavour == 'segmented':
+        n_seg = 3
+        segment = jr.randint(k[0], (n_dets, n_points), 0, n_seg).astype(jnp.int32)
+        values = jr.normal(k[1], (n_dets, 2, n_points))
+        return (
+            SegmentedBasis.per_detector_stack(segment=segment, values=values, n_segments=n_seg),
+            [SegmentedBasis(g, v, n_seg) for g, v in zip(segment, values, strict=True)],
+        )
+    if flavour == 'windowed':
+        n_blocks, n_window = 6, 4
+        offset = jr.randint(k[0], (n_dets, n_points), 0, n_blocks - n_window + 1).astype(jnp.int32)
+        weights = jr.normal(k[1], (n_dets, n_window, n_points))
+        sub = jr.normal(k[2], (n_dets, 2, n_points))
+        return (
+            WindowedBasis.per_detector_stack(
+                offset=offset,
+                block_weights=weights,
+                sub_values=sub,
+                n_blocks=n_blocks,
+            ),
+            [
+                WindowedBasis(o, w, v, n_blocks)
+                for o, w, v in zip(offset, weights, sub, strict=True)
+            ],
+        )
+    raise AssertionError(flavour)
+
+
+FLAVOURS = ['tensor', 'kronecker', 'segmented', 'windowed']
+
+
+class TestPerDetectorStack:
+    @pytest.mark.parametrize('flavour', FLAVOURS)
+    def test_keeps_the_single_detector_index(self, flavour: str) -> None:
+        # the stack describes one detector's amplitudes; only the arrays gain a detector axis.
+        stacked, singles = _stacked_and_singles(flavour, 3, 900)
+        assert stacked.per_detector
+        assert stacked.shape == singles[0].shape
+        assert stacked.in_structure == singles[0].in_structure
+        assert stacked.n_points == singles[0].n_points
+        assert [leaf.shape for leaf in jax.tree.leaves(stacked)] == [
+            (3, *leaf.shape) for leaf in jax.tree.leaves(singles[0])
+        ]
+
+    @pytest.mark.parametrize('flavour', FLAVOURS)
+    def test_expands_each_detector_with_its_own_basis(self, flavour: str) -> None:
+        n_dets = 3
+        stacked, singles = _stacked_and_singles(flavour, n_dets, 910)
+        op = _wrap(stacked, n_dets)
+        amps = jr.normal(jr.key(911), (n_dets, *singles[0].shape))
+        expected = jnp.stack([b.expand(a) for b, a in zip(singles, amps, strict=True)])
+        assert_allclose(op({'t': amps}), expected, rtol=TOL)
+
+    @pytest.mark.parametrize('flavour', FLAVOURS)
+    def test_projects_each_detector_with_its_own_basis(self, flavour: str) -> None:
+        n_dets = 3
+        stacked, singles = _stacked_and_singles(flavour, n_dets, 920)
+        op = _wrap(stacked, n_dets)
+        signal = jr.normal(jr.key(921), (n_dets, singles[0].n_points))
+        expected = jnp.stack([b.project(s) for b, s in zip(singles, signal, strict=True)])
+        assert_allclose(op.T(signal)['t'], expected, rtol=TOL)
+
+    def test_rejects_a_missing_array(self) -> None:
+        with pytest.raises(ValueError, match='WindowedBasis needs a detector-stacked sub_values'):
+            WindowedBasis.per_detector_stack(
+                offset=jnp.zeros((3, 30), jnp.int32),
+                block_weights=jnp.ones((3, 4, 30)),
+                n_blocks=6,
+            )
+
+    def test_constructor_rejects_a_hand_set_marker(self) -> None:
+        # a hand-built stack would keep the one-detector shape, silently breaking expand/project
+        with pytest.raises(ValueError, match='per_detector is set by per_detector_stack'):
+            TensorBasis(jnp.ones((3, 2, 30)), per_detector=True)
+
+    def test_rejects_disagreeing_detector_counts(self) -> None:
+        with pytest.raises(ValueError, match=r'detector axes disagree: \[2, 3\]'):
+            SegmentedBasis.per_detector_stack(
+                segment=jnp.zeros((3, 30), jnp.int32),
+                values=jnp.ones((2, 2, 30)),
+                n_segments=3,
+            )
 
 
 # ---------------------------------------------------------------------------
@@ -425,33 +543,10 @@ class TestLegendreAndHarmonics:
 
 
 # ---------------------------------------------------------------------------
-# PerDetectorTemplate wrapper (shared vs per-detector basis, transpose)
+# Synchronous templates (bare basis factories)
 # ---------------------------------------------------------------------------
-
-
-class TestPerDetectorTemplate:
-    def test_shared_basis_applies_same_basis_to_every_detector(self) -> None:
-        n_dets, k, n_points = 3, 4, 30
-        values = jr.normal(jr.key(800), (k, n_points))
-        op = PerDetectorTemplate.from_basis(TensorBasis.create(values), n_dets, shared=True)
-        assert op.in_structure.shape == (n_dets, k)
-        assert op.out_structure.shape == (n_dets, n_points)
-        coeffs = jr.normal(jr.key(801), (n_dets, k))
-        assert_allclose(op(coeffs), coeffs @ values, rtol=TOL)
-
-    def test_transpose_is_a_per_detector_template_and_is_adjoint(self) -> None:
-        n_dets, k, n_points = 3, 4, 30
-        values = jr.normal(jr.key(810), (k, n_points))
-        op = PerDetectorTemplate.from_basis(TensorBasis.create(values), n_dets, shared=True)
-        assert isinstance(op.T, PerDetectorTemplate)
-        coeffs = jr.normal(jr.key(811), op.in_structure.shape)
-        signal = jr.normal(jr.key(812), op.out_structure.shape)
-        assert_allclose(jnp.vdot(op(coeffs), signal), jnp.vdot(coeffs, op.T(signal)), rtol=TOL)
-
-
-# ---------------------------------------------------------------------------
-# Synchronous templates (factory constructors)
-# ---------------------------------------------------------------------------
+# Per-detector broadcasting and transpose-adjoint mechanics are TemplateOperator's job,
+# covered by test_template_operator.py; these test the basis construction itself.
 
 
 def _geometry(n_samps: int):
@@ -462,122 +557,115 @@ def _geometry(n_samps: int):
 
 class TestSynchronousTemplates:
     def test_scan_synchronous_is_shared_legendre(self) -> None:
-        n_dets, n_samps = 3, 200
+        n_samps = 200
         azimuth, _ = _geometry(n_samps)
         legendre = PolynomialOrders(0, 3)
-        op = PerDetectorTemplate.scan_synchronous(legendre, azimuth, n_dets, jnp.float64)
-        assert op.shared_basis
-        assert op.in_structure.shape == (n_dets, legendre.n_orders)
-        coeffs = jr.normal(jr.key(901), op.in_structure.shape)
+        basis = scan_synchronous_basis(legendre, azimuth, jnp.float64)
+        assert basis.shape == (legendre.n_orders,)
+        coeffs = jr.normal(jr.key(901), basis.shape)
         legs = _legendre(azimuth, legendre.min_order, legendre.max_order, jnp.float64)
-        assert_allclose(op(coeffs), coeffs @ legs, rtol=TOL)
+        assert_allclose(basis(coeffs), coeffs @ legs, rtol=TOL)
 
     def test_binaz_synchronous_one_amplitude_per_bin(self) -> None:
-        n_dets, n_samps = 3, 200
+        n_samps = 200
         azimuth, _ = _geometry(n_samps)
         bins = BinsConfig(n_bins=6, interpolate=False, smooth=False)
-        op = PerDetectorTemplate.binaz_synchronous(bins, azimuth, n_dets, jnp.float64)
-        assert op.in_structure.shape == (n_dets, bins.n_bins)
-        coeffs = jr.normal(jr.key(911), op.in_structure.shape)
-        signal = jr.normal(jr.key(912), op.out_structure.shape)
-        assert_allclose(jnp.vdot(op(coeffs), signal), jnp.vdot(coeffs, op.T(signal)), rtol=TOL)
+        basis = binaz_synchronous_basis(bins, azimuth, jnp.float64)
+        assert basis.shape == (bins.n_bins,)
+        coeffs = jr.normal(jr.key(911), basis.shape)
+        signal = jr.normal(jr.key(912), basis.out_structure.shape)
+        assert_allclose(
+            jnp.vdot(basis(coeffs), signal), jnp.vdot(coeffs, basis.T(signal)), rtol=TOL
+        )
 
     def test_hwp_synchronous_has_two_rows_per_harmonic(self) -> None:
-        n_dets, n_samps, n_harm = 3, 200, 4
+        n_samps, n_harm = 200, 4
         _, hwp = _geometry(n_samps)
-        op = PerDetectorTemplate.hwp_synchronous(n_harm, hwp, n_dets, jnp.float64)
-        assert op.in_structure.shape == (n_dets, 2 * n_harm)  # no DC row
-        coeffs = jr.normal(jr.key(921), op.in_structure.shape)
+        basis = hwp_synchronous_basis(n_harm, hwp, jnp.float64)
+        assert basis.shape == (2 * n_harm,)  # no DC row
+        coeffs = jr.normal(jr.key(921), basis.shape)
         matrix = _harmonics(hwp, n_harm, jnp.float64, dc=False)
-        assert_allclose(op(coeffs), coeffs @ matrix, rtol=TOL)
+        assert_allclose(basis(coeffs), coeffs @ matrix, rtol=TOL)
 
     def test_azhwp_synchronous_is_kronecker_shaped(self) -> None:
-        n_dets, n_samps, n_harm = 2, 200, 3
+        n_samps, n_harm = 200, 3
         azimuth, hwp = _geometry(n_samps)
         legendre = PolynomialOrders(0, 2)
-        op = PerDetectorTemplate.azhwp_synchronous(
-            legendre, n_harm, azimuth, hwp, n_dets, jnp.float64
-        )
+        basis = azhwp_synchronous_basis(legendre, n_harm, azimuth, hwp, jnp.float64)
         # azimuth Legendre orders x HWP harmonics with DC (2*n_harm + 1)
-        assert op.in_structure.shape == (n_dets, legendre.n_orders, 2 * n_harm + 1)
-        coeffs = jr.normal(jr.key(931), op.in_structure.shape)
-        signal = jr.normal(jr.key(932), op.out_structure.shape)
-        assert_allclose(jnp.vdot(op(coeffs), signal), jnp.vdot(coeffs, op.T(signal)), rtol=TOL)
+        assert basis.shape == (legendre.n_orders, 2 * n_harm + 1)
+        coeffs = jr.normal(jr.key(931), basis.shape)
+        signal = jr.normal(jr.key(932), basis.out_structure.shape)
+        assert_allclose(
+            jnp.vdot(basis(coeffs), signal), jnp.vdot(coeffs, basis.T(signal)), rtol=TOL
+        )
 
     def test_azhwp_scan_mask_zeroes_flagged_samples(self) -> None:
         # zeroing the azimuth leg kills every basis function there -> zero synthesis.
-        n_dets, n_samps, n_harm = 2, 200, 3
+        n_samps, n_harm = 200, 3
         azimuth, hwp = _geometry(n_samps)
         scan_mask = (jnp.arange(n_samps) % 3 != 0).astype(jnp.float64)
-        op = PerDetectorTemplate.azhwp_synchronous(
-            PolynomialOrders(0, 2), n_harm, azimuth, hwp, n_dets, jnp.float64, scan_mask=scan_mask
+        basis = azhwp_synchronous_basis(
+            PolynomialOrders(0, 2), n_harm, azimuth, hwp, jnp.float64, scan_mask=scan_mask
         )
-        coeffs = jr.normal(jr.key(941), op.in_structure.shape)
-        out = op(coeffs)
-        assert_allclose(out[:, scan_mask == 0], 0.0, atol=TOL)
+        coeffs = jr.normal(jr.key(941), basis.shape)
+        out = basis(coeffs)
+        assert_allclose(out[scan_mask == 0], 0.0, atol=TOL)
 
     def test_binazhwp_synchronous_is_kronecker_shaped(self) -> None:
-        n_dets, n_samps, n_harm = 2, 200, 3
+        n_samps, n_harm = 200, 3
         azimuth, hwp = _geometry(n_samps)
         bins = BinsConfig(n_bins=5, interpolate=False, smooth=False)
-        op = PerDetectorTemplate.binazhwp_synchronous(
-            bins, n_harm, azimuth, hwp, n_dets, jnp.float64
+        basis = binazhwp_synchronous_basis(bins, n_harm, azimuth, hwp, jnp.float64)
+        assert basis.shape == (bins.n_bins, 2 * n_harm + 1)
+        coeffs = jr.normal(jr.key(951), basis.shape)
+        signal = jr.normal(jr.key(952), basis.out_structure.shape)
+        assert_allclose(
+            jnp.vdot(basis(coeffs), signal), jnp.vdot(coeffs, basis.T(signal)), rtol=TOL
         )
-        assert op.in_structure.shape == (n_dets, bins.n_bins, 2 * n_harm + 1)
-        coeffs = jr.normal(jr.key(951), op.in_structure.shape)
-        signal = jr.normal(jr.key(952), op.out_structure.shape)
-        assert_allclose(jnp.vdot(op(coeffs), signal), jnp.vdot(coeffs, op.T(signal)), rtol=TOL)
 
 
 # ---------------------------------------------------------------------------
-# PerDetectorTemplate.polynomial (structure, gaps)
+# polynomial_basis (structure, gaps)
 # ---------------------------------------------------------------------------
 
 
 class TestPolynomialStructure:
-    def test_amplitude_shape_is_dets_intervals_orders(self) -> None:
-        n_samps, n_dets, order = 200, 3, 3
+    def test_amplitude_shape_is_intervals_orders(self) -> None:
+        n_samps, order = 200, 3
         intervals = jnp.array([[0, 100], [100, 200]])
         times = jnp.arange(n_samps, dtype=jnp.float64)
-        op = PerDetectorTemplate.polynomial(order, intervals, times, n_dets, jnp.float64)
-        # one polynomial (orders 0..order) per interval per detector
-        assert op.in_structure.shape == (n_dets, 2, order + 1)
-        assert op.out_structure.shape == (n_dets, n_samps)
+        basis = polynomial_basis(order, intervals, times, jnp.float64)
+        # one polynomial (orders 0..order) per interval
+        assert basis.shape == (2, order + 1)
+        assert basis.out_structure.shape == (n_samps,)
 
     def test_samples_in_gaps_carry_no_signal(self) -> None:
         # a gap between intervals: those samples sit in no segment -> zero column.
-        n_samps, n_dets, order = 200, 2, 3
+        n_samps, order = 200, 3
         intervals = jnp.array([[0, 80], [120, 200]])  # 80..120 is a gap
         times = jnp.arange(n_samps, dtype=jnp.float64)
-        op = PerDetectorTemplate.polynomial(order, intervals, times, n_dets, jnp.float64)
-        coeffs = jr.normal(jr.key(960), op.in_structure.shape)
-        out = op(coeffs)
+        basis = polynomial_basis(order, intervals, times, jnp.float64)
+        coeffs = jr.normal(jr.key(960), basis.shape)
+        out = basis(coeffs)
         gap = (jnp.arange(n_samps) >= 80) & (jnp.arange(n_samps) < 120)
-        assert_allclose(out[:, gap], 0.0, atol=TOL)
+        assert_allclose(out[gap], 0.0, atol=TOL)
 
 
 # ---------------------------------------------------------------------------
-# PerDetectorTemplate.polynomial (masking)
+# polynomial_basis (masking)
 # ---------------------------------------------------------------------------
 
 
 class TestPolynomialMask:
     n_samps = 200
-    n_dets = 3
     max_poly_order = 3
 
     def _setup(self, valid_mask):
         half = self.n_samps // 2
         intervals = jnp.array([[0, half], [half, self.n_samps]])
         times = jnp.arange(self.n_samps, dtype=jnp.float64)
-        return PerDetectorTemplate.polynomial(
-            max_poly_order=self.max_poly_order,
-            intervals=intervals,
-            times=times,
-            n_dets=self.n_dets,
-            dtype=jnp.float64,
-            valid_mask=valid_mask,
-        )
+        return polynomial_basis(self.max_poly_order, intervals, times, jnp.float64, valid_mask)
 
     def _valid_mask(self) -> Float[Array, ' samp']:
         # flag every 5th sample
@@ -585,29 +673,29 @@ class TestPolynomialMask:
 
     def test_mask_zeros_template_at_flagged_samples(self) -> None:
         valid = self._valid_mask()
-        op = self._setup(valid)
-        coeffs = jr.normal(jr.key(20), op.in_structure.shape)
-        out = op(coeffs)
+        basis = self._setup(valid)
+        coeffs = jr.normal(jr.key(20), basis.shape)
+        out = basis(coeffs)
         # flagged samples carry no template signal
-        assert_allclose(out[:, valid == 0], 0.0, atol=TOL)
+        assert_allclose(out[valid == 0], 0.0, atol=TOL)
 
     def test_mask_drops_flagged_from_projection(self) -> None:
         valid = self._valid_mask()
-        op = self._setup(valid)
-        signal = jr.normal(jr.key(21), op.out_structure.shape)
+        basis = self._setup(valid)
+        signal = jr.normal(jr.key(21), basis.out_structure.shape)
         # corrupting flagged samples must not change the projected coefficients
-        corrupt = signal.at[:, valid == 0].add(1e3)
-        assert_allclose(op.T(signal), op.T(corrupt), atol=TOL)
+        corrupt = signal.at[valid == 0].add(1e3)
+        assert_allclose(basis.T(signal), basis.T(corrupt), atol=TOL)
 
     def test_no_mask_matches_explicit_ones(self) -> None:
-        op_none = self._setup(None)
-        op_ones = self._setup(jnp.ones(self.n_samps, dtype=jnp.float64))
-        coeffs = jr.normal(jr.key(22), op_none.in_structure.shape)
-        assert_allclose(op_none(coeffs), op_ones(coeffs), rtol=TOL)
+        basis_none = self._setup(None)
+        basis_ones = self._setup(jnp.ones(self.n_samps, dtype=jnp.float64))
+        coeffs = jr.normal(jr.key(22), basis_none.shape)
+        assert_allclose(basis_none(coeffs), basis_ones(coeffs), rtol=TOL)
 
 
 # ---------------------------------------------------------------------------
-# PerDetectorTemplate per-detector basis (T2P leakage template)
+# temperature_basis (T2P leakage template's per-detector basis)
 # ---------------------------------------------------------------------------
 
 
@@ -616,66 +704,60 @@ class TestTemperatureTemplate:
         # each detector's basis is its own temperature stream -> mv(lambda) = lambda * T_d
         n_dets, n_samps = 4, 200
         T = jr.normal(jr.key(40), (n_dets, n_samps))
-        op = PerDetectorTemplate.temperature(T, jnp.float64)
-        assert op.in_structure.shape == (n_dets, 1)  # one amplitude per detector
-        lam = jr.normal(jr.key(41), op.in_structure.shape)
-        assert_allclose(op(lam), lam * T, rtol=TOL)
+        op = _wrap(temperature_basis(T, jnp.float64), n_dets)
+        assert op.in_structure['t'].shape == (n_dets, 1)  # one amplitude per detector
+        lam = jr.normal(jr.key(41), (n_dets, 1))
+        assert_allclose(op({'t': lam}), lam * T, rtol=TOL)
 
     def test_projection_is_per_detector_inner_product(self) -> None:
         n_dets, n_samps = 4, 200
         T = jr.normal(jr.key(42), (n_dets, n_samps))
-        op = PerDetectorTemplate.temperature(T, jnp.float64)
-        x = jr.normal(jr.key(43), op.out_structure.shape)
-        assert_allclose(op.T(x), jnp.sum(T * x, axis=-1)[:, None], rtol=TOL)
+        op = _wrap(temperature_basis(T, jnp.float64), n_dets)
+        x = jr.normal(jr.key(43), (n_dets, n_samps))
+        assert_allclose(op.T(x)['t'], jnp.sum(T * x, axis=-1)[:, None], rtol=TOL)
 
     def test_adjoint(self) -> None:
         n_dets, n_samps = 4, 200
         T = jr.normal(jr.key(44), (n_dets, n_samps))
-        op = PerDetectorTemplate.temperature(T, jnp.float64)
-        lam = jr.normal(jr.key(45), op.in_structure.shape)
-        x = jr.normal(jr.key(46), op.out_structure.shape)
-        assert_allclose(jnp.vdot(op(lam), x), jnp.vdot(lam, op.T(x)), rtol=TOL)
+        op = _wrap(temperature_basis(T, jnp.float64), n_dets)
+        lam = jr.normal(jr.key(45), (n_dets, 1))
+        x = jr.normal(jr.key(46), (n_dets, n_samps))
+        assert_allclose(jnp.vdot(op({'t': lam}), x), jnp.vdot(lam, op.T(x)['t']), rtol=TOL)
 
     def test_scan_stacking_over_observations(self) -> None:
         # the per-detector basis values gain an obs axis under lax.scan; one program
         n_obs, n_dets, n_samps = 3, 4, 200
         Ts = jr.normal(jr.key(47), (n_obs, n_dets, n_samps))
         _, stack = jax.lax.scan(
-            lambda _, Ti: (None, PerDetectorTemplate.temperature(Ti, jnp.float64)), None, Ts
+            lambda _, Ti: (None, _wrap(temperature_basis(Ti, jnp.float64), n_dets)),
+            None,
+            Ts,
         )
         op0 = jax.tree.map(lambda leaf: leaf[0], stack)
-        lam = jr.normal(jr.key(48), op0.in_structure.shape)
-        assert_allclose(op0(lam), lam * Ts[0], rtol=TOL)
+        lam = jr.normal(jr.key(48), (n_dets, 1))
+        assert_allclose(op0({'t': lam}), lam * Ts[0], rtol=TOL)
 
     def test_fit_band_limits_the_basis_to_the_band(self) -> None:
         # fit_band band-passes the temperature basis: synthesis lives only in (f0, f1)
         n_dets, n_samps, fs = 2, 1024, 10.0
         f0, f1 = 0.5, 2.0
         T = jr.normal(jr.key(49), (n_dets, n_samps))
-        op = PerDetectorTemplate.temperature(T, jnp.float64, fit_band=(f0, f1), sample_rate=fs)
-        lam = jnp.ones((n_dets, 1))
-        out = op(lam)  # = bandpass(T) since lambda = 1
+        basis = temperature_basis(T, jnp.float64, fit_band=(f0, f1), sample_rate=fs)
+        op = _wrap(basis, n_dets)
+        out = op({'t': jnp.ones((n_dets, 1))})  # = bandpass(T) since lambda = 1
         spec = jnp.abs(jnp.fft.rfft(out, axis=-1))
         freqs = jnp.fft.rfftfreq(n_samps, d=1.0 / fs)
         out_of_band = (freqs <= f0) | (freqs >= f1)
         assert jnp.max(spec[:, out_of_band]) < TOL  # power confined to the band
-
-    def test_none_leg_has_no_amplitudes_and_zero_output(self) -> None:
-        n_dets, n_samps = 4, 200
-        empty = PerDetectorTemplate.none(n_dets, n_samps, jnp.float64)
-        assert empty.in_structure.shape == (n_dets, 0)  # no amplitudes to fit
-        out = empty(jnp.zeros(empty.in_structure.shape))
-        assert out.shape == (n_dets, n_samps)
-        assert_allclose(out, 0.0, atol=0.0)
 
     def test_decimated_synthesis_is_block_averaged_and_held(self) -> None:
         # decimation_factor=q stores T on a q-coarser grid; lambda = 1 -> synthesis is the
         # block-averaged temperature, held over each block.
         n_dets, n_samps, q = 2, 60, 4
         T = jr.normal(jr.key(970), (n_dets, n_samps))
-        op = PerDetectorTemplate.temperature(T, jnp.float64, decimation_factor=q)
-        assert op.in_structure.shape == (n_dets, 1)
-        out = op(jnp.ones((n_dets, 1)))
+        op = _wrap(temperature_basis(T, jnp.float64, decimation_factor=q), n_dets)
+        assert op.in_structure['t'].shape == (n_dets, 1)
+        out = op({'t': jnp.ones((n_dets, 1))})
         assert out.shape == (n_dets, n_samps)
 
         n_dec = -(-n_samps // q)
@@ -795,56 +877,58 @@ class TestSplineHWPSSTemplate:
         assert not jnp.allclose(sin_part, cos_part)
 
     def test_template_structure(self) -> None:
-        n_dets, n_samps, n_knots = 2, 100, 3
+        n_samps, n_knots = 100, 3
         t = jnp.linspace(0, 10, n_samps)
         hwp = jnp.linspace(0, 2 * jnp.pi, n_samps)
-        op = PerDetectorTemplate.bspline_hwpss(t, hwp, n_dets, n_knots=n_knots, dtype=jnp.float64)
+        basis = bspline_hwpss_basis(t, hwp, n_knots, (4,), jnp.float64)
 
         K = n_knots + 2
-        # WindowedBasis amplitudes: (K knots, 2 = cos/sin) per detector
-        assert op.in_structure.shape == (n_dets, K, 2)
-        assert op.out_structure.shape == (n_dets, n_samps)
+        # WindowedBasis amplitudes: (K knots, 2 = cos/sin)
+        assert basis.shape == (K, 2)
+        assert basis.out_structure.shape == (n_samps,)
 
     def test_equivalent_to_dense_4f_basis(self) -> None:
         # WindowedBasis spline_hwpss reproduces the dense (2K, N) interleaved basis.
-        n_dets, n_samps, n_knots = 1, 120, 5
+        n_samps, n_knots = 120, 5
         t = jnp.linspace(0, 10, n_samps)
         hwp = jnp.linspace(0, 6 * jnp.pi, n_samps)
-        op = PerDetectorTemplate.bspline_hwpss(t, hwp, n_dets, n_knots=n_knots, dtype=jnp.float64)
-        dense = TensorBasis.create(spline_4f_hwpss_basis(t, hwp, n_knots))  # rows 2j=sin, 2j+1=cos
+        basis = bspline_hwpss_basis(t, hwp, n_knots, (4,), jnp.float64)
+        dense = TensorBasis(spline_4f_hwpss_basis(t, hwp, n_knots))  # rows 2j=sin, 2j+1=cos
 
         K = n_knots + 2
         a = jr.normal(jr.key(1010), (K, 2))  # WindowedBasis amplitudes a[j] = (sin amp, cos amp)
         # dense uses the same interleaved order [sin_0, cos_0, sin_1, cos_1, ...]
-        assert_allclose(op.operator.expand(a), dense.expand(a.reshape(-1)), rtol=TOL)
+        assert_allclose(basis.expand(a), dense.expand(a.reshape(-1)), rtol=TOL)
 
     def test_adjoint(self) -> None:
-        n_dets, n_samps, n_knots = 2, 100, 3
+        n_samps, n_knots = 100, 3
         t = jnp.linspace(0, 10, n_samps)
         hwp = jnp.linspace(0, 2 * jnp.pi, n_samps)
-        op = PerDetectorTemplate.bspline_hwpss(t, hwp, n_dets, n_knots=n_knots, dtype=jnp.float64)
+        basis = bspline_hwpss_basis(t, hwp, n_knots, (4,), jnp.float64)
 
-        coeffs = jr.normal(jr.key(1001), op.in_structure.shape)
-        signal = jr.normal(jr.key(1002), op.out_structure.shape)
-        assert _adjoint_residual(op.operator, coeffs[0], signal[0]) < TOL
-        assert_allclose(jnp.vdot(op(coeffs), signal), jnp.vdot(coeffs, op.T(signal)), rtol=TOL)
+        coeffs = jr.normal(jr.key(1001), basis.shape)
+        signal = jr.normal(jr.key(1002), basis.out_structure.shape)
+        assert _adjoint_residual(basis, coeffs, signal) < TOL
+        assert_allclose(
+            jnp.vdot(basis(coeffs), signal), jnp.vdot(coeffs, basis.T(signal)), rtol=TOL
+        )
 
     def test_spline_hwpss_multiple_harmonics(self) -> None:
-        n_dets, n_samps = 2, 100
+        n_samps = 100
         t = jnp.linspace(0, 10, n_samps)
         hwp = jnp.linspace(0, 2 * jnp.pi, n_samps)
         harmonics = [2, 4]
-        op = PerDetectorTemplate.bspline_hwpss(t, hwp, n_dets, n_knots=4, harmonics=harmonics)
-        # amplitudes: (det, K, 2 * n_harm)
+        basis = bspline_hwpss_basis(t, hwp, 4, harmonics, jnp.float64)
+        # amplitudes: (K, 2 * n_harm)
         # K = n_knots + 2 = 4 + 2 = 6
         # 2 * n_harm = 2 * 2 = 4
-        assert op.in_structure.shape == (n_dets, 6, 4)
+        assert basis.shape == (6, 4)
 
     def test_spline_hwpss_int_harmonics(self) -> None:
         # an int n is the harmonics 1..n, matching `_harmonics`' convention.
-        n_dets, n_samps = 2, 100
+        n_samps = 100
         t = jnp.linspace(0, 10, n_samps)
         hwp = jnp.linspace(0, 2 * jnp.pi, n_samps)
-        op = PerDetectorTemplate.bspline_hwpss(t, hwp, n_dets, n_knots=4, harmonics=3)
+        basis = bspline_hwpss_basis(t, hwp, 4, 3, jnp.float64)
         # 1..3 -> 3 harmonics -> 2 * 3 = 6 columns; K = 4 + 2 = 6
-        assert op.in_structure.shape == (n_dets, 6, 6)
+        assert basis.shape == (6, 6)

--- a/tests/mapmaking/test_templates.py
+++ b/tests/mapmaking/test_templates.py
@@ -98,32 +98,6 @@ class TestTensorBasis:
         assert basis.out_structure == jax.ShapeDtypeStruct((n_points,), values.dtype)
 
     @pytest.mark.parametrize('shape', [(4,), (3, 5), (2, 3, 4)])
-    def test_expand_matches_einsum(self, shape: tuple[int, ...]) -> None:
-        n_points = 6
-        values = jr.normal(jr.key(1), (*shape, n_points))
-        coeffs = jr.normal(jr.key(2), shape)
-        basis = TensorBasis(values)
-
-        axes = 'abcdefg'[: len(shape)]
-        expected = jnp.einsum(f'{axes},{axes}s->s', coeffs, values)
-        assert_allclose(basis.expand(coeffs), expected, rtol=TOL)
-        # mv is bound to expand
-        assert_allclose(basis(coeffs), expected, rtol=TOL)
-
-    @pytest.mark.parametrize('shape', [(4,), (3, 5), (2, 3, 4)])
-    def test_project_matches_einsum(self, shape: tuple[int, ...]) -> None:
-        n_points = 6
-        values = jr.normal(jr.key(3), (*shape, n_points))
-        signal = jr.normal(jr.key(4), (n_points,))
-        basis = TensorBasis(values)
-
-        axes = 'abcdefg'[: len(shape)]
-        expected = jnp.einsum(f'{axes}s,s->{axes}', values, signal)
-        assert_allclose(basis.project(signal), expected, rtol=TOL)
-        # transpose mv is bound to project
-        assert_allclose(basis.T(signal), expected, rtol=TOL)
-
-    @pytest.mark.parametrize('shape', [(4,), (3, 5), (2, 3, 4)])
     def test_expand_project_adjoint(self, shape: tuple[int, ...]) -> None:
         n_points = 6
         values = jr.normal(jr.key(5), (*shape, n_points))
@@ -188,13 +162,6 @@ class TestKroneckerBasis:
         signal = jr.normal(jr.key(311), (n_points,))
         assert _adjoint_residual(basis, coeffs, signal) < TOL
 
-    @pytest.mark.parametrize('shape', [(4,), (3, 5)])
-    def test_transpose_as_matrix(self, shape: tuple[int, ...]) -> None:
-        n_points = 5
-        factors = _factors(shape, n_points, 400)
-        basis = KroneckerBasis(factors)
-        assert_allclose(basis.T.as_matrix().T, basis.as_matrix(), rtol=TOL)
-
 
 # ---------------------------------------------------------------------------
 # TensorBasis (decimated: q > 1)
@@ -216,24 +183,14 @@ class TestDecimatedTensorBasis:
         assert basis.n_points == n_full
         assert basis.out_structure == jax.ShapeDtypeStruct((n_full,), basis.dtype)
 
-    def test_expand_holds_each_coarse_value_over_its_block(self) -> None:
-        # synthesis = einsum on coarse grid, then repeat each value q times, trimmed.
-        shape, n_dec, q, n_full = (4,), 5, 4, 18  # 5*4 = 20 > 18 -> trailing block trimmed
-        basis = _decimated(shape, n_dec, q, n_full, 501)
-        coeffs = jr.normal(jr.key(502), shape)
-        coarse = jnp.einsum('k,kd->d', coeffs, basis.values)
-        expected = jnp.repeat(coarse, q)[:n_full]
-        assert_allclose(basis.expand(coeffs), expected, rtol=TOL)
-
-    def test_project_sums_each_block(self) -> None:
-        # analysis downsamples by block-summing, then einsum back to coefficients.
-        shape, n_dec, q, n_full = (4,), 5, 4, 18
-        basis = _decimated(shape, n_dec, q, n_full, 503)
-        signal = jr.normal(jr.key(504), (n_full,))
-        pad = n_dec * q - n_full
-        block_sum = jnp.pad(signal, (0, pad)).reshape(n_dec, q).sum(axis=-1)
-        expected = jnp.einsum('kd,d->k', basis.values, block_sum)
-        assert_allclose(basis.project(signal), expected, rtol=TOL)
+    def test_holds_each_coarse_value_over_its_block(self) -> None:
+        # one basis function [1, 2, 3] on a q=2 grid covering 5 samples: each coarse value is
+        # held over its 2 samples, and the last block is trimmed to fit.
+        basis = TensorBasis(jnp.array([[1.0, 2.0, 3.0]]), q=2, n_full=5)
+        assert_allclose(basis.expand(jnp.array([1.0])), [1.0, 1.0, 2.0, 2.0, 3.0], rtol=TOL)
+        # project is its transpose: [0,1,2,3,4] block-sums to [1, 5, 4], then weights by the
+        # basis function -> 1*1 + 2*5 + 3*4.
+        assert_allclose(basis.project(jnp.arange(5.0)), [23.0], rtol=TOL)
 
     @pytest.mark.parametrize('shape', [(4,), (2, 3)])
     def test_expand_project_adjoint(self, shape: tuple[int, ...]) -> None:
@@ -242,10 +199,6 @@ class TestDecimatedTensorBasis:
         coeffs = jr.normal(jr.key(506), shape)
         signal = jr.normal(jr.key(507), (n_full,))
         assert _adjoint_residual(basis, coeffs, signal) < TOL
-
-    def test_transpose_as_matrix(self) -> None:
-        basis = _decimated((4,), 5, 4, 18, 508)
-        assert_allclose(basis.T.as_matrix().T, basis.as_matrix(), rtol=TOL)
 
     def test_q_one_matches_plain_dense_basis(self) -> None:
         # q=1 stores the full grid: decimation collapses to the plain dense basis.
@@ -378,10 +331,6 @@ class TestWindowedBasis:
         coeffs = jr.normal(jr.key(831), basis.shape)
         signal = jr.normal(jr.key(832), (50,))
         assert _adjoint_residual(basis, coeffs, signal) < TOL
-
-    def test_transpose_as_matrix(self) -> None:
-        basis, *_ = _windowed(6, 4, 3, 40, 840)
-        assert_allclose(basis.T.as_matrix().T, basis.as_matrix(), rtol=TOL)
 
     def test_each_sample_only_sees_its_window(self) -> None:
         # perturbing one block's amplitudes only changes samples whose window covers it.
@@ -858,24 +807,6 @@ class TestSplineHWPSynchronousConfig:
 
 
 class TestSplineHWPSynchronousTemplate:
-    def test_4f_basis_structure(self) -> None:
-        t = jnp.linspace(0, 10, 100)
-        hwp = jnp.linspace(0, 2 * jnp.pi, 100)
-        n_knots = 3
-        B = spline_4f_hwp_basis(t, hwp, n_knots=n_knots)
-        K = n_knots + 2
-        # 2K because cos and sin blocks
-        assert B.shape == (2 * K, 100)
-
-    def test_4f_modulation_nonzero(self) -> None:
-        t = jnp.linspace(0, 10, 100)
-        hwp = jnp.linspace(0, 2 * jnp.pi, 100)
-        B = spline_4f_hwp_basis(t, hwp, n_knots=3)
-        sin_part = B[0]
-        cos_part = B[1]
-        # should not be identical
-        assert not jnp.allclose(sin_part, cos_part)
-
     def test_template_structure(self) -> None:
         n_samps, n_knots = 100, 3
         t = jnp.linspace(0, 10, n_samps)

--- a/zensical.toml
+++ b/zensical.toml
@@ -42,6 +42,7 @@ nav = [
           "api/mapmaking/observation.md",
           "api/mapmaking/mapmaker.md",
           "api/mapmaking/config.md",
+          "api/mapmaking/templates.md",
           "api/mapmaking/preconditioner.md",
           "api/mapmaking/streaming.md",
       ] },


### PR DESCRIPTION
This PR rewrites some of the template code for mapmaking in preparation of #125.

The "two-step" single-observation mapmakers are removed.

Core rewrite:

- `Basis` gets a new static `per_detector` attribute for the case where template functions differ from detector to detector. Use `per_detector_stack()` as the constructor in that case.
- Basis factories are now module-level functions instead of classmethods on the corresponding Basis subclass.
- `PerDetectorTemplate` is removed in favour of `TemplateOperator` (for regular TODs) and `StokesTemplateOperator` (for demodulated data).

Config changes:

- Add `T2PConfig` for T->P leakage template subtraction.
- **Breaking:** template YAML keys are spelled out (`binaz_synchronous` → `binned_azimuth_synchronous`, `azhwp_synchronous` → `azimuth_hwp_synchronous`, `binazhwp_synchronous` → `binned_azimuth_hwp_synchronous`, `spline_hwpss` → `spline_hwp_synchronous`). Existing configs must be updated.
- Each template config class gains a boolean `explicit` field (not used just yet).