### PR TITLE
Speed up test suite using parallelism and caching

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,7 @@ jobs:
   test:
     name: "Run tests on Python ${{ matrix.python-version }}"
     runs-on: ubuntu-latest
-    timeout-minutes: 25
+    timeout-minutes: 15
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,6 +55,16 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - name: "Install dependencies"
         run: uv sync --locked --all-extras
+      # Most of the suite's wall time is XLA compilation of small kernels that do not change
+      # between runs. Entries are keyed on the jaxlib version too, so the lockfile is part of
+      # the cache key; a test that compiles something new simply misses.
+      - name: "Cache compiled XLA kernels"
+        uses: actions/cache@v6.1.0
+        with:
+          path: .pytest_cache/jax
+          key: jax-${{ matrix.python-version }}-${{ hashFiles('uv.lock') }}
+          restore-keys: |
+            jax-${{ matrix.python-version }}-
       - name: "Run tests"
         run: uv run pytest -vv -n auto
       # `insubprocess` tests re-exec themselves, which xdist reads as a worker crash, so the

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,6 +56,10 @@ jobs:
       - name: "Install dependencies"
         run: uv sync --locked --all-extras
       - name: "Run tests"
-        run: uv run pytest -vv
+        run: uv run pytest -vv -n auto
+      # `insubprocess` tests re-exec themselves, which xdist reads as a worker crash, so the
+      # parallel selection above drops them and they run here instead.
+      - name: "Run in-subprocess tests"
+        run: uv run pytest -vv -m insubprocess
       - name: "Run distributed tests"
         run: uv run pytest -vv -m distributed

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -102,9 +102,10 @@ The two sets do not overlap: `distributed` is about device count, `insubprocess`
 
 ### Suite runtime
 
-Nearly all of the wall time is XLA compilation of small kernels, not the numerics. Every run compiles from scratch, on purpose: reusing executables from an earlier run can hide a change in what the suite compiles.
+Nearly all of the wall time is XLA compilation of small kernels, not the numerics, so the two things that matter are running kernels in parallel and not compiling the same kernel twice.
 
 - `-n auto` (pytest-xdist) spreads the suite over the available cores, which is the practical local check.
+- A session fixture points JAX's persistent compilation cache at `.pytest_cache/jax`, so a re-run compiles only what changed. Set `FURAX_TEST_NO_COMPILATION_CACHE=1` to measure against cold compilation, or `FURAX_TEST_COMPILATION_CACHE_DIR` to relocate it. Deleting the directory is always safe.
 - A test costs roughly what it compiles. Adding a case that reuses shapes already covered is close to free; one that introduces a new shape, dtype, or Stokes combination is not.
 
 ## Architecture

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,7 +17,8 @@ Preserve useful human-written comments unless the code change makes them inaccur
 - `uv run path/to/script.py|command`: Run a Python file/snippet using the project environment
 - `uv add <package>`: Add a new dependency to the project
 - `uv remove <package>`: Remove a dependency from the project
-- `uv run pytest -v`: Run the full test suite
+- `uv run pytest -n auto`: Run the test suite in parallel (except distributed and in-subprocess)
+- `uv run pytest -v`: Run the test suite serially
 - `uv run pytest path/to/test.py -v`: Run a single test file
 - `uv run pytest path/to/test.py::TestClass::test_method -v`: Run a single test
 - `uv run prek run`: Run pre-commit hooks (staged files)
@@ -83,9 +84,28 @@ def foo(x: Float[jax.Array, ' n'], scale: float = 1.0) -> Float[jax.Array, ' n']
 
 - Add tests for new behaviour: cover success, failure, and edge cases.
 - Use `@pytest.mark.parametrize` for multiple similar inputs: consolidate tests that only differ in input/expected values into a single parametrized test.
