### PR TITLE
Exclude padded Welch windows from the noise fit

### DIFF
--- a/docs/development/changelog.md
+++ b/docs/development/changelog.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `BlockSelectOperator`: extract one block of a block-structured input, and embed a single-block operator into the whole through its transpose (#237)
 
+### Fixed
+
+- The fitted noise PSD no longer averages in Welch windows that fall in an observation's padded tail (#239)
+
 ## [0.12.1]
 
 ### Added

--- a/src/furax/mapmaking/_model.py
+++ b/src/furax/mapmaking/_model.py
@@ -22,7 +22,7 @@ from .config import (
     WeightingMode,
 )
 from .gram import gram_inverse
-from .noise import AtmosphericNoiseModel, NoiseModel, WhiteNoiseModel
+from .noise import AtmosphericNoiseModel, NoiseModel, WhiteNoiseModel, padding_aware_welch
 from .templates import (
     AbstractTemplateOperator,
     ATOPProjectionOperator,
@@ -87,7 +87,9 @@ class ObservationModel:
             data.get(ReaderField.VALID_SCANNING_MASKS),
             structure=tod_struct,
         )
-        noise_model, sample_rate = _noise_model(data, config, tod_structure=tod_struct)
+        noise_model, sample_rate = _noise_model(
+            data, config, tod_structure=tod_struct, padding=padding
+        )
         Ninv = _noise_operator(
             noise_model,
             tod_struct,
@@ -205,6 +207,7 @@ def _noise_model(
     data: Any,
     config: MapMakingConfig,
     tod_structure: jax.ShapeDtypeStruct | None = None,
+    padding: Any | None = None,
 ) -> tuple[PyTree[NoiseModel], Array]:
     """Compute the noise model and sample rate for a single observation block."""
     fs = _sample_rate(data[ReaderField.TIMESTAMPS])
@@ -227,8 +230,12 @@ def _noise_model(
 
         tod = _as_array(data[ReaderField.SAMPLE_DATA])  # (*lead, nsamp)
         lead = tod.shape[:-1]
-        f, Pxx = jax.scipy.signal.welch(
-            tod.reshape(-1, tod.shape[-1]), fs=fs, nperseg=fit_config.nperseg
+        sample_padding = 0 if padding is None else _as_array(padding[ReaderField.SAMPLE_DATA])[-1]
+        f, Pxx = padding_aware_welch(
+            tod.reshape(-1, tod.shape[-1]),
+            sample_padding,
+            fs=fs,
+            nperseg=fit_config.nperseg,
         )
         flat_model = noise_model_class.fit_psd_model(
             f, Pxx, sample_rate=fs, hwp_frequency=fhwp, config=fit_config

--- a/src/furax/mapmaking/noise.py
+++ b/src/furax/mapmaking/noise.py
@@ -253,11 +253,16 @@ def padding_aware_welch(
 ) -> tuple[Array, Array]:
     """Estimate a Welch PSD without averaging windows from a padded tail.
 
+    The segment length sets the number of frequency bins, so it is static and cannot depend on
+    `sample_padding`. When fewer than `nperseg` real samples are available, there is therefore no
+    all-real segment to average and the estimate falls back to the first one, padding included.
+    Keep `nperseg` at or below the real sample count to stay in the regime where this is exact.
+
     Args:
         tod: Time-ordered data with detector and sample axes.
         sample_padding: Number of padded samples at the end of the sample axis.
         fs: Sampling frequency.
-        nperseg: Number of samples per Welch segment.
+        nperseg: Number of samples per Welch segment, clipped to the buffer length.
 
     Returns:
         The sample frequencies and power spectral density.

--- a/src/furax/mapmaking/noise.py
+++ b/src/furax/mapmaking/noise.py
@@ -248,6 +248,48 @@ def apodization_window(size: int, kind: str = 'chebwin') -> Float[Array, ' {size
     return window
 
 
+def padding_aware_welch(
+    tod: Array, sample_padding: Array | int, *, fs: Array, nperseg: int
+) -> tuple[Array, Array]:
+    """Estimate a Welch PSD without averaging windows from a padded tail.
+
+    Args:
+        tod: Time-ordered data with detector and sample axes.
+        sample_padding: Number of padded samples at the end of the sample axis.
+        fs: Sampling frequency.
+        nperseg: Number of samples per Welch segment.
+
+    Returns:
+        The sample frequencies and power spectral density.
+    """
+    input_samples = tod.shape[-1]
+    nperseg = min(nperseg, input_samples)
+
+    noverlap = nperseg // 2
+    frequencies, _, spectrum = jax.scipy.signal.stft(
+        tod,
+        fs=fs,
+        nperseg=nperseg,
+        noverlap=noverlap,
+        detrend='constant',  # type: ignore[arg-type]
+        boundary=None,
+        padded=False,
+    )
+    periodograms = jnp.real(jnp.conjugate(spectrum) * spectrum)
+    window = (jnp.ones(1) if nperseg == 1 else jnp.hanning(nperseg + 1)[:-1]).astype(tod.dtype)
+    density_scale = window.sum() ** 2 / (fs * jnp.sum(window**2))
+    periodograms *= density_scale
+    end = None if nperseg % 2 else -1
+    periodograms = periodograms.at[..., 1:end, :].mul(2)
+
+    step = nperseg - noverlap
+    real_samples = input_samples - sample_padding
+    n_valid = jnp.maximum(1, 1 + (real_samples - nperseg) // step)
+    valid = jnp.arange(periodograms.shape[-1]) < n_valid
+    psd = jnp.sum(jnp.where(valid, periodograms, 0), axis=-1) / n_valid
+    return frequencies, psd
+
+
 def fit_white_noise_model(
     f: Float[Array, ' freqs'],
     Pxx: Float[Array, 'dets freqs'],

--- a/tests/mapmaking/test_model.py
+++ b/tests/mapmaking/test_model.py
@@ -5,7 +5,34 @@ from numpy.testing import assert_allclose, assert_array_equal
 
 from furax.mapmaking._model import _noise_model, _noise_operator, _sample_mask
 from furax.mapmaking.config import MapMakingConfig, Methods, WeightingConfig, WeightingMode
-from furax.mapmaking.noise import WhiteNoiseModel
+from furax.mapmaking.noise import WhiteNoiseModel, padding_aware_welch
+
+
+def test_padding_aware_welch_matches_unpadded_signal():
+    signal = jax.random.normal(jax.random.key(0), (2, 1024), dtype=jnp.float64)
+    expected_f, expected_psd = jax.scipy.signal.welch(signal, fs=100.0, nperseg=256)
+    padded = jnp.pad(signal, ((0, 0), (0, 512)))
+    actual_f, actual_psd = padding_aware_welch(padded, 512, fs=jnp.array(100.0), nperseg=256)
+    assert_allclose(actual_f, expected_f)
+    assert_allclose(actual_psd, expected_psd, rtol=1e-12, atol=1e-12)
+
+
+def test_padding_aware_welch_clips_segment_to_short_signal():
+    signal = jax.random.normal(jax.random.key(0), (2, 127), dtype=jnp.float64)
+    expected_f, expected_psd = jax.scipy.signal.welch(signal, fs=100.0, nperseg=256)
+    actual_f, actual_psd = padding_aware_welch(signal, 0, fs=jnp.array(100.0), nperseg=256)
+    assert_allclose(actual_f, expected_f)
+    assert_allclose(actual_psd, expected_psd, rtol=1e-12, atol=1e-12)
+
+
+def test_padding_aware_welch_preserves_float32():
+    with jax.enable_x64():
+        signal = jax.random.normal(jax.random.key(0), (2, 256), dtype=jnp.float32)
+        frequencies, psd = padding_aware_welch(
+            signal, 0, fs=jnp.array(100.0, dtype=jnp.float32), nperseg=128
+        )
+    assert frequencies.dtype == jnp.float32
+    assert psd.dtype == jnp.float32
 
 
 class TestSampleMask:


### PR DESCRIPTION
## Summary

An observation's buffers are padded to a common sample count, and `jax.scipy.signal.welch` averaged over every segment of the padded buffer, including the ones lying entirely in the zero tail. Those segments carry no signal, so the fitted PSD was biased low by an amount that depends on how much padding the observation happened to receive.

- `padding_aware_welch(tod, sample_padding, *, fs, nperseg)` computes the periodograms with `stft` and averages only the segments that start inside the real samples
- `_noise_model` receives the observation's padding and uses it, so the fit sees only real data
- Matches `jax.scipy.signal.welch` exactly on unpadded input, clips `nperseg` to short signals, and preserves float32

## Checklist

- [x] Tests added/updated for new or changed behavior
- [x] `uvx prek run -a` passes (ruff, mypy, etc.)
- [x] Added a changelog entry under `[Unreleased]` in `docs/development/changelog.md`, or this PR doesn't need one (e.g. internal refactor, CI-only change)
- [x] Updated docs for user-facing changes (docstrings, `docs/`)
