### PR TITLE
Ignore tuning knobs when deciding whether templates are enabled

### DIFF
--- a/docs/development/changelog.md
+++ b/docs/development/changelog.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `in_stacked`/`out_stacked` say which side carries the stream axis, per component, so one stream can mix shared and per-slice components
 - **Breaking:** `AbstractLinearOperator.__call__`, `BJPreconditioner.create`, and the `LBSObservation`/`ToastObservation` pointing helpers now raise `TypeError` (previously `ValueError`/`RuntimeError`) for invalid argument/operator/landscape types (#194)
 - Bumped ruff to 0.16.1 and updated rule selection accordingly (#194)
+- Fixed detection of templates usage in map-making configuration (#225)
 
 ## [0.12.0] - 2026-07-24
 

--- a/src/furax/mapmaking/config.py
+++ b/src/furax/mapmaking/config.py
@@ -521,7 +521,7 @@ class TemplatesConfig:
     ground: GroundConfig | None = None
     """Ground pickup template, binned in (azimuth, elevation)."""
 
-    regularization: float = 0.0
+    regularization: float = field(default=0.0, metadata={'template': False})
     """Ridge regularization strength applied to the template regression."""
 
     @classmethod
@@ -541,7 +541,12 @@ class TemplatesConfig:
     @property
     def empty(self) -> bool:
         """True when every template is disabled."""
-        return all(getattr(self, f.name) is None for f in fields(self))
+        # a field counts as a template unless marked otherwise
+        return all(
+            getattr(self, field.name) is None
+            for field in fields(self)
+            if field.metadata.get('template', True)
+        )
 
 
 @dataclass(frozen=True)

--- a/tests/mapmaking/test_config.py
+++ b/tests/mapmaking/test_config.py
@@ -5,6 +5,7 @@ import yaml
 from apischema import deserialize
 
 from furax.mapmaking import config as config_module
+from furax.mapmaking.config import HWPSynchronousConfig, MapMakingConfig, TemplatesConfig
 
 # Every config class whose docstring carries an `Examples:` block.
 EXAMPLE_CLASSES = [
@@ -56,3 +57,18 @@ def test_docstring_example_parses_and_deserializes(cls: type, yaml_block: str):
     )
     (value,) = parsed.values()
     deserialize(cls, value)
+
+
+@pytest.mark.parametrize(
+    'templates, enabled',
+    [
+        (TemplatesConfig(), False),
+        # a tuning knob always holds a value: setting one must not enable template fitting
+        (TemplatesConfig(regularization=0.1), False),
+        (TemplatesConfig(hwp_synchronous=HWPSynchronousConfig()), True),
+    ],
+    ids=['none-enabled', 'tuning-knob-only', 'one-enabled'],
+)
+def test_use_templates_follows_the_enabled_templates(templates: TemplatesConfig, enabled: bool):
+    assert templates.empty == (not enabled)
+    assert MapMakingConfig(templates=templates).use_templates == enabled


### PR DESCRIPTION
## Summary

Previously, `TemplatesConfig.empty` checked every field, including `regularization` which is always set (it is not a "template config" per se). A config with an empty templates section thus still reported `use_template=True`.

## Checklist

- [x] Tests added/updated for new or changed behavior
- [x] `uvx prek run -a` passes (ruff, mypy, etc.)
- [x] Added a changelog entry under `[Unreleased]` in `docs/development/changelog.md`, or this PR doesn't need one (e.g. internal refactor, CI-only change)
- [x] Updated docs for user-facing changes (docstrings, `docs/`)