-- Use `@pytest.mark.slow` for expensive tests (excluded from default test runs)
-- Top-level `tests/conftest.py` contains an session-scope autouse fixture that sets `jax_enable_x64=True` for all tests.
-- x64-off tests: mark `@pytest.mark.insubprocess` and flip `jax.config.update('jax_enable_x64', False)` in-body (the autouse fixture forces x64 on otherwise). Precedent: `tests/core/base/test_inverse.py`.
+- Tests mirror the `/src` layout.
+- `tests/conftest.py` holds the session-scope autouse fixtures every test sees, and gives the run 8 host devices via `XLA_FLAGS`.
+- Floating point: x64 is on for all tests (autouse fixture). A test that needs it off marks `insubprocess` and calls `jax.config.update('jax_enable_x64', False)` in-body, since the fixture would otherwise force it back on. Precedent: `tests/core/base/test_inverse.py`.
+
+### Markers
+
+Three markers take a test out of the default selection, each for a different reason, and each gets its own run. CI runs all four selections.
+
+| Marker | Why it cannot run with the rest | Its own run |
+| --- | --- | --- |
+| `slow` | expensive; excluded by `addopts` so the default run stays usable | `uv run pytest -m slow` |
+| `distributed` | needs several devices, and is skipped when fewer than two are visible | `uv run pytest -m distributed` |
+| `insubprocess` | re-execs itself through a hook that replaces the run protocol, which xdist reads as a crashed worker, so a parallel selection deselects it | `uv run pytest -m insubprocess` |
+
+The two sets do not overlap: `distributed` is about device count, `insubprocess` about global JAX config a test has to change before the interpreter warms up.
+
+### Suite runtime
+
+Nearly all of the wall time is XLA compilation of small kernels, not the numerics. Every run compiles from scratch, on purpose: reusing executables from an earlier run can hide a change in what the suite compiles.
+
+- `-n auto` (pytest-xdist) spreads the suite over the available cores, which is the practical local check.
+- A test costs roughly what it compiles. Adding a case that reuses shapes already covered is close to free; one that introduces a new shape, dtype, or Stokes combination is not.
 
 ## Architecture
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -89,6 +89,7 @@ dev = [
     'pytest-mock',
     'pytest-insubprocess>=1.1',
     'beartype',
+    'pytest-xdist>=3.8.0',
 ]
 docs = [
     'zensical>=0.0.50',

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,6 @@
 import logging
 import os
+from pathlib import Path
 
 import pytest
 
@@ -66,6 +67,30 @@ def enable_x64() -> None:
     import jax
 
     jax.config.update('jax_enable_x64', True)
+
+
+@pytest.fixture(scope='session', autouse=True)
+def compilation_cache() -> None:
+    """Persist XLA executables across runs, so a re-run pays for tracing but not compilation.
+
+    Most of the suite's wall time is XLA compilation of small kernels, and the same kernels come
+    back run after run. JAX keys each entry on the HLO and on the jaxlib/backend version, so a
+    stale entry is a miss, not a wrong answer. The defaults skip anything that compiles in under a
+    second or is under a few kilobytes, which is nearly every kernel here, hence the thresholds.
+
+    Set ``FURAX_TEST_NO_COMPILATION_CACHE`` to run against cold compilation instead.
+    """
+    import jax
+
+    if os.environ.get('FURAX_TEST_NO_COMPILATION_CACHE'):
+        return
+    cache_dir = os.environ.get('FURAX_TEST_COMPILATION_CACHE_DIR')
+    jax.config.update(
+        'jax_compilation_cache_dir',
+        cache_dir or str(Path(__file__).parents[1] / '.pytest_cache' / 'jax'),
+    )
+    jax.config.update('jax_persistent_cache_min_entry_size_bytes', -1)
+    jax.config.update('jax_persistent_cache_min_compile_time_secs', 0.0)
 
 
 @pytest.fixture(scope='session', autouse=True)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -30,16 +30,35 @@ def pytest_configure(config: pytest.Config) -> None:
         os.environ.setdefault('XLA_FLAGS', '--xla_force_host_platform_device_count=8')
 
 
-def pytest_collection_modifyitems(items: list[pytest.Item]) -> None:
-    """Skip ``distributed``-marked tests unless several devices are available."""
+def pytest_collection_modifyitems(config: pytest.Config, items: list[pytest.Item]) -> None:
+    """Drop the marked tests that the current session cannot run.
+
+    ``distributed`` tests need several devices, and are skipped so the summary names the selection
+    that picks them up.
+
+    ``insubprocess`` tests re-exec themselves through a hook that replaces the whole run protocol,
+    which pytest-xdist reads as a worker crash and turns into an INTERNALERROR. That same hook
+    fires before a skip mark would be honoured, so under xdist they have to leave the item list
+    outright; `pytest -m insubprocess` runs them in a serial session.
+    """
     import jax
 
-    if jax.device_count() >= 2:
+    if jax.device_count() < 2:
+        skip = pytest.mark.skip('distributed test; run with `pytest -m distributed`')
+        for item in items:
+            if item.get_closest_marker('distributed'):
+                item.add_marker(skip)
+
+    # the controller carries `dist`, each worker carries `workerinput`; both collect, and their
+    # collections have to agree, so the condition must hold on either side
+    under_xdist = getattr(config.option, 'dist', 'no') != 'no' or hasattr(config, 'workerinput')
+    if not under_xdist:
         return
-    skip = pytest.mark.skip(reason='distributed test; run with `pytest -m distributed`')
-    for item in items:
-        if item.get_closest_marker('distributed'):
-            item.add_marker(skip)
+    deselected = [item for item in items if item.get_closest_marker('insubprocess')]
+    if not deselected:
+        return
+    items[:] = [item for item in items if item.get_closest_marker('insubprocess') is None]
+    config.hook.pytest_deselected(items=deselected)
 
 
 @pytest.fixture(scope='session', autouse=True)

--- a/uv.lock
+++ b/uv.lock
@@ -896,6 +896,15 @@ wheels = [
 ]
 
 [[package]]
+name = "execnet"
+version = "2.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/bf/89/780e11f9588d9e7128a3f87788354c7946a9cbb1401ad38a48c4db9a4f07/execnet-2.1.2.tar.gz", hash = "sha256:63d83bfdd9a23e35b9c6a3261412324f964c2ec8dcd8d3c6916ee9373e0befcd", size = 166622, upload-time = "2025-11-12T09:56:37.75Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ab/84/02fc1827e8cdded4aa65baef11296a9bbe595c474f0d6d758af082d849fd/execnet-2.1.2-py3-none-any.whl", hash = "sha256:67fba928dd5a544b783f6056f449e5e3931a5c378b128bc18501f7ea79e296ec", size = 40708, upload-time = "2025-11-12T09:56:36.333Z" },
+]
+
+[[package]]
 name = "executing"
 version = "2.2.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1072,6 +1081,7 @@ dev = [
     { name = "pytest-cov" },
     { name = "pytest-insubprocess" },
     { name = "pytest-mock" },
+    { name = "pytest-xdist" },
     { name = "zensical" },
 ]
 docs = [
@@ -1130,6 +1140,7 @@ dev = [
     { name = "pytest-cov" },
     { name = "pytest-insubprocess", specifier = ">=1.1" },
     { name = "pytest-mock" },
+    { name = "pytest-xdist", specifier = ">=3.8.0" },
     { name = "zensical", specifier = ">=0.0.50" },
 ]
 docs = [
@@ -3491,6 +3502,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/68/14/eb014d26be205d38ad5ad20d9a80f7d201472e08167f0bb4361e251084a9/pytest_mock-3.15.1.tar.gz", hash = "sha256:1849a238f6f396da19762269de72cb1814ab44416fa73a8686deac10b0d87a0f", size = 34036, upload-time = "2025-09-16T16:37:27.081Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/5a/cc/06253936f4a7fa2e0f48dfe6d851d9c56df896a9ab09ac019d70b760619c/pytest_mock-3.15.1-py3-none-any.whl", hash = "sha256:0a25e2eb88fe5168d535041d09a4529a188176ae608a6d249ee65abc0949630d", size = 10095, upload-time = "2025-09-16T16:37:25.734Z" },
+]
+
+[[package]]
+name = "pytest-xdist"
+version = "3.8.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "execnet" },
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/78/b4/439b179d1ff526791eb921115fca8e44e596a13efeda518b9d845a619450/pytest_xdist-3.8.0.tar.gz", hash = "sha256:7e578125ec9bc6050861aa93f2d59f1d8d085595d6551c2c90b6f4fad8d3a9f1", size = 88069, upload-time = "2025-07-01T13:30:59.346Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ca/31/d4e37e9e550c2b92a9cbc2e4d0b7420a27224968580b5a447f420847c975/pytest_xdist-3.8.0-py3-none-any.whl", hash = "sha256:202ca578cfeb7370784a8c33d6d05bc6e13b4f25b5053c30a152269fd10f0b88", size = 46396, upload-time = "2025-07-01T13:30:56.632Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

The full suite took ~20 minutes, which made it impractical as a local check and slowed down CI results. Nearly all of that time is actually XLA compiling small kernels, so there are two things to gain: distribute them on several cores, and avoid compiling the same kernel on every run.

### Parallel runs

The suite now runs under `pytest-xdist`.

Two markers cannot take part in a parallel selection:
- `insubprocess` tests re-exec themselves and this is ultimately read as a crash, so `pytest_collection_modify_items` deselects those items outright when the session is under xdist. `uv run pytest -m insubprocess` runs them serially.
- `distributed` tests need at least two devices and are skipped otherwise, as before.

CI runs the parallel selection, then `-m insubprocess` and `-m distributed` in their own sessions.

### Caching

A session fixture points JAX's persistent compilation cache at `.pytest_cache/jax`, so a re-run pays for tracing but not for compilation. On this PR this results in a ~2min additional gain.

CI restores the same directory between runs, keyed on `uv.lock` so a jax/jaxlib upgrade starts from scratch.

Use `FURAX_TEST_NO_COMPILATION_CACHE=1` to force cold compilation. Change `FURAX_TEST_COMPILATION_CACHE_DIR` to relocate the cache.

## Checklist

- [x] Tests added/updated for new or changed behavior
- [x] `uvx prek run -a` passes (ruff, mypy, etc.)
- [x] Added a changelog entry under `[Unreleased]` in `docs/development/changelog.md`, or this PR doesn't need one (e.g. internal refactor, CI-only change)
- [x] Updated docs for user-facing changes (docstrings, `docs/`)
