### PR TITLE
Change type-checker from mypy to ty

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -5,6 +5,6 @@
 ## Checklist
 
 - [ ] Tests added/updated for new or changed behavior
-- [ ] `uvx prek run -a` passes (ruff, mypy, etc.)
+- [ ] `uvx prek run -a` passes (ruff, ty, etc.)
 - [ ] Added a changelog entry under `[Unreleased]` in `docs/development/changelog.md`, or this PR doesn't need one (e.g. internal refactor, CI-only change)
 - [ ] Updated docs for user-facing changes (docstrings, `docs/`)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,11 +29,15 @@ jobs:
           key: prek-${{ hashFiles('.pre-commit-config.yaml') }}
           restore-keys: |
             prek-
+      # ty resolves third-party imports from the environment, so the optional dependencies have
+      # to be installed for it to see pixell, sotodlib, pysm3 and friends.
+      - name: "Install dependencies"
+        run: uv sync --locked --all-extras --no-default-groups --group lint
       - name: "Run prek"
         run: |
           echo '```console' > "$GITHUB_STEP_SUMMARY"
           # Enable color output for prek and remove it for the summary
-          uv run --only-group lint --locked prek run --all-files --show-diff-on-failure --color always | \
+          uv run --no-sync prek run --all-files --show-diff-on-failure --color always | \
             tee >(sed -E 's/\x1B\[([0-9]{1,2}(;[0-9]{1,2})*)?[mGK]//g' >> "$GITHUB_STEP_SUMMARY") >&1
           exit_code="${PIPESTATUS[0]}"
           echo '```' >> "$GITHUB_STEP_SUMMARY"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -31,25 +31,9 @@ repos:
   hooks:
   - id: uv-lock
 
-- repo: https://github.com/pre-commit/mirrors-mypy
-  rev: v2.3.1
+- repo: https://github.com/astral-sh/ty-pre-commit
+  rev: v0.0.80
   hooks:
-  - id: mypy
-    additional_dependencies:
-    - apischema
-    - astropy
-    - healpy
-    - jax==0.11.1
-    - jaxtyping
-    - jax-healpy
-    - lineax
-    - types-PyYAML
-    - scipy
-    - traitlets
-    args:
-    - --strict
-    - --show-error-codes
-    - --enable-error-code=ignore-without-code
-    - --allow-untyped-calls
-    - --num-workers=4
-    files: ^src/
+  - id: ty
+
+exclude: '^slurms/'

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,7 +25,7 @@ Preserve useful human-written comments unless the code change makes them inaccur
 - `uv run prek run -a`: Run pre-commit hooks (all files)
 - `uv run prek ruff-check`: Run linting hook
 - `uv run prek ruff-format`: Run formatting hook
-- `uv run prek mypy`: Run type-checking hook
+- `uv run prek ty`: Run type-checking hook
 
 ## Guidelines
 
@@ -76,7 +76,7 @@ def foo(x: Float[jax.Array, ' n'], scale: float = 1.0) -> Float[jax.Array, ' n']
 ## When to ask first
 
 - Don't add or remove dependencies (`uv add`/`uv remove`) without confirming.
-- Don't weaken checks to go green: no blanket `# type: ignore` / `# noqa` or relaxing ruff/mypy config — fix the cause or ask.
+- Don't weaken checks to go green: no blanket `# ty: ignore` / `# noqa` or relaxing ruff/ty config — fix the cause or ask.
 - Don't change operator algebra (tags, composition/addition reduction rules) or public API signatures without confirming.
 - If a task needs tools or permissions beyond what's available, stop and ask rather than guess.
 

--- a/docs/development/changelog.md
+++ b/docs/development/changelog.md
@@ -17,6 +17,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Group mapmaker observations into buckets of similar buffer shape to reduce padding overhead (#236)
 - Migrate quaternion operations to `fastquat` (#247)
+- **Breaking:** `Stokes.from_stokes` takes lowercase keywords (`i=`, `q=`, `u=`, `v=`) and no longer accepts uppercase ones (#250)
+- Type checking moved from mypy to ty (#250)
 
 ### Removed
 
@@ -26,6 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - The fitted noise PSD no longer averages in Welch windows that fall in an observation's padded tail (#239)
 - The Welch segment is clipped to the shortest observation, so the noise fit never sees a padded sample (#236)
+- Aligned `Stokes.from_stokes` keyword handling with its declared overloads (#250)
 
 ## [0.12.1]
 

--- a/docs/development/contributing.md
+++ b/docs/development/contributing.md
@@ -24,7 +24,7 @@ pip install -e .[dev]
 
 This installs:
 - Core dependencies (JAX, Lineax, etc.)
-- Development tools (pytest, mypy, ruff, pre-commit)
+- Development tools (pytest, ty, ruff, pre-commit)
 - Documentation tools (zensical, etc.)
 
 ### Pre-commit Hooks
@@ -61,14 +61,14 @@ Configuration:
 
 ### Type Checking
 
-We use MyPy for static type checking:
+We use [ty](https://github.com/astral-sh/ty) for static type checking:
 
 ```bash
 # Type check the core package
-mypy src/furax/
+uv run ty check
 ```
 
-Type checking is enforced only on the `src/furax/` directory. External dependencies like `healpy` and `jax-healpy` are ignored.
+Type checking is enforced only on the `src/furax/` directory. Untyped dependencies like `toast` and `litebird_sim` are replaced with `Any`.
 
 Key requirements:
 - All public functions should have type annotations
@@ -291,7 +291,7 @@ where $P$ is the pointing matrix.
 ### Before Submitting
 
 1. Ensure all tests pass: `pytest`
-2. Check code quality: `ruff check src/` and `mypy src/furax/`
+2. Check code quality: `ruff check src/` and `uv run ty check`
 3. Update documentation if needed
 4. Add tests for new functionality
 

--- a/docs/user_guide/getting_started.md
+++ b/docs/user_guide/getting_started.md
@@ -38,7 +38,7 @@ Furax relies on the JAX ecosystem and scientific Python packages:
 
 - **Core**: JAX
 - **Astronomy**: jax-healpy, astropy
-- **Development**: pytest, pre-commit, ruff, mypy
+- **Development**: pytest, pre-commit, ruff, ty
 
 ## First Steps
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -119,6 +119,12 @@ replace-imports-with-any = [
     'toast.**',
 ]
 
+[tool.ty.rules]
+dynamic-function-decorator-return = "error"
+missing-type-argument = "error"
+possibly-unresolved-reference = "warn"
+unused-ignore-comment = "error"
+
 [tool.ty.src]
 include = ["src/furax"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -111,27 +111,16 @@ skip_covered = true
 [tool.hatch.version]
 source = 'vcs'
 
-[[tool.mypy.overrides]]
-module = [
-    'astropy.*',
-    'cadre',
-    'cyclopts',
-    'fastquat',
-    'healpy',
-    'jax_healpy',
-    'lineax',
-    'matplotlib.*',
-    'mpl_toolkits.*',
+[tool.ty.analysis]
+replace-imports-with-any = [
     'litebird_sim',
-    'pixell.*',
-    'pysm3.*',
-    'scipy.*',
-    'so3g.*',
-    'sotodlib.*',
-    'toast.*',
-    'wadler_lindig',
+    'litebird_sim.**',
+    'toast',
+    'toast.**',
 ]
-ignore_missing_imports = true
+
+[tool.ty.src]
+include = ["src/furax"]
 
 [tool.pytest]
 # addopts includes jaxtyping option for type-checking tests:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -126,7 +126,7 @@ possibly-unresolved-reference = "warn"
 unused-ignore-comment = "error"
 
 [tool.ty.src]
-include = ["src/furax"]
+include = ["src"]
 
 [tool.pytest]
 # addopts includes jaxtyping option for type-checking tests:

--- a/src/furax/_config.py
+++ b/src/furax/_config.py
@@ -34,11 +34,11 @@ class ConfigState:
     solver_options: dict[str, Any] = field(default_factory=dict)
     solver_callback: Callable[[lx.Solution], None] = default_solver_callback
 
-    def tree_flatten(self):  # type: ignore[no-untyped-def]
+    def tree_flatten(self):
         return (), asdict(self)
 
     @classmethod
-    def tree_unflatten(cls, aux_data, children):  # type: ignore[no-untyped-def]
+    def tree_unflatten(cls, aux_data, children):
         return cls(**aux_data)
 
 

--- a/src/furax/_config.py
+++ b/src/furax/_config.py
@@ -23,13 +23,13 @@ def verbose_solver_callback(solution: lx.Solution) -> None:
         print(f'Did not converge in {num_steps} iterations')
 
 
-def default_solver() -> lx.AbstractLinearSolver:
+def default_solver() -> lx.AbstractLinearSolver[Any]:
     return lx.CG(rtol=1e-6, atol=1e-6, max_steps=500)
 
 
 @dataclass(frozen=True)
 class ConfigState:
-    solver: lx.AbstractLinearSolver = field(default_factory=default_solver)
+    solver: lx.AbstractLinearSolver[Any] = field(default_factory=default_solver)
     solver_throw: bool = False
     solver_options: dict[str, Any] = field(default_factory=dict)
     solver_callback: Callable[[lx.Solution], None] = default_solver_callback

--- a/src/furax/_instruments/sky.py
+++ b/src/furax/_instruments/sky.py
@@ -122,8 +122,8 @@ class FGBusterInstrument(eqx.Module):
     ) -> 'FGBusterInstrument':
         """Converts depths to a specified unit and dtype."""
         # Because we used @property, self.depth_i and self.frequency act like normal numpy arrays here!
-        depth_i = self.depth_i * u.arcmin * u.uK_CMB
-        depth_p = self.depth_p * u.arcmin * u.uK_CMB
+        depth_i = self.depth_i * u.arcmin * u.uK_CMB  # ty: ignore[unresolved-attribute]
+        depth_p = self.depth_p * u.arcmin * u.uK_CMB  # ty: ignore[unresolved-attribute]
 
         depth_i = depth_i.to(
             getattr(u, unit) * u.arcmin,
@@ -266,9 +266,7 @@ def get_observation(
     else:
         noise_sky = landscapes.zeros()
 
-    stoke_arrays: Array = np.array([np.zeros(noise_sky.shape) for _ in stokes_type]).transpose(  # type: ignore[assignment]
-        1, 0, 2
-    )
+    stoke_arrays = np.array([np.zeros(noise_sky.shape) for _ in stokes_type]).transpose(1, 0, 2)
     match stokes_type:
         case 'I':
             # From a two dimension array for example (3 , 48) take a[0].reshape(1 , -1)

--- a/src/furax/core/_axes.py
+++ b/src/furax/core/_axes.py
@@ -82,8 +82,8 @@ class MoveAxisInverseRule(AbstractCompositionRule):
     def apply(
         self, left: AbstractLinearOperator, right: AbstractLinearOperator
     ) -> list[AbstractLinearOperator]:
-        assert isinstance(left, MoveAxisOperator)  # mypy assert
-        assert isinstance(right, MoveAxisOperator)  # mypy assert
+        assert isinstance(left, MoveAxisOperator)  # ty assert
+        assert isinstance(right, MoveAxisOperator)  # ty assert
         if left.source != right.destination or left.destination != right.source:
             raise NoReduction
         return []
@@ -100,7 +100,7 @@ class AbstractRavelOrReshapeOperator(AbstractLinearOperator):
         return jnp.eye(self.in_size, dtype=self.out_promoted_dtype)
 
     def transpose(self) -> AbstractLinearOperator:
-        return ReshapeTransposeOperator(self)  # type: ignore[arg-type]
+        return ReshapeTransposeOperator(self)  # ty: ignore[invalid-argument-type]
 
     def reduce(self) -> AbstractLinearOperator:
         if self.out_structure == self.in_structure:

--- a/src/furax/core/_base.py
+++ b/src/furax/core/_base.py
@@ -121,7 +121,7 @@ class AbstractLinearOperator(ABC):
 
     @overload
     def __call__(
-        self, /, *, solver: lx.AbstractLinearSolver | None = None, **keywords: Any
+        self, /, *, solver: lx.AbstractLinearSolver[Any] | None = None, **keywords: Any
     ) -> 'AbstractLinearOperator': ...
 
     @overload
@@ -646,7 +646,7 @@ class InverseOperator(AbstractLazyInverseOperator):
         x: PyTree[jax.ShapeDtypeStruct] | None = None,
         /,
         *,
-        solver: lx.AbstractLinearSolver | None = None,
+        solver: lx.AbstractLinearSolver[Any] | None = None,
         throw: bool | None = None,
         callback: Callable[[lx.Solution], None] | object = MISSING,
         **options: Any,

--- a/src/furax/core/_base.py
+++ b/src/furax/core/_base.py
@@ -31,12 +31,8 @@ def structure_equal(a: PyTree[jax.ShapeDtypeStruct], b: PyTree[jax.ShapeDtypeStr
     a_leaves, a_treedef = jax.tree.flatten(a)
     b_leaves, b_treedef = jax.tree.flatten(b)
     # equal treedefs guarantee equal leaf counts, so the zip below is aligned
-    return (
-        a_treedef == b_treedef  # type: ignore[operator]
-        and all(
-            x.shape == y.shape and x.dtype == y.dtype
-            for x, y in zip(a_leaves, b_leaves, strict=True)
-        )
+    return a_treedef == b_treedef and all(
+        x.shape == y.shape and x.dtype == y.dtype for x, y in zip(a_leaves, b_leaves, strict=True)
     )
 
 
@@ -125,14 +121,14 @@ class AbstractLinearOperator(ABC):
 
     @overload
     def __call__(
-        self, *, solver: lx.AbstractLinearSolver, **keywords: Any
+        self, /, *, solver: lx.AbstractLinearSolver | None = None, **keywords: Any
     ) -> 'AbstractLinearOperator': ...
 
     @overload
-    def __call__(self, x: PyTree[jax.ShapeDtypeStruct]) -> PyTree[jax.ShapeDtypeStruct]: ...
+    def __call__(self, x: PyTree[jax.ShapeDtypeStruct], /) -> PyTree[jax.ShapeDtypeStruct]: ...
 
     def __call__(
-        self, x: PyTree[jax.ShapeDtypeStruct] | None = None, **keywords: Any
+        self, x: PyTree[jax.ShapeDtypeStruct] | None = None, /, **keywords: Any
     ) -> 'AbstractLinearOperator | PyTree[jax.ShapeDtypeStruct]':
         if keywords:
             raise TypeError('No keywords is allowed in AbstractLinearOperator __call__ method')
@@ -182,7 +178,7 @@ class AbstractLinearOperator(ABC):
 
     def __mul__(self, other: ScalarLike) -> 'AbstractLinearOperator':
         result = other * self
-        assert isinstance(result, AbstractLinearOperator)  # mypy
+        assert isinstance(result, AbstractLinearOperator)  # ty assert
         return result
 
     def __rmul__(self, other: ScalarLike) -> 'AbstractLinearOperator':
@@ -223,7 +219,7 @@ class AbstractLinearOperator(ABC):
 
         for ileaf, leaf in enumerate(in_leaves_ref):
 
-            def body(index, carry):  # type: ignore[no-untyped-def]
+            def body(index, carry):
                 matrix, jcounter = carry
                 zeros = in_leaves_ref.copy()
                 zeros[ileaf] = leaf.ravel().at[index].set(1).reshape(leaf.shape)  # noqa: B023 (`body` consumed immediately, no deferred call)
@@ -333,7 +329,7 @@ class AbstractLinearOperator(ABC):
 def square[T: AbstractLinearOperator](cls: type[T]) -> type[T]:
     """Mark an operator as square."""
     cls.class_tags |= OperatorTag.SQUARE
-    cls.out_structure = property(lambda self: self.in_structure)  # type: ignore[assignment,method-assign]
+    cls.out_structure = property(lambda self: self.in_structure)  # ty: ignore[invalid-assignment]
     return cls
 
 
@@ -341,7 +337,7 @@ def symmetric[T: AbstractLinearOperator](cls: type[T]) -> type[T]:
     """Mark an operator as symmetric (implies square)."""
     square(cls)
     cls.class_tags |= OperatorTag.SYMMETRIC
-    cls.transpose = lambda self: self  # type: ignore[method-assign]
+    cls.transpose = lambda self: self  # ty: ignore[invalid-assignment]
     return cls
 
 
@@ -349,7 +345,7 @@ def orthogonal[T: AbstractLinearOperator](cls: type[T]) -> type[T]:
     """Mark an operator as orthogonal (implies square)."""
     square(cls)
     cls.class_tags |= OperatorTag.ORTHOGONAL
-    cls.inverse = cls.transpose  # type: ignore[method-assign]
+    cls.inverse = cls.transpose  # ty: ignore[invalid-assignment]
     return cls
 
 

--- a/src/furax/core/_blocks.py
+++ b/src/furax/core/_blocks.py
@@ -161,8 +161,8 @@ class BlockDiagonalOperator(AbstractBlockOperator):
         # required: otherwise, the parent constructor would not be called by the dataclass-generated constructor
         super().__init__(blocks)
 
-    def mv(self, vector: PyTree[Inexact[Array, ' _b']]) -> PyTree[Inexact[Array, ' _a']]:
-        return self._tree_map(lambda op, vect: op.mv(vect), vector)
+    def mv(self, x: PyTree[Inexact[Array, ' _b']]) -> PyTree[Inexact[Array, ' _a']]:
+        return self._tree_map(lambda op, vect: op.mv(vect), x)
 
     def transpose(self) -> AbstractLinearOperator:
         return BlockDiagonalOperator(self._tree_map(lambda op: op.T))
@@ -176,7 +176,7 @@ class BlockDiagonalOperator(AbstractBlockOperator):
         return BlockDiagonalOperator(self._tree_map(lambda op: op.I))
 
     def as_matrix(self) -> Inexact[Array, 'a b']:
-        return jsl.block_diag(*[op.as_matrix() for op in self.block_leaves])  # type: ignore[no-any-return]
+        return jsl.block_diag(*[op.as_matrix() for op in self.block_leaves])
 
     def reduce(self) -> AbstractLinearOperator:
         """BlockDiagonalOperator([I, I, ...]) -> I."""
@@ -243,8 +243,8 @@ class BlockColumnOperator(AbstractBlockOperator):
                 f' - {structures_as_str}'
             )
 
-    def mv(self, vector: PyTree[Inexact[Array, ' _b']]) -> PyTree[Inexact[Array, ' _a']]:
-        return self._tree_map(lambda op: op.mv(vector))
+    def mv(self, x: PyTree[Inexact[Array, ' _b']]) -> PyTree[Inexact[Array, ' _a']]:
+        return self._tree_map(lambda op: op.mv(x))
 
     def transpose(self) -> AbstractLinearOperator:
         return BlockRowOperator(self._tree_map(lambda op: op.T))
@@ -259,8 +259,8 @@ class AbstractBlockDiagonalRule(AbstractCompositionRule):
     def apply(
         self, left: AbstractLinearOperator, right: AbstractLinearOperator
     ) -> list[AbstractLinearOperator]:
-        assert isinstance(left, AbstractBlockOperator)  # mypy assert
-        assert isinstance(right, AbstractBlockOperator)  # mypy assert
+        assert isinstance(left, AbstractBlockOperator)  # ty assert
+        assert isinstance(right, AbstractBlockOperator)  # ty assert
         return [self.reduced_class(left._tree_map(lambda l, r: l @ r, right.blocks)).reduce()]
 
 
@@ -370,8 +370,8 @@ class BlockSelectBlockDiagonalRule(AbstractCompositionRule):
     def apply(
         self, left: AbstractLinearOperator, right: AbstractLinearOperator
     ) -> list[AbstractLinearOperator]:
-        assert isinstance(left, BlockSelectOperator)  # mypy assert
-        assert isinstance(right, BlockDiagonalOperator)  # mypy assert
+        assert isinstance(left, BlockSelectOperator)  # ty assert
+        assert isinstance(right, BlockDiagonalOperator)  # ty assert
         try:
             block = right.blocks[left.key]
         except (IndexError, KeyError, TypeError):

--- a/src/furax/core/_fourier.py
+++ b/src/furax/core/_fourier.py
@@ -102,7 +102,7 @@ class FourierOperator(AbstractLinearOperator):
         """
         kernel = self.get_kernel()
         func = jnp.vectorize(self._apply, signature='(n),(m)->(n)')
-        return func(x, kernel)  # type: ignore[no-any-return]
+        return func(x, kernel)
 
     def get_kernel(self) -> Inexact[Array, '...']:
         freqs = jnp.fft.rfftfreq(self.fft_size, d=1 / self.sample_rate)
@@ -203,7 +203,7 @@ class FourierOperator(AbstractLinearOperator):
         # Create filter kernel based on filter_type
         if filter_type == 'square':
 
-            def kernel_func(freqs):  # type: ignore[no-untyped-def]
+            def kernel_func(freqs):
                 # Sharp cutoff (ideal brick-wall filter)
                 mask = (freqs >= f_low) & (freqs <= f_high)
                 return mask.astype(jnp.complex128)
@@ -211,7 +211,7 @@ class FourierOperator(AbstractLinearOperator):
         elif filter_type == 'butter4':
             import scipy.signal
 
-            def kernel_func(freqs):  # type: ignore[no-untyped-def]
+            def kernel_func(freqs):
                 # 4th-order Butterworth bandpass filter using scipy
 
                 # Design Butterworth bandpass filter
@@ -245,7 +245,7 @@ class FourierOperator(AbstractLinearOperator):
 
         elif filter_type == 'cos2':
 
-            def kernel_func(freqs):  # type: ignore[no-untyped-def]
+            def kernel_func(freqs):
                 # Cosine-squared transition outside the passband
                 # Define transition width (10% of bandwidth on each side, outside the band)
                 bandwidth = f_high - f_low

--- a/src/furax/core/_indices.py
+++ b/src/furax/core/_indices.py
@@ -98,7 +98,7 @@ class IndexOperator(AbstractLinearOperator):
 
             if out_structure is None:
                 # Compute output structure manually
-                def temp_mv(x):  # type: ignore[no-untyped-def]
+                def temp_mv(x):
                     return jax.tree.map(lambda leaf: leaf[indices], x)
 
                 out_structure = jax.eval_shape(temp_mv, in_structure)

--- a/src/furax/core/_mask.py
+++ b/src/furax/core/_mask.py
@@ -52,7 +52,7 @@ class MaskOperator(AbstractLinearOperator):
         mask_treedef = jax.tree.structure(boolean_mask)
         struct_treedef = jax.tree.structure(in_structure)
 
-        if mask_treedef == struct_treedef:  # type: ignore[operator]
+        if mask_treedef == struct_treedef:
             # Pytree of masks matching in_structure: pack each leaf
             packed_mask = jax.tree.map(_check_and_pack, boolean_mask, in_structure)
         else:

--- a/src/furax/core/_toeplitz.py
+++ b/src/furax/core/_toeplitz.py
@@ -233,7 +233,7 @@ class SymmetricBandToeplitzOperator(AbstractLinearOperator):
             return y
 
         y = lax.fori_loop(0, nblock, func, y)
-        return y[half_band_width : half_band_width + l]  # type: ignore[no-any-return]
+        return y[half_band_width : half_band_width + l]
 
     def _get_kernel(self, band_values: Array) -> Array:
         """[4, 3, 2, 1] -> [1, 2, 3, 4, 3, 2, 1]"""
@@ -241,7 +241,7 @@ class SymmetricBandToeplitzOperator(AbstractLinearOperator):
 
     def mv(self, x: Float[Array, '...']) -> Float[Array, '...']:
         func = jnp.vectorize(self._get_func(), signature='(n),(k)->(n)')
-        return func(x, self.band_values)  # type: ignore[no-any-return]
+        return func(x, self.band_values)
 
     def as_matrix(self) -> Inexact[Array, 'a a']:
         @partial(jnp.vectorize, signature='(n),(k)->(n,n)')

--- a/src/furax/core/rules.py
+++ b/src/furax/core/rules.py
@@ -262,9 +262,9 @@ class AbstractCompositionRule(AbstractBinaryRule):
     def check(self, left: AbstractLinearOperator, right: AbstractLinearOperator) -> None:
         self._check_operands(left, right)
         # In addition to checking operands, handle the case of TransposeOperator
-        if self.left_operator_class is TransposeOperator and left.operator is not right:  # type: ignore[attr-defined]
+        if self.left_operator_class is TransposeOperator and left.operator is not right:  # ty: ignore[unresolved-attribute]
             raise NoReduction
-        if self.right_operator_class is TransposeOperator and right.operator is not left:  # type: ignore[attr-defined]
+        if self.right_operator_class is TransposeOperator and right.operator is not left:  # ty: ignore[unresolved-attribute]
             raise NoReduction
 
 
@@ -279,7 +279,7 @@ class InverseBinaryRule(AbstractCompositionRule):
             if left.operator is not right:
                 raise NoReduction
         else:
-            assert isinstance(right, self.operator_class)  # mypy assert
+            assert isinstance(right, self.operator_class)  # ty assert
             if right.operator is not left:
                 raise NoReduction
 
@@ -323,6 +323,6 @@ class HomothetyAdditionRule(AbstractAdditionRule):
     def apply(
         self, left: AbstractLinearOperator, right: AbstractLinearOperator
     ) -> list[AbstractLinearOperator]:
-        assert isinstance(left, HomothetyOperator)  # mypy
-        assert isinstance(right, HomothetyOperator)  # mypy
+        assert isinstance(left, HomothetyOperator)  # ty assert
+        assert isinstance(right, HomothetyOperator)  # ty assert
         return [HomothetyOperator(left.value + right.value, in_structure=left.in_structure)]

--- a/src/furax/core/utils.py
+++ b/src/furax/core/utils.py
@@ -1,8 +1,11 @@
 import dataclasses
 from collections.abc import Iterable
-from typing import Any, TypeVar
+from typing import TYPE_CHECKING, Any, TypeVar
 
 from jax._src.tree_util import GetAttrKey, register_pytree_with_keys
+
+if TYPE_CHECKING:
+    from _typeshed import DataclassInstance
 
 T = TypeVar('T')
 
@@ -23,13 +26,13 @@ class DefaultIdentityDict(dict[T, T]):
             return key
 
 
-def register_dataclass_with_keys[T](cls: type[T]) -> type[T]:
+def register_dataclass_with_keys[T: DataclassInstance](cls: type[T]) -> type[T]:
     """Register a dataclass as a pytree node, bypassing __init__ during unflatten.
 
     The motivation to reimplement jax.tree_util.register_dataclass comes from the fact that it does not handle
     dataclasses with an __init__ constructor that does not match the fields of the dataclass.
     """
-    fields = dataclasses.fields(cls)  # type: ignore[arg-type]
+    fields = dataclasses.fields(cls)
     data_fields = tuple(f.name for f in fields if not f.metadata.get('static', False))
     meta_fields = tuple(f.name for f in fields if f.metadata.get('static', False))
 

--- a/src/furax/interfaces/lineax.py
+++ b/src/furax/interfaces/lineax.py
@@ -63,7 +63,7 @@ def _get_lineax_tags(operator: AbstractLinearOperator, tags: OperatorTag) -> fro
     return frozenset(lineax_tags)
 
 
-class _FuraxLinearOperator(lx.AbstractLinearOperator):  # type: ignore[misc]
+class _FuraxLinearOperator(lx.AbstractLinearOperator):
     """Lineax-compatible wrapper around a furax AbstractLinearOperator.
 
     Unlike lx.FunctionLinearOperator, this stores the furax operator as a
@@ -97,13 +97,13 @@ def _materialise(operator: _FuraxLinearOperator) -> lx.AbstractLinearOperator:
 
 
 def _diagonal(operator: _FuraxLinearOperator) -> Shaped[Array, ' size']:
-    return lx.diagonal(_to_function_linear_operator(operator))  # type: ignore[no-any-return]
+    return lx.diagonal(_to_function_linear_operator(operator))
 
 
 def _tridiagonal(
     operator: _FuraxLinearOperator,
 ) -> tuple[Shaped[Array, ' size'], Shaped[Array, ' size-1'], Shaped[Array, ' size-1']]:
-    return lx.tridiagonal(_to_function_linear_operator(operator))  # type: ignore[no-any-return]
+    return lx.tridiagonal(_to_function_linear_operator(operator))
 
 
 def _to_function_linear_operator(

--- a/src/furax/interfaces/litebird_sim/observation.py
+++ b/src/furax/interfaces/litebird_sim/observation.py
@@ -41,7 +41,7 @@ class LBSObservation(AbstractSatelliteObservation[lbs.Observation]):
 
     @property
     def n_samples(self) -> int:
-        return self.data.n_samples  # type: ignore[no-any-return]
+        return self.data.n_samples
 
     @property
     def detectors(self) -> list[str]:
@@ -50,11 +50,11 @@ class LBSObservation(AbstractSatelliteObservation[lbs.Observation]):
 
     @property
     def n_detectors(self) -> int:
-        return self.data.n_detectors  # type: ignore[no-any-return]
+        return self.data.n_detectors
 
     @property
     def sample_rate(self) -> float:
-        return self.data.sampling_rate_hz  # type: ignore[no-any-return]
+        return self.data.sampling_rate_hz
 
     def get_tods(self) -> Float[np.ndarray, 'dets samps']:
         tods = np.asarray(self.data.tod, dtype=np.float64)

--- a/src/furax/interfaces/sotodlib/mapmaker_multi.py
+++ b/src/furax/interfaces/sotodlib/mapmaker_multi.py
@@ -81,24 +81,25 @@ def main(
     if isinstance(preprocess_config, str):
         with open(preprocess_config) as f:
             preprocess_config = yaml.safe_load(f)
-    logger.info('Preprocessing config loaded from file')
+        logger.info('Preprocessing config loaded from file')
 
     for obs_id in obs_ids:
         # First check if we need to load this obs or not
-        completed = True
-        for mapmaking_config in mapmaking_configs:
-            output_dir = get_output_dir(
-                root_dir=output_path,  # type: ignore[arg-type]
-                mapmaking_config=mapmaking_config,
-                obs_id=obs_id,
-                det_select=det_select,
+        if output_path is not None:
+            completed = all(
+                os.path.exists(
+                    get_output_dir(
+                        root_dir=output_path,
+                        mapmaking_config=mapmaking_config,
+                        obs_id=obs_id,
+                        det_select=det_select,
+                    )
+                )
+                for mapmaking_config in mapmaking_configs
             )
-            if not os.path.exists(output_dir):
-                completed = False
-                break
-        if completed:
-            logger.info(f'Skipping {obs_id}...')
-            continue
+            if completed:
+                logger.info(f'Skipping {obs_id}...')
+                continue
 
         # Load obs
         try:
@@ -113,7 +114,7 @@ def main(
             # First check if we need to do mapmaking or not
             mm_name = os.path.basename(mapmaking_config)
             output_dir = get_output_dir(
-                root_dir=output_path,  # type: ignore[arg-type]
+                root_dir=output_path,
                 mapmaking_config=mapmaking_config,
                 obs_id=obs_id,
                 det_select=det_select,
@@ -146,7 +147,10 @@ def main(
 
 
 def get_output_dir(
-    root_dir: str, mapmaking_config: str, obs_id: str, det_select: dict[str, Any] | None = None
+    root_dir: str | None,
+    mapmaking_config: str,
+    obs_id: str,
+    det_select: dict[str, Any] | None = None,
 ) -> str:
     name = Path(mapmaking_config).stem
     output_dir = f'{root_dir}/{name}/{obs_id}'

--- a/src/furax/interfaces/sotodlib/observation.py
+++ b/src/furax/interfaces/sotodlib/observation.py
@@ -74,18 +74,18 @@ def _enable_preproc_context_cache() -> None:
         # Keyed by config path (not context_file) so init/proc layers stay distinct even when
         # they share a context — each keeps its own appended preprocess archive.
         if context is not None or not isinstance(configs, str):
-            return original(configs, context)  # type: ignore[no-any-return]
+            return original(configs, context)
         key = (configs, threading.get_ident())
         if key not in _PREPROC_CONTEXT_CACHE:
             _PREPROC_CONTEXT_CACHE[key] = original(configs, context)
         return _PREPROC_CONTEXT_CACHE[key]
 
-    cached._furax_cached = True  # type: ignore[attr-defined]
+    cached._furax_cached = True  # ty: ignore[unresolved-attribute]
     # Relies on sotodlib calling get_preprocess_context by its module-global name (which
     # load_and_preprocess / multilayer_load_and_preprocess do): reassigning the module attribute
     # is what makes the cache take effect. A future sotodlib that imports it as a local alias, or
     # builds core.Context directly, would bypass this.
-    pu.get_preprocess_context = cached
+    pu.get_preprocess_context = cached  # ty: ignore[invalid-assignment]
 
 
 class SOTODLibObservation(AbstractGroundObservation[AxisManager]):
@@ -240,23 +240,23 @@ class SOTODLibObservation(AbstractGroundObservation[AxisManager]):
 
     @property
     def name(self) -> str:
-        return self.data.obs_info.obs_id  # type: ignore[no-any-return]
+        return self.data.obs_info.obs_id
 
     @property
     def telescope(self) -> str:
-        return self.data.obs_info.get('telescope')  # type: ignore[no-any-return]
+        return self.data.obs_info.get('telescope')
 
     @property
     def n_samples(self) -> int:
-        return self.data.samps.count  # type: ignore[no-any-return]
+        return self.data.samps.count
 
     @property
     def detectors(self) -> list[str]:
-        return self.data.dets.vals  # type: ignore[no-any-return]
+        return self.data.dets.vals
 
     @property
     def n_detectors(self) -> int:
-        return self.data.dets.count  # type: ignore[no-any-return]
+        return self.data.dets.count
 
     @property
     def sample_rate(self) -> float:
@@ -286,7 +286,7 @@ class SOTODLibObservation(AbstractGroundObservation[AxisManager]):
         if stokes == 'IQUV':
             raise NotImplementedError
         kls = Stokes.class_for(stokes)
-        tods = [self._get_demodulated_tod(s) for s in stokes]  # type: ignore[arg-type]
+        tods = [self._get_demodulated_tod(s) for s in stokes]
         return kls.from_array(np.stack(tods, axis=0))
 
     def _get_demodulated_tod(self, stoke: Literal['I', 'Q', 'U']) -> NDArray[np.float64]:
@@ -382,7 +382,7 @@ class SOTODLibObservation(AbstractGroundObservation[AxisManager]):
         spin_proj = jnp.array(spin_proj, dtype=landscape.dtype)
         spin_ang = jnp.arctan2(spin_proj[..., 2], spin_proj[..., 1]) / 2.0
 
-        return pixel_inds, spin_ang  # type: ignore[return-value]
+        return pixel_inds, spin_ang  # ty: ignore[invalid-return-type]
 
     def get_timestamps(self) -> Float[np.ndarray, ' a']:
         """Returns timestamps (sec) of the samples."""
@@ -411,7 +411,7 @@ class SOTODLibObservation(AbstractGroundObservation[AxisManager]):
         """
         if stokes == 'IQUV':
             raise NotImplementedError
-        fits = np.stack([self._get_noise_fit_for_stoke(s) for s in stokes], axis=1)  # type: ignore[arg-type]
+        fits = np.stack([self._get_noise_fit_for_stoke(s) for s in stokes], axis=1)
         return AtmosphericNoiseModel(*fits)
 
     def _get_noise_fit_for_stoke(self, stoke: Literal['I', 'Q', 'U']) -> NDArray[np.floating]:
@@ -482,7 +482,7 @@ class SOTODLibObservation(AbstractGroundObservation[AxisManager]):
         else:
             # Estimate psd
             raise NotImplementedError('Self-psd evaluation not implemented')
-        return fit[:, 1]  # type: ignore[no-any-return]
+        return fit[:, 1]
     '''
 
     def get_boresight_quaternions(self) -> Float[np.ndarray, 'samp 4']:

--- a/src/furax/interfaces/sotodlib/observation.py
+++ b/src/furax/interfaces/sotodlib/observation.py
@@ -376,13 +376,12 @@ class SOTODLibObservation(AbstractGroundObservation[AxisManager]):
         # which have 1, cos(2*p), sin(2*p) where p is the parallactic angle
         pixel_inds, spin_proj = proj.get_pointing_matrix(assembly)
 
-        # TODO: check if this could be jnp array directly
-        pixel_inds = np.array(pixel_inds)
+        pixel_inds = jnp.array(pixel_inds)
 
         spin_proj = jnp.array(spin_proj, dtype=landscape.dtype)
         spin_ang = jnp.arctan2(spin_proj[..., 2], spin_proj[..., 1]) / 2.0
 
-        return pixel_inds, spin_ang  # ty: ignore[invalid-return-type]
+        return pixel_inds, spin_ang
 
     def get_timestamps(self) -> Float[np.ndarray, ' a']:
         """Returns timestamps (sec) of the samples."""

--- a/src/furax/interfaces/toast/observation.py
+++ b/src/furax/interfaces/toast/observation.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import typing
 from collections.abc import Collection
-from functools import partial
 from pathlib import Path
 from typing import Any
 
@@ -367,7 +366,7 @@ class LazyToastObservation(FileBackedLazyObservation[toast.Data]):
     interface_class = ToastObservation
 
 
-@partial(np.vectorize, signature='(4)->()')
+@np.vectorize(signature='(4)->()')  # ty: ignore[dynamic-function-decorator-return]
 def get_local_meridian_angle(quat):
     """Compute angle between local meridian and orientation vector from quaternions.
 

--- a/src/furax/interfaces/toast/observation.py
+++ b/src/furax/interfaces/toast/observation.py
@@ -137,15 +137,15 @@ class ToastObservation(AbstractGroundObservation[toast.Data]):
 
     @property
     def name(self) -> str:
-        return self.data.name  # type: ignore[no-any-return]
+        return self.data.name
 
     @property
     def telescope(self) -> str:
-        return self.data.telescope.name  # type: ignore[no-any-return]
+        return self.data.telescope.name
 
     @property
     def n_samples(self) -> int:
-        return self.data.n_local_samples  # type: ignore[no-any-return]
+        return self.data.n_local_samples
 
     @property
     def detectors(self) -> list[str]:
@@ -161,7 +161,7 @@ class ToastObservation(AbstractGroundObservation[toast.Data]):
     @property
     def sample_rate(self) -> float:
         """Returns the sampling rate (in Hz) of the data."""
-        return self._focal_plane.sample_rate.to_value(u.Hz)  # type: ignore[no-any-return]
+        return self._focal_plane.sample_rate.to_value(u.Hz)
 
     def get_tods(self) -> Float[np.ndarray, 'dets samps']:
         """Returns the timestream data."""
@@ -368,7 +368,7 @@ class LazyToastObservation(FileBackedLazyObservation[toast.Data]):
 
 
 @partial(np.vectorize, signature='(4)->()')
-def get_local_meridian_angle(quat):  # type: ignore[no-untyped-def]
+def get_local_meridian_angle(quat):
     """Compute angle between local meridian and orientation vector from quaternions.
 
     Assumes that the quaternions encode the rotation between the celestial frame

--- a/src/furax/io/readers.py
+++ b/src/furax/io/readers.py
@@ -256,11 +256,11 @@ class AbstractReader(ABC):
         """Return finite filler data without touching any backing store."""
         padding_structure = self._padding_structure()
 
-        def callback():  # type: ignore[no-untyped-def]
+        def callback():
             return self._failure_filler(), zeros_like(padding_structure), np.array(False)
 
         result_shape = (self.out_structure, padding_structure, jax.ShapeDtypeStruct((), bool))
-        return io_callback(callback, result_shape)  # type: ignore[no-any-return]
+        return io_callback(callback, result_shape)
 
     @staticmethod
     def _padding_to_arrays(padding: PyTree[tuple[int, ...]]) -> PyTree[np.ndarray]:

--- a/src/furax/linalg/_eigvalsh.py
+++ b/src/furax/linalg/_eigvalsh.py
@@ -86,11 +86,11 @@ def eigvalsh(A: Float[Array, '... n n'], batch_size: int = 10_000) -> Float[Arra
     if n == 1:
         return A[..., :1, 0]
     elif n == 2:
-        return _eigvalsh_2x2(A)  # type: ignore[no-any-return]
+        return _eigvalsh_2x2(A)
     elif n == 3:
-        return _eigvalsh_3x3(A)  # type: ignore[no-any-return]
+        return _eigvalsh_3x3(A)
     else:
         leading = A.shape[:-2]
         flat = A.reshape(-1, n, n)
         result = jax.lax.map(jnp.linalg.eigvalsh, flat, batch_size=batch_size)
-        return result.reshape(*leading, n)  # type: ignore[no-any-return]
+        return result.reshape(*leading, n)

--- a/src/furax/linalg/_lanczos.py
+++ b/src/furax/linalg/_lanczos.py
@@ -83,7 +83,7 @@ def _lanczos_loop(
         v_last: Residual direction after the final step.
     """
 
-    def body_fn(j, carry):  # type: ignore[no-untyped-def]
+    def body_fn(j, carry):
         V_m, alpha, beta, v, v_prev, beta_prev = carry
 
         w = A(v)  # w = A v_j
@@ -93,7 +93,7 @@ def _lanczos_loop(
         w = tree.add(tree.mul(-alpha_j, v), w)  # w -= α_j v_j
         w = tree.add(tree.mul(-beta_prev, v_prev), w)  # w -= β_{j-1} v_{j-1}
 
-        def reorth_step(k, w):  # type: ignore[no-untyped-def]
+        def reorth_step(k, w):
             v_k = jax.tree.map(lambda V_leaf: V_leaf[k], V_m)
             coeff = tree.dot(v_k, w)
             return tree.add(tree.mul(-coeff, v_k), w)  # w -= <v_k, w> v_k
@@ -172,7 +172,7 @@ def _default_m(A: AbstractLinearOperator, k: int) -> int:
     """Default Krylov subspace size: min(2k, n)."""
     leaves = jax.tree.leaves(A.in_structure)
     n = sum(leaf.size for leaf in leaves)
-    return min(2 * k, n)  # type: ignore[no-any-return]
+    return min(2 * k, n)
 
 
 def lanczos_eigh(
@@ -436,7 +436,7 @@ def lanczos_tr(
     if m <= k:
         raise ValueError(f'm ({m}) must be > k ({k})')
 
-    def _select_wanted(theta):  # type: ignore[no-untyped-def]
+    def _select_wanted(theta):
         if which == 'LM':  # largest magnitude
             sorted_idx = jnp.argsort(-jnp.abs(theta))
         elif which == 'SM':  # smallest magnitude
@@ -452,7 +452,7 @@ def lanczos_tr(
             return jnp.concatenate([sorted_idx[:n_low], sorted_idx[-n_high:]])
         return sorted_idx[:k]
 
-    def _check_converged(theta, beta_last, S, wanted_idx):  # type: ignore[no-untyped-def]
+    def _check_converged(theta, beta_last, S, wanted_idx):
         # ARPACK criterion: |β_m| |s_i[-1]| ≤ tol * max(|θ_i|, eps*||A||)
         # Floor prevents stall when θ_i ≈ 0; max|θ| estimates ||A||.
         ritz_res = jnp.abs(beta_last) * jnp.abs(S[-1, wanted_idx])  # |β_m| |s_i[-1]|
@@ -466,11 +466,11 @@ def lanczos_tr(
     wanted_idx = _select_wanted(theta)
     init_converged = _check_converged(theta, beta_last, S, wanted_idx)
 
-    def cond_fn(state):  # type: ignore[no-untyped-def]
+    def cond_fn(state):
         *_, iteration, converged, _theta, _S, _wanted_idx = state
         return jnp.logical_and(iteration < max_restarts, ~converged)
 
-    def body_fn(state):  # type: ignore[no-untyped-def]
+    def body_fn(state):
         V, beta_last, v_last, iteration, _converged, theta, S, wanted_idx = state
 
         V_k = _vecmat(V, S[:, wanted_idx])  # U_k = V S[:,wanted]  (Ritz vectors)

--- a/src/furax/linalg/cholesky.py
+++ b/src/furax/linalg/cholesky.py
@@ -99,7 +99,7 @@ class BandedCholeskyOperator(AbstractLinearOperator):
         sizes = [prod(leaf.shape[batch_ndim:]) for leaf in leaves]
         chunks = jnp.split(yf, np.cumsum(sizes)[:-1], axis=-1)
         out = [c.reshape(leaf.shape) for c, leaf in zip(chunks, leaves, strict=True)]
-        return treedef.unflatten(out)  # type: ignore[attr-defined]
+        return treedef.unflatten(out)
 
 
 def banded_cholesky(
@@ -159,7 +159,7 @@ def banded_cholesky(
         scale = jnp.mean(diag, axis=-1)[..., None, None]  # (*batch, n, 1, 1)
         ridge = regularization * scale * jnp.eye(k, dtype=bands.dtype)
         bands = bands.at[..., 0, :, :].add(ridge)
-    return _block_banded_cholesky(bands)  # type: ignore[no-any-return]
+    return _block_banded_cholesky(bands)
 
 
 @partial(jnp.vectorize, signature='(n,w1,k,k)->(n,w1,k,k)')
@@ -178,10 +178,10 @@ def _block_banded_cholesky(bands: Float[Array, 'n w1 k k']) -> Float[Array, 'n w
     n, w1, k, _ = bands.shape
     w = w1 - 1
 
-    def read(arr: Array, idx: Array):  # type: ignore[no-untyped-def]
+    def read(arr: Array, idx: Array):
         return jax.lax.dynamic_index_in_dim(arr, jnp.clip(idx, 0, n - 1), axis=0, keepdims=False)
 
-    def row(i: Array, lb: Array):  # type: ignore[no-untyped-def]
+    def row(i: Array, lb: Array):
         cur = jnp.zeros((w1, k, k), bands.dtype)  # this row's blocks lb[i, :]
         # columns j = i - d0, processed high d0 (far) to low (diagonal last).
         for d0 in range(w, -1, -1):
@@ -228,10 +228,10 @@ def banded_cholesky_solve(
     n, w1, k, _ = lb.shape
     w = w1 - 1
 
-    def read(arr: Array, idx: Array):  # type: ignore[no-untyped-def]
+    def read(arr: Array, idx: Array):
         return jax.lax.dynamic_index_in_dim(arr, jnp.clip(idx, 0, n - 1), axis=0, keepdims=False)
 
-    def fwd(i: Array, y: Array):  # type: ignore[no-untyped-def]  # forward: L y = b
+    def fwd(i: Array, y: Array):  # forward: L y = b
         rhs = read(b, i)
         lb_i = read(lb, i)
         for d in range(1, w + 1):
@@ -241,7 +241,7 @@ def banded_cholesky_solve(
 
     y = jax.lax.fori_loop(0, n, fwd, jnp.zeros((n, k), b.dtype))
 
-    def bwd(step: Array, x: Array):  # type: ignore[no-untyped-def]  # backward: Lᵀ x = y
+    def bwd(step: Array, x: Array):  # backward: Lᵀ x = y
         i = n - 1 - step
         rhs = read(y, i)
         for d in range(1, w + 1):  # L[i+d, i] = lb[i+d, d]

--- a/src/furax/mapmaking/_model.py
+++ b/src/furax/mapmaking/_model.py
@@ -269,7 +269,7 @@ def _sample_mask(data: Any, config: MapMakingConfig) -> Array:
         # -> False samples have mask = False
         # in both cases the logical and eliminates the tail
 
-    return mask  # type: ignore[no-any-return]
+    return mask
 
 
 def _noise_operator(

--- a/src/furax/mapmaking/_observation.py
+++ b/src/furax/mapmaking/_observation.py
@@ -75,21 +75,25 @@ class HashedObservationMetadata:
     @classmethod
     def structure_for(cls, n_dets: int) -> Self:
         return cls(
-            uid=jax.ShapeDtypeStruct((), dtype=np.uint32),  # type: ignore[arg-type]
-            telescope_uid=jax.ShapeDtypeStruct((), dtype=np.uint32),  # type: ignore[arg-type]
-            detector_uids=jax.ShapeDtypeStruct((n_dets,), dtype=np.uint32),  # type: ignore[arg-type]
+            uid=jax.ShapeDtypeStruct((), dtype=np.uint32),  # ty: ignore[invalid-argument-type]
+            telescope_uid=jax.ShapeDtypeStruct(  # ty: ignore[invalid-argument-type]
+                (), dtype=np.uint32
+            ),
+            detector_uids=jax.ShapeDtypeStruct(  # ty: ignore[invalid-argument-type]
+                (n_dets,), dtype=np.uint32
+            ),
         )
 
     def split_key(self, key: Key[Array, '']) -> Key[Array, '*#dets']:
         fold = jnp.vectorize(jax.random.fold_in, signature='(),()->()')
-        return fold(fold(fold(key, self.uid), self.telescope_uid), self.detector_uids)  # type: ignore[no-any-return]
+        return fold(fold(fold(key, self.uid), self.telescope_uid), self.detector_uids)
 
 
 def _names_to_uids(names: str | list[str] | np.ndarray) -> UInt32[np.ndarray, ...]:
     """Converts names to unsigned 32-bit integers using hashing."""
     # SHA-1 hash truncated to a non-negative 32-bit integer
     to_int = lambda s: int(sha1(s.encode()).hexdigest(), 16) & 0x7FFFFFFF
-    return np.vectorize(to_int, otypes=[np.uint32])(names)  # type: ignore[no-any-return]
+    return np.vectorize(to_int, otypes=[np.uint32])(names)
 
 
 class AbstractObservation[T](ABC):
@@ -227,7 +231,7 @@ class AbstractObservation[T](ABC):
     def get_elapsed_times(self) -> Float[np.ndarray, ' a']:
         """Returns time (sec) of the samples since the observation began."""
         timestamps = self.get_timestamps()
-        return timestamps - timestamps[0]  # type: ignore[no-any-return]
+        return timestamps - timestamps[0]
 
     @abstractmethod
     def get_wcs_shape_and_kernel(
@@ -455,7 +459,7 @@ class AbstractLazyObservation[T](ABC):
                 msg = 'observation does not support reading scanning intervals'
                 raise RuntimeError(msg)
             data = self.get_data([ReaderField.SCANNING_INTERVALS])
-            n_intervals = data.get_scanning_intervals().shape[0]  # type: ignore[attr-defined]
+            n_intervals = data.get_scanning_intervals().shape[0]  # ty: ignore[unresolved-attribute]
         else:
             data = self.get_data([])
             n_intervals = 0

--- a/src/furax/mapmaking/_reader.py
+++ b/src/furax/mapmaking/_reader.py
@@ -313,7 +313,7 @@ class ObservationReader[T](AbstractReader):
             return structures
         return {field: structures[field] for field in fields}
 
-    def _get_data_field_readers(self):  # type: ignore[no-untyped-def]
+    def _get_data_field_readers(self):
         def if_none_raise_error(x: Any) -> Any:
             if x is None:
                 raise ValueError('Data field not available')

--- a/src/furax/mapmaking/acquisition.py
+++ b/src/furax/mapmaking/acquisition.py
@@ -42,7 +42,7 @@ def build_acquisition_operator(
         interpolate=pointing_interpolate,
     )
     if not pointing_on_the_fly:
-        pointing = pointing.as_expanded_operator()  # type: ignore[assignment]
+        pointing = pointing.as_expanded_operator()
 
     # If there is no HWP, we just add a polarizer at the end
     # NB: already in detector frame at this point

--- a/src/furax/mapmaking/config.py
+++ b/src/furax/mapmaking/config.py
@@ -925,4 +925,4 @@ class MapMakingConfig:
     @property
     def dtype(self) -> DTypeLike:
         """The floating-point dtype used throughout the pipeline, per `double_precision`."""
-        return jnp.float64 if self.double_precision else jnp.float32  # type: ignore[no-any-return]
+        return jnp.float64 if self.double_precision else jnp.float32

--- a/src/furax/mapmaking/gap_filling.py
+++ b/src/furax/mapmaking/gap_filling.py
@@ -231,7 +231,7 @@ def _draw_block(
         raise ValueError(msg)
 
     @partial(jnp.vectorize, signature='(),(k)->(n)')
-    def _draw(subkey, psd):  # type: ignore[no-untyped-def]
+    def _draw(subkey, psd):
         # Gaussian Re/Im random numbers
         rngdata = jax.random.normal(subkey, shape=(fft_size,))
 
@@ -255,4 +255,4 @@ def _draw_block(
         xi = tdata[offset : offset + n]
         return xi - jnp.mean(xi)
 
-    return _draw(subkeys, psd)  # type: ignore[no-any-return]
+    return _draw(subkeys, psd)

--- a/src/furax/mapmaking/gram.py
+++ b/src/furax/mapmaking/gram.py
@@ -230,7 +230,7 @@ def _probed_gram_inverse(
             jnp.broadcast_to(part.reshape(s.shape[1:]), s.shape)
             for part, s in zip(jnp.split(flat, split_points), leaves, strict=True)
         ]
-        response = gram_op(treedef.unflatten(parts))  # type: ignore[attr-defined]
+        response = gram_op(treedef.unflatten(parts))
         per_leaf = [leaf.reshape(n_dets, -1) for leaf in jax.tree.leaves(response)]
         return jnp.concatenate(per_leaf, axis=-1)  # (n_dets, n_amps)
 

--- a/src/furax/mapmaking/layout.py
+++ b/src/furax/mapmaking/layout.py
@@ -408,5 +408,5 @@ class SlotLayout:
         for bucket, values in zip(self.buckets, per_bucket, strict=True):
             real = values[: bucket.n_real]
             region = (bucket.observations, *(slice(0, n) for n in real.shape[1:]))
-            out[region] = real  # type: ignore[index]
+            out[region] = real
         return out

--- a/src/furax/mapmaking/mapmaker.py
+++ b/src/furax/mapmaking/mapmaker.py
@@ -568,8 +568,8 @@ class MultiObservationMapMaker[T]:
         is_real = self.distribute(bucket.is_real[local])
         axis = jax.sharding.get_abstract_mesh().axis_names[0]
 
-        def kernel(items, is_real):  # type: ignore[no-untyped-def]
-            def step(carry, args):  # type: ignore[no-untyped-def]
+        def kernel(items, is_real):
+            def step(carry, args):
                 hits_acc, rhs_acc = carry
                 i, real = args
 
@@ -598,7 +598,7 @@ class MultiObservationMapMaker[T]:
                 hits_i = jnp.int64(hit_pointing.T(StokesI(masked)).i)
 
                 # RHS contribution (optionally gap-filled).
-                def func_gapfill(tod):  # type: ignore[no-untyped-def]
+                def func_gapfill(tod):
                     # Only reached under GapTreatment.FILL, where W is the plain inner-mask weight.
                     assert isinstance(obs.W, WeightOperator)
                     # Optional M_b N M_b preconditioner (covariance from the noise model).
@@ -659,7 +659,7 @@ class MultiObservationMapMaker[T]:
         in_specs = (P(axis), P(axis))
         out_specs = (P(), P(), P(axis))
         skernel = jax.shard_map(in_specs=in_specs, out_specs=out_specs, check_vma=False)(kernel)
-        return skernel(items, is_real)  # type: ignore[no-any-return]
+        return skernel(items, is_real)
 
     def pixel_selection(
         self, hits: Integer[Array, ' pixels'], weights: Float[Array, 'pixels stokes stokes']
@@ -764,7 +764,7 @@ def _wcs_landscape_from_geometry(
     if wcs_config.geometry_file is not None:
         shape, wcs = pixell.enmap.read_map_geometry(wcs_config.geometry_file)
     else:
-        assert wcs_config.patch is not None  # mypy: has_geometry guarantees patch is set here
+        assert wcs_config.patch is not None  # ty assert: has_geometry guarantees patch is set here
         res = wcs_config.resolution * pixell.utils.arcmin
         half_w = np.radians(wcs_config.patch.width / 2)
         half_h = np.radians(wcs_config.patch.height / 2)
@@ -850,9 +850,9 @@ class MapMaker:
         }[config.method]
 
         if logger is None:
-            return maker(config)  # type: ignore[abstract]
+            return maker(config)
         else:
-            return maker(config, logger=logger)  # type: ignore[abstract]
+            return maker(config, logger=logger)
 
     @classmethod
     def from_yaml(cls, path: str | Path, logger: Logger | None = None) -> 'MapMaker':
@@ -863,7 +863,7 @@ class MapMaker:
         lc = self.config.landscape
         if (landscape := _static_landscape(lc, self.config.dtype)) is not None:
             return landscape
-        assert lc.wcs is not None  # mypy: _static_landscape returns None only for auto WCS
+        assert lc.wcs is not None  # ty assert: _static_landscape returns None only for auto WCS
         wcs_shape, wcs_kernel = observation.get_wcs_shape_and_kernel(
             resolution_arcmin=lc.wcs.resolution, projection=lc.wcs.projection
         )
@@ -919,19 +919,21 @@ class MapMaker:
         if self.config.demodulated:
             return pointing
         else:
-            meta = {
-                'shape': (observation.n_detectors, observation.n_samples),
-                'stokes': landscape.stokes,
-                'dtype': self.config.dtype,
-            }
+            shape = (observation.n_detectors, observation.n_samples)
+            stokes = landscape.stokes
+            dtype = self.config.dtype
             polarizer = LinearPolarizerOperator.create(
-                **meta,  # type: ignore[arg-type]
+                shape,
+                stokes=stokes,
+                dtype=dtype,
                 angles=jnp.asarray(
                     observation.get_detector_offset_angles().astype(self.config.dtype)[:, None]
                 ),
             )
             hwp = HWPOperator.create(
-                **meta,  # type: ignore[arg-type]
+                shape,
+                stokes=stokes,
+                dtype=dtype,
                 angles=jnp.asarray(observation.get_hwp_angles().astype(self.config.dtype)),
             )
 
@@ -1108,7 +1110,7 @@ class BinnedMapMaker(MapMaker):
         mapmaking_operator = system.inverse() @ binner
 
         @jax.jit
-        def process(d):  # type: ignore[no-untyped-def]
+        def process(d):
             return mapmaking_operator.reduce()(d)
 
         logger_info('Set up mapmaking operator')
@@ -1126,7 +1128,7 @@ class BinnedMapMaker(MapMaker):
         final_map = np.array([res.i, res.q, res.u])
         weights = np.array(system.blocks)
 
-        output = {'map': final_map, 'weights': weights}
+        output: dict[str, Any] = {'map': final_map, 'weights': weights}
         if isinstance(landscape, WCSLandscape):
             output['wcs'] = landscape.to_wcs()
         elif isinstance(landscape, AstropyWCSLandscape):
@@ -1135,7 +1137,7 @@ class BinnedMapMaker(MapMaker):
             config.weighting.source == NoiseSource.FIT
             and config.weighting.mode != WeightingMode.IDENTITY
         ):
-            output['noise_fit'] = noise_model.to_array()  # type: ignore[assignment]
+            output['noise_fit'] = noise_model.to_array()
         if config.debug:
             proj_map = (masker.T @ acquisition)(res)
             output['proj_map'] = proj_map
@@ -1221,11 +1223,10 @@ class MLMapmaker(MapMaker):
         # Adjust the sample mask according to the new pixel selection
         positive_sample_hits = (
             (masker @ acquisition @ selector.T)(
-                StokesIQU.from_iquv(
-                    i=jnp.ones(selector.out_structure.shape, dtype=data.dtype),
-                    q=jnp.zeros(selector.out_structure.shape, dtype=data.dtype),
-                    u=jnp.zeros(selector.out_structure.shape, dtype=data.dtype),
-                    v=None,  # type: ignore[arg-type]
+                StokesIQU.from_stokes(
+                    jnp.ones(selector.out_structure.shape, dtype=data.dtype),
+                    jnp.zeros(selector.out_structure.shape, dtype=data.dtype),
+                    jnp.zeros(selector.out_structure.shape, dtype=data.dtype),
                 )
             )
             > 0
@@ -1261,7 +1262,7 @@ class MLMapmaker(MapMaker):
         mapmaking_operator = (h.T @ M @ h).I(**options) @ h.T @ M
 
         @jax.jit
-        def process(d):  # type: ignore[no-untyped-def]
+        def process(d):
             return mapmaking_operator.reduce()(d)
 
         logger_info('Completed setting up the solver')
@@ -1281,7 +1282,7 @@ class MLMapmaker(MapMaker):
         # Format output and compute auxiliary data
         final_map = np.array([result_map.i, result_map.q, result_map.u])
 
-        output = {'map': final_map, 'weights': weights, 'weights_uncut': blocks}
+        output: dict[str, Any] = {'map': final_map, 'weights': weights, 'weights_uncut': blocks}
         if isinstance(landscape, WCSLandscape):
             output['wcs'] = landscape.to_wcs()
         elif isinstance(landscape, AstropyWCSLandscape):
@@ -1397,7 +1398,7 @@ class ATOPMapMaker(MapMaker):
         # Format output and compute auxiliary data
         final_map = np.array([result_map.q, result_map.u])
 
-        output = {'map': final_map, 'weights': blocks}
+        output: dict[str, Any] = {'map': final_map, 'weights': blocks}
         if isinstance(landscape, AstropyWCSLandscape):
             output['wcs'] = landscape.wcs
         if (

--- a/src/furax/mapmaking/mapmaker.py
+++ b/src/furax/mapmaking/mapmaker.py
@@ -899,6 +899,10 @@ class MapMaker:
                 if pixel_inds.shape[-1] == 1:
                     pixel_inds = pixel_inds[..., 0]
                 indexer = IndexOperator((..., pixel_inds), in_structure=landscape.structure)
+            else:
+                raise NotImplementedError(
+                    f'Cannot index a landscape of type {type(landscape).__name__}.'
+                )
 
             # Rotation due to coordinate transform
             tod_shape = pixel_inds.shape[:2]

--- a/src/furax/mapmaking/mapmaker.py
+++ b/src/furax/mapmaking/mapmaker.py
@@ -1224,9 +1224,9 @@ class MLMapmaker(MapMaker):
         positive_sample_hits = (
             (masker @ acquisition @ selector.T)(
                 StokesIQU.from_stokes(
-                    jnp.ones(selector.out_structure.shape, dtype=data.dtype),
-                    jnp.zeros(selector.out_structure.shape, dtype=data.dtype),
-                    jnp.zeros(selector.out_structure.shape, dtype=data.dtype),
+                    i=jnp.ones(selector.out_structure.shape, dtype=data.dtype),
+                    q=jnp.zeros(selector.out_structure.shape, dtype=data.dtype),
+                    u=jnp.zeros(selector.out_structure.shape, dtype=data.dtype),
                 )
             )
             > 0

--- a/src/furax/mapmaking/mapmaker.py
+++ b/src/furax/mapmaking/mapmaker.py
@@ -1128,7 +1128,7 @@ class BinnedMapMaker(MapMaker):
         final_map = np.array([res.i, res.q, res.u])
         weights = np.array(system.blocks)
 
-        output: dict[str, Any] = {'map': final_map, 'weights': weights}
+        output = {'map': final_map, 'weights': weights}
         if isinstance(landscape, WCSLandscape):
             output['wcs'] = landscape.to_wcs()
         elif isinstance(landscape, AstropyWCSLandscape):
@@ -1282,7 +1282,7 @@ class MLMapmaker(MapMaker):
         # Format output and compute auxiliary data
         final_map = np.array([result_map.i, result_map.q, result_map.u])
 
-        output: dict[str, Any] = {'map': final_map, 'weights': weights, 'weights_uncut': blocks}
+        output = {'map': final_map, 'weights': weights, 'weights_uncut': blocks}
         if isinstance(landscape, WCSLandscape):
             output['wcs'] = landscape.to_wcs()
         elif isinstance(landscape, AstropyWCSLandscape):
@@ -1398,7 +1398,7 @@ class ATOPMapMaker(MapMaker):
         # Format output and compute auxiliary data
         final_map = np.array([result_map.q, result_map.u])
 
-        output: dict[str, Any] = {'map': final_map, 'weights': blocks}
+        output = {'map': final_map, 'weights': blocks}
         if isinstance(landscape, AstropyWCSLandscape):
             output['wcs'] = landscape.wcs
         if (

--- a/src/furax/mapmaking/noise.py
+++ b/src/furax/mapmaking/noise.py
@@ -276,7 +276,7 @@ def padding_aware_welch(
         fs=fs,
         nperseg=nperseg,
         noverlap=noverlap,
-        detrend='constant',  # type: ignore[arg-type]
+        detrend='constant',  # ty: ignore[invalid-argument-type]
         boundary=None,
         padded=False,
     )

--- a/src/furax/mapmaking/pixell_utils.py
+++ b/src/furax/mapmaking/pixell_utils.py
@@ -2,7 +2,6 @@ from typing import Any
 
 import healpy as hp
 import jax
-import matplotlib.axes
 import matplotlib.pyplot as plt
 import numpy as np
 import pixell.enmap
@@ -30,9 +29,9 @@ def plot_ndmap(
     vmin: float | None = None,
     cmap: str = 'RdBu_r',
     scale: float = 1.0,
-    fig: matplotlib.figure.Figure | None = None,
-    ax: matplotlib.axes._axes.Axes | None = None,
-) -> tuple[matplotlib.figure.Figure, matplotlib.axes._axes.Axes]:
+    fig=None,
+    ax=None,
+):
     """Visualisation function for ndmap that replaces pixell.enplot.eshow for now.
 
     Inputs:
@@ -53,7 +52,7 @@ def plot_ndmap(
         vmax = scale * np.max(np.abs(data))
         vmin = -vmax
 
-    wcs = data.wcs.wcs
+    wcs = data.wcs.wcs  # ty: ignore[unresolved-attribute]
     # Note that the data has axes [Dec, RA], unlike the wcs object's [RA, Dec]
     ra = wcs.crval[0] + wcs.cdelt[0] * (np.arange(data.shape[1] + 1) - wcs.crpix[0] - 0.5)
     dec = wcs.crval[1] + wcs.cdelt[1] * (np.arange(data.shape[0] + 1) - wcs.crpix[1] - 0.5)
@@ -85,9 +84,9 @@ def plot_cartview(
     vmins: list[float] | list[None] | None = None,
     vmax_quantile: float = 0.999,
     nside: int | None = None,
-    fig: matplotlib.figure.Figure | None = None,
-    axs: matplotlib.axes._axes.Axes | None = None,
-) -> tuple[matplotlib.figure.Figure, NDArray[matplotlib.axes.Axes]]:
+    fig=None,
+    axs=None,
+):
     """Visualisation function for CAR projection of healpix maps.
 
     Unlike healpy.cartview, this function returns matplotlib Axes object, and one can have

--- a/src/furax/mapmaking/results.py
+++ b/src/furax/mapmaking/results.py
@@ -82,7 +82,7 @@ class MapMakingResults:
                 for leg, amplitudes in legs.items():
                     key = f'{name}/{leg}' if leg else name
                     entries[key] = np.array(amplitudes)
-            np.savez(out_dir / _AMPLITUDES_FILE, **entries)  # type: ignore[arg-type]
+            np.savez(out_dir / _AMPLITUDES_FILE, **entries)  # ty: ignore[invalid-argument-type]
         if self.solver_stats is not None:
             (out_dir / 'solver_stats.json').write_text(json.dumps(self.solver_stats, indent=2))
         if self.failed_observations:
@@ -151,7 +151,7 @@ class MapMakingResults:
             path = out_dir / f'{name}.npy'
             if not path.exists():
                 raise FileNotFoundError(f'Expected file not found: {path}')
-            return np.load(path)  # type: ignore[no-any-return]
+            return np.load(path)
 
     @staticmethod
     def _load_map(out_dir: Path, landscape: StokesLandscape) -> StokesType:
@@ -233,7 +233,7 @@ class MapMakingResults:
         stokes = self.landscape.stokes
         ns = len(stokes)
         upper = [(i, j) for i in range(ns) for j in range(i, ns)]
-        column_names = [stokes[i] + stokes[j] for i, j in upper]
+        column_names: list[str] = [stokes[i] + stokes[j] for i, j in upper]
         arr_upper = np.stack([arr[i, j] for i, j in upper], axis=0)
         self._save_array(arr_upper, 'icov', out_dir, column_names=column_names)
 

--- a/src/furax/mapmaking/streaming.py
+++ b/src/furax/mapmaking/streaming.py
@@ -294,7 +294,7 @@ class StreamOperator(AbstractLinearOperator):
             ValueError: As for [`block_row`][furax.mapmaking.streaming.StreamOperator.block_row].
         """
         result = cls.block_row([op.T for op in operands]).T
-        assert isinstance(result, StreamOperator)  # mypy
+        assert isinstance(result, StreamOperator)  # ty assert
         return result
 
     @classmethod
@@ -427,8 +427,8 @@ class StreamOperator(AbstractLinearOperator):
         in_pspecs = (P(axis), P(), P(axis), P())
 
         @jax.shard_map(in_specs=in_pspecs, out_specs=out_pspecs, check_vma=False)
-        def kernel(dyn, static, x_stacked, x_shared):  # type: ignore[no-untyped-def]
-            def step(carry, args):  # type: ignore[no-untyped-def]
+        def kernel(dyn, static, x_stacked, x_shared):
+            def step(carry, args):
                 dyn_i, xs_i = args
                 y = _apply_chain(dyn_i, static, eqx.combine(xs_i, x_shared))
                 ys_i, y_shared = eqx.partition(y, out_mask)
@@ -521,8 +521,8 @@ class StreamStreamFusionRule(AbstractCompositionRule):
 
     def check(self, left: AbstractLinearOperator, right: AbstractLinearOperator) -> None:
         super().check(left, right)
-        assert isinstance(left, StreamOperator)  # mypy
-        assert isinstance(right, StreamOperator)  # mypy
+        assert isinstance(left, StreamOperator)  # ty assert
+        assert isinstance(right, StreamOperator)  # ty assert
         # n_lead must be checked explicitly: the all-stacked test below is vacuous on a leafless
         # junction (no leaves to disagree), so it cannot catch a slot-count mismatch on its own.
         if left.n_lead != right.n_lead:
@@ -538,8 +538,8 @@ class StreamStreamFusionRule(AbstractCompositionRule):
     def apply(
         self, left: AbstractLinearOperator, right: AbstractLinearOperator
     ) -> list[AbstractLinearOperator]:
-        assert isinstance(left, StreamOperator)  # mypy
-        assert isinstance(right, StreamOperator)  # mypy
+        assert isinstance(left, StreamOperator)  # ty assert
+        assert isinstance(right, StreamOperator)  # ty assert
         segments = left.segments + right.segments
         return [
             StreamOperator.create(
@@ -585,7 +585,7 @@ class HomothetyStreamRule(AbstractCompositionRule):
         self, left: AbstractLinearOperator, right: AbstractLinearOperator
     ) -> list[AbstractLinearOperator]:
         split = self._split(left, right)
-        assert split is not None  # mypy
+        assert split is not None  # ty assert
         homo, block, on_output_side = split
         if on_output_side:  # homo @ block: leading constant segment
             # we need the per-block structure here, not the public one with the leading axis
@@ -624,8 +624,8 @@ class StreamStreamAdditionRule(AbstractAdditionRule):
 
     def check(self, left: AbstractLinearOperator, right: AbstractLinearOperator) -> None:
         super().check(left, right)
-        assert isinstance(left, StreamOperator)  # mypy
-        assert isinstance(right, StreamOperator)  # mypy
+        assert isinstance(left, StreamOperator)  # ty assert
+        assert isinstance(right, StreamOperator)  # ty assert
         # An addition stream's structures are per-slice, so `__add__`'s structure check does not
         # force equal n; a mismatched-n sum is legal algebra that must stay unreduced. Mixed specs
         # (previously guaranteed equal by same-class dispatch) must now be checked explicitly too.
@@ -645,8 +645,8 @@ class StreamStreamAdditionRule(AbstractAdditionRule):
     def apply(
         self, left: AbstractLinearOperator, right: AbstractLinearOperator
     ) -> list[AbstractLinearOperator]:
-        assert isinstance(left, StreamOperator)  # mypy
-        assert isinstance(right, StreamOperator)  # mypy
+        assert isinstance(left, StreamOperator)  # ty assert
+        assert isinstance(right, StreamOperator)  # ty assert
         n_sliced = max(left.sliced_count, right.sliced_count)
         if n_sliced == 0:
             raise NoReduction  # nothing to stream: defer to a plain AdditionOperator

--- a/src/furax/mapmaking/templates.py
+++ b/src/furax/mapmaking/templates.py
@@ -226,7 +226,7 @@ class Basis(AbstractLinearOperator):
     @property
     def shape(self) -> tuple[int, ...]:
         """Shape of the basis index, for a single detector."""
-        return self.in_structure.shape  # type: ignore[no-any-return]
+        return self.in_structure.shape
 
     @property
     @abstractmethod
@@ -240,7 +240,7 @@ class Basis(AbstractLinearOperator):
 
     @property
     def dtype(self) -> DTypeLike:
-        return self.in_structure.dtype  # type: ignore[no-any-return]
+        return self.in_structure.dtype
 
     @property
     def out_structure(self) -> jax.ShapeDtypeStruct:
@@ -917,7 +917,7 @@ class AbstractTemplateOperator(AbstractLinearOperator):
     # ---- TOD side -------------------------------------------------------------------------------
     def _a_basis(self) -> Basis:
         """Any one of the bases: they agree on sample count and dtype."""
-        return jax.tree.leaves(self.bases, is_leaf=is_basis)[0]  # type: ignore[no-any-return]
+        return jax.tree.leaves(self.bases, is_leaf=is_basis)[0]
 
     def _stream_structure(self) -> jax.ShapeDtypeStruct:
         """One detector-by-sample stream, the shape every Stokes leg of the TOD takes."""
@@ -937,12 +937,12 @@ class AbstractTemplateOperator(AbstractLinearOperator):
     @classmethod
     def _expand(cls, basis: Basis, a: Array) -> Array:
         vmapped = jax.vmap(lambda op, ai: op.expand(ai), in_axes=cls._in_axes(basis))
-        return vmapped(basis, a)  # type: ignore[no-any-return]
+        return vmapped(basis, a)
 
     @classmethod
     def _project(cls, basis: Basis, s: Array) -> Array:
         vmapped = jax.vmap(lambda op, si: op.project(si), in_axes=cls._in_axes(basis))
-        return vmapped(basis, s)  # type: ignore[no-any-return]
+        return vmapped(basis, s)
 
     # ---- adjoint --------------------------------------------------------------------------------
     @abstractmethod

--- a/src/furax/obs/_likelihoods.py
+++ b/src/furax/obs/_likelihoods.py
@@ -142,7 +142,7 @@ def preconditionner(
     dust_nu0: float,
     synchrotron_nu0: float,
     patch_indices: PyTree[Array] = single_cluster_indices,
-) -> MixingMatrixOperator:  # type: ignore[valid-type]
+) -> AbstractLinearOperator:
     """Constructs the MixingMatrixOperator for preconditioning purposes.
 
     This function builds the mixing matrix operator based on the provided spectral parameters

--- a/src/furax/obs/_likelihoods.py
+++ b/src/furax/obs/_likelihoods.py
@@ -266,7 +266,7 @@ def _spectral_likelihood_core(
 # ==============================================================================
 
 
-@partial(jax.custom_vjp, nondiff_argnums=(4, 5))
+@partial(jax.custom_vjp, nondiff_argnums=(4, 5))  # ty: ignore[dynamic-function-decorator-return]
 def _spectral_log_likelihood_analytical(
     params: PyTree[Array],
     nu: Array,
@@ -439,7 +439,7 @@ def spectral_log_likelihood(
     return ll
 
 
-@partial(jax.custom_vjp, nondiff_argnums=(4, 5))
+@partial(jax.custom_vjp, nondiff_argnums=(4, 5))  # ty: ignore[dynamic-function-decorator-return]
 def _sky_signal_analytical(
     params: PyTree[Array],
     nu: Array,

--- a/src/furax/obs/atmosphere/_likelihood.py
+++ b/src/furax/obs/atmosphere/_likelihood.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 import jax
 import jax.numpy as jnp
 import lineax as lx
@@ -17,7 +19,7 @@ def profile_neg_log_likelihood(
     d: StokesI,
     noise_cov_inv: AbstractLinearOperator,
     *,
-    solver: lx.AbstractLinearSolver | None = None,
+    solver: lx.AbstractLinearSolver[Any] | None = None,
 ) -> Scalar:
     r"""Negative profile log-likelihood for atmosphere pointing parameters.
 

--- a/src/furax/obs/atmosphere/_operator.py
+++ b/src/furax/obs/atmosphere/_operator.py
@@ -106,7 +106,7 @@ class AtmospherePointingOperator(PointingOperator):
         if not self.elevation_modulation:
             return tod
         sin_el = qdet_full.rotate_vector(ZAXIS)[..., 2]  # (det, samp)
-        return tree.truediv(tod, sin_el)  # type: ignore[no-any-return]
+        return tree.truediv(tod, sin_el)
 
     def _quat2index(self, qdet_full: Quaternion) -> Array:
         x, y = self._wind_xy(qdet_full)

--- a/src/furax/obs/landscapes.py
+++ b/src/furax/obs/landscapes.py
@@ -82,7 +82,7 @@ class StokesLandscape(Landscape):
         if shape is not None and pixel_shape is not None:
             raise TypeError('Either the shape or pixel_shape should be specified.')
         shape = shape if pixel_shape is None else pixel_shape[::-1]
-        assert shape is not None  # mypy assert
+        assert shape is not None  # ty assert
         super().__init__(shape, dtype)
         self.stokes = stokes
         self.pixel_shape = shape[::-1]
@@ -232,7 +232,7 @@ class ProjectionType(IntEnum):
 
 
 @register_static
-@dataclass
+@dataclass(frozen=True)
 class WCSProjection:
     """Class that holds basic WCS projection parameters."""
 
@@ -523,7 +523,7 @@ class AstropyWCSLandscape(StokesLandscape):
             WCS map index pairs
         """
 
-        def f(theta, phi):  # type: ignore[no-untyped-def]
+        def f(theta, phi):
             # SkyCoord takes (lon,lat)
             pix_i, pix_j = self.wcs.world_to_pixel(SkyCoord(phi, (np.pi / 2 - theta), unit='rad'))
             return np.array(pix_i), np.array(pix_j)
@@ -531,7 +531,7 @@ class AstropyWCSLandscape(StokesLandscape):
         struct = jax.ShapeDtypeStruct(theta.shape, theta.dtype)
         result_shape = (struct, struct)
 
-        return jax.pure_callback(f, result_shape, theta, phi)  # type: ignore[no-any-return]
+        return jax.pure_callback(f, result_shape, theta, phi)
 
 
 @register_static

--- a/src/furax/obs/operators/__init__.py
+++ b/src/furax/obs/operators/__init__.py
@@ -7,7 +7,7 @@ from ._seds import (
     CMBOperator,
     DustOperator,
     MixingMatrixOperator,
-    NoiseDiagonalOperator,
+    NoiseDiagonalOperator,  # ty: ignore[deprecated]
     SynchrotronOperator,
 )
 from ._transfer_matrix import (

--- a/src/furax/obs/operators/_qu_rotations.py
+++ b/src/furax/obs/operators/_qu_rotations.py
@@ -97,7 +97,7 @@ class QURotationOperator(AbstractLinearOperator):
         return cls(angles=angles, atomic=atomic, in_structure=structure)
 
     def mv(self, x: _StokesT) -> _StokesT:
-        return rotate_qu(x, self.angles)  # type: ignore[no-any-return]
+        return rotate_qu(x, self.angles)
 
     def transpose(self) -> AbstractLinearOperator:
         return QURotationTransposeOperator(operator=self)
@@ -107,7 +107,7 @@ class QURotationTransposeOperator(AbstractLazyInverseOrthogonalOperator):
     operator: QURotationOperator
 
     def mv(self, x: _StokesT) -> _StokesT:
-        return rotate_qu(x, -self.operator.angles)  # type: ignore[no-any-return]
+        return rotate_qu(x, -self.operator.angles)
 
 
 class QURotationRule(AbstractCompositionRule):

--- a/src/furax/obs/operators/_seds.py
+++ b/src/furax/obs/operators/_seds.py
@@ -50,7 +50,7 @@ def K_RK_2_K_CMB(nu: Array | float) -> Array:
     res = jnp.expm1(_H_OVER_K_GHZ * nu / _T_CMB) ** 2 / (
         jnp.exp(_H_OVER_K_GHZ * nu / _T_CMB) * (_H_OVER_K_GHZ * nu / _T_CMB) ** 2
     )
-    return res  # type: ignore [no-any-return]
+    return res
 
 
 class AbstractSEDOperator(AbstractLinearOperator):
@@ -112,7 +112,7 @@ class AbstractSEDOperator(AbstractLinearOperator):
         input_shapes = {leaf.shape for leaf in jax.tree.leaves(in_structure)}
         if len(input_shapes) != 1:
             raise ValueError(f'the leaves of the input do not have the same shape: {in_structure}')
-        return input_shapes.pop()  # type: ignore[no-any-return]
+        return input_shapes.pop()
 
     def _broadcast_over_maps(self, x: Any) -> Float[Array, '...']:
         """Reshape a per-frequency (or scalar) array to broadcast like `frequencies`.
@@ -422,7 +422,9 @@ class NoiseDiagonalOperator(AbstractLinearOperator):
         return jax.tree.map(lambda v, leaf: v * leaf, self.vector, x)
 
     def inverse(self) -> AbstractLinearOperator:
-        return NoiseDiagonalOperator(vector=1 / self.vector, in_structure=self.in_structure)
+        return NoiseDiagonalOperator(  # ty: ignore[deprecated]
+            vector=1 / self.vector, in_structure=self.in_structure
+        )
 
     def as_matrix(self) -> Any:
         return jax.tree.map(lambda x: jnp.diag(x.flatten()), self.vector)

--- a/src/furax/obs/operators/_transfer_matrix.py
+++ b/src/furax/obs/operators/_transfer_matrix.py
@@ -296,7 +296,7 @@ def _layer_transfer_matrix(
 
     # Transfer matrix: Ψ Φ (Ψ Φ P)⁻¹
     PsiPhi = Psi @ Phi
-    return PsiPhi @ jnp.linalg.inv(PsiPhi @ P)  # type: ignore[no-any-return]
+    return PsiPhi @ jnp.linalg.inv(PsiPhi @ P)
 
 
 def _stack_transfer_matrix(

--- a/src/furax/obs/pointing.py
+++ b/src/furax/obs/pointing.py
@@ -111,7 +111,7 @@ class PointingOperator(AbstractLinearOperator):
 
             # Return the rotated Stokes parameters
             cos_angles, sin_angles = to_polarization_angle_cos_sin(qdet_full)
-            return rotate_qu_cs(tod, cos_angles, sin_angles)  # type: ignore[no-any-return]
+            return rotate_qu_cs(tod, cos_angles, sin_angles)
 
         # Loop over batches of detectors.
         # NB: lax.map was tried here (PR #172) instead of the fori_loop+scatter form

--- a/src/furax/obs/stokes.py
+++ b/src/furax/obs/stokes.py
@@ -331,9 +331,10 @@ class Stokes(ABC):
                 'arguments.'
             )
         if keywords:
-            # 'iquv' is conveniently in alphabetical order
-            stokes = ''.join(sorted(keywords))
-            if stokes.upper() not in get_args(ValidStokesLiteral):
+            # The keywords are the lowercase component names of the overloads (i=, q=, ...)
+            valid = tuple(combination.lower() for combination in get_args(ValidStokesLiteral))
+            stokes = ''.join(sorted(keywords))  #'iquv' is alphabetically sorted
+            if stokes not in valid:
                 raise TypeError(
                     f"Invalid Stokes vectors: {stokes!r}. Use 'i', 'qu', 'iqu' or 'iquv'."
                 )

--- a/src/furax/obs/stokes.py
+++ b/src/furax/obs/stokes.py
@@ -311,11 +311,7 @@ class Stokes(ABC):
     ) -> 'StokesIQUV': ...
 
     @classmethod
-    def from_stokes(
-        cls,
-        *args: Any,
-        **keywords: Any,
-    ) -> 'Stokes':
+    def from_stokes(cls, *args: Any, **keywords: Any) -> 'Stokes':
         """Returns a StokesPyTree according to the specified Stokes vectors.
 
         Examples:
@@ -323,6 +319,11 @@ class Stokes(ABC):
             >>> tod_qu = Stokes.from_stokes(q, u)
             >>> tod_iqu = Stokes.from_stokes(i, q, u)
             >>> tod_iquv = Stokes.from_stokes(i, q, u, v)
+
+            The components can also be named, with lowercase keywords:
+
+            >>> tod_qu = Stokes.from_stokes(q=q, u=u)
+            >>> tod_iqu = Stokes.from_stokes(i=i, q=q, u=u)
         """
         if args and keywords:
             raise TypeError(
@@ -330,10 +331,11 @@ class Stokes(ABC):
                 'arguments.'
             )
         if keywords:
+            # 'iquv' is conveniently in alphabetical order
             stokes = ''.join(sorted(keywords))
-            if stokes not in get_args(ValidStokesLiteral):
+            if stokes.upper() not in get_args(ValidStokesLiteral):
                 raise TypeError(
-                    f"Invalid Stokes vectors: {stokes!r}. Use 'I', 'QU', 'IQU' or 'IQUV'."
+                    f"Invalid Stokes vectors: {stokes!r}. Use 'i', 'qu', 'iqu' or 'iquv'."
                 )
             args = tuple(keywords[stoke] for stoke in stokes)
 

--- a/src/furax/obs/stokes.py
+++ b/src/furax/obs/stokes.py
@@ -108,7 +108,7 @@ class Stokes(ABC):
             raise ValueError(msg)
         # Bypass __init__ to avoid device transfer
         instance = object.__new__(cls)
-        instance.data = array  # type: ignore[assignment]
+        instance.data = array  # ty: ignore[invalid-assignment]
         return instance
 
     def __pdoc__(self, **kwargs: Any) -> wl.AbstractDoc:
@@ -116,7 +116,7 @@ class Stokes(ABC):
         return wl.ConcatDoc(wl.TextDoc(f'{type(self).__name__}('), inner, wl.TextDoc(')'))
 
     def __repr__(self) -> str:
-        return wl.pformat(self, width=80)  # type: ignore[no-any-return]
+        return wl.pformat(self, width=80)
 
     # ---- component access -----------------------------------------------------------------------
     def _component(self, letter: str) -> Array:
@@ -196,7 +196,7 @@ class Stokes(ABC):
         if rhs is NotImplemented:
             # mypy's exemption for returning NotImplemented only applies inside a method
             # literally named as a dunder (e.g. __add__), not this shared helper.
-            return NotImplemented  # type: ignore[no-any-return]
+            return NotImplemented
         return self.from_array(fn(rhs, self.data) if reflected else fn(self.data, rhs))
 
     def __add__(self, other: Any) -> Self:

--- a/src/furax/tree.py
+++ b/src/furax/tree.py
@@ -230,14 +230,14 @@ def is_leaf(x: Any) -> bool:
 def apply(
     operation: Callable[[Any, Any], Any], a: PyTree[Array], b: PyTree[Array]
 ) -> PyTree[Array]:
-    def func_a_treedef(a_leaf, b_leaf):  # type: ignore[no-untyped-def]
+    def func_a_treedef(a_leaf, b_leaf):
         if a_leaf is None or b_leaf is None:
             return None
         if is_leaf(b_leaf):
             return operation(a_leaf, b_leaf)
         return jax.tree.map(lambda b_inner_leaf: operation(a_leaf, b_inner_leaf), b_leaf)
 
-    def func_b_treedef(a_leaf, b_leaf):  # type: ignore[no-untyped-def]
+    def func_b_treedef(a_leaf, b_leaf):
         if a_leaf is None or b_leaf is None:
             return None
         if is_leaf(a_leaf):
@@ -246,16 +246,16 @@ def apply(
 
     a_leaves, treedef = jax.tree.flatten(a)
     try:
-        b_leaves = treedef.flatten_up_to(b)  # type: ignore[attr-defined]
+        b_leaves = treedef.flatten_up_to(b)
         func = func_a_treedef
     except ValueError:
         b_leaves, treedef = jax.tree.flatten(b)
         try:
-            a_leaves = treedef.flatten_up_to(a)  # type: ignore[attr-defined]
+            a_leaves = treedef.flatten_up_to(a)
         except ValueError as exc:
             raise StructureError(str(exc)) from exc
         func = func_b_treedef
-    return treedef.unflatten(func(*xs) for xs in zip(a_leaves, b_leaves))  # type: ignore[attr-defined]
+    return treedef.unflatten(func(*xs) for xs in zip(a_leaves, b_leaves))
 
 
 def add(a: PyTree[Array], b: PyTree[Array]) -> PyTree[Array]:
@@ -470,7 +470,7 @@ def _get_outer_treedef(inner_treedef: PyTreeDef | PyTree[Any], tree: PyTree[Arra
         inner_treedef = jax.tree.structure(inner_treedef)
 
     def is_inner(node: Any) -> bool:
-        return jax.tree.structure(node) == inner_treedef  # type: ignore[no-any-return]
+        return jax.tree.structure(node) == inner_treedef
 
     outer_tree = jax.tree.map(lambda x: 0, tree, is_leaf=is_inner)
     return jax.tree.structure(outer_tree)

--- a/src/so_mapmaking/prepare.py
+++ b/src/so_mapmaking/prepare.py
@@ -73,8 +73,8 @@ def _process_obs(obs_id: str, ctx: _Context) -> None:
     logger.info(f'saved observation to {obsfile.name}')
 
 
-@app.default  # type: ignore[untyped-decorator]
-def prepare(  # type: ignore[no-untyped-def]
+@app.default
+def prepare(
     init_config: Path,
     proc_config: Path | None = None,
     obsid: list[str] | None = None,

--- a/src/so_mapmaking/run.py
+++ b/src/so_mapmaking/run.py
@@ -12,8 +12,8 @@ from .util import detector_selection, resolve_obsids, setup_logger
 app = App(help='Run the mapmaker on SO observations, loaded straight from the preproc db.')
 
 
-@app.default  # type: ignore[untyped-decorator]
-def run(  # type: ignore[no-untyped-def]
+@app.default
+def run(
     init_config: Path | None = None,
     proc_config: Path | None = None,
     obsid: list[str] | None = None,

--- a/src/so_mapmaking/stage.py
+++ b/src/so_mapmaking/stage.py
@@ -131,7 +131,7 @@ def stage_config(stager: Stager, config_path: Path) -> Path:
     return patched_config
 
 
-@app.default  # type: ignore[untyped-decorator]
+@app.default
 def stage(init_config: Path, dest: Path, proc_config: Path | None = None) -> None:
     """Stage the init (and optional proc) preproc indices to ``dest`` and print the patched configs.
 

--- a/src/so_mapmaking/util.py
+++ b/src/so_mapmaking/util.py
@@ -3,7 +3,7 @@ from pathlib import Path
 
 
 def setup_logger(loglevel: str, log_path: Path | None, process_index: int = 0) -> logging.Logger:
-    level = logging.getLevelName(loglevel.upper())
+    level = loglevel.upper()
     # Configure the package-root logger so every ``furax.*`` submodule (mapmaker, io.readers, ...)
     # propagates its records to these handlers. Configuring ``furax.mapmaker`` alone would drop
     # sibling loggers such as ``furax.io.readers`` (per-observation read logging).

--- a/tests/interfaces/sotodlib/_preproc_db.py
+++ b/tests/interfaces/sotodlib/_preproc_db.py
@@ -16,7 +16,7 @@ from sotodlib.core import OBSLOADER_REGISTRY, AxisManager, metadata
 _RAW_FILES: dict[str, str] = {}
 
 
-def _furax_test_loader(_obsfiledb, obs_id, dets=None, samples=None, no_signal=None, **_kwargs):  # type: ignore[no-untyped-def]
+def _furax_test_loader(_obsfiledb, obs_id, dets=None, samples=None, no_signal=None, **_kwargs):
     """Serve the raw observation from a saved AxisManager file (test obs loader).
 
     Mimics a real obs loader: returns signal + geometry only, leaving obs_info and the

--- a/tests/interfaces/sotodlib/test_io.py
+++ b/tests/interfaces/sotodlib/test_io.py
@@ -177,7 +177,7 @@ def test_preproc_context_cache(tmp_path, monkeypatch) -> None:
     n_builds = 0
     original_init = Context.__init__
 
-    def counting_init(self, *args, **kwargs):  # type: ignore[no-untyped-def]
+    def counting_init(self, *args, **kwargs):
         nonlocal n_builds
         n_builds += 1
         original_init(self, *args, **kwargs)
@@ -224,7 +224,7 @@ def test_mapmaker_reads_each_observation_once(tmp_path, monkeypatch) -> None:
     n_loads = 0
     original = SOTODLibObservation.from_preproc_group.__func__
 
-    def counting(cls, *args, **kwargs):  # type: ignore[no-untyped-def]
+    def counting(cls, *args, **kwargs):
         nonlocal n_loads
         n_loads += 1
         return original(cls, *args, **kwargs)

--- a/tests/mapmaking/helpers.py
+++ b/tests/mapmaking/helpers.py
@@ -47,7 +47,7 @@ class FakeObservation(AbstractObservation[None]):
         sample_rate: float = 100.0,
         hwp_frequency: float = 2.0,
         seed: int = 0,
-    ) -> None:  # type: ignore[override]
+    ) -> None:
         # Bypass AbstractObservation.__init__: there is no underlying
         # ``data`` container for an in-memory observation.
         self._n_dets = n_dets
@@ -152,7 +152,7 @@ class FakeLazyObservation(AbstractLazyObservation[None]):
 
     interface_class = FakeObservation
 
-    def __init__(self, **kwargs: Any) -> None:  # type: ignore[override]
+    def __init__(self, **kwargs: Any) -> None:
         self.file = Path('<synthetic>')
         self._kwargs = kwargs
 
@@ -293,7 +293,7 @@ class FakeLazyGroundObservation(AbstractLazyObservation[None]):
 
     interface_class = FakeGroundObservation
 
-    def __init__(self, **kwargs: Any) -> None:  # type: ignore[override]
+    def __init__(self, **kwargs: Any) -> None:
         self.file = Path('<synthetic>')
         self._kwargs = kwargs
 

--- a/tests/obs/operators/seds/test_seds.py
+++ b/tests/obs/operators/seds/test_seds.py
@@ -16,7 +16,7 @@ def fg_data() -> tuple[dict[str, np.ndarray], Stokes, jax.ShapeDtypeStruct]:
 
     data = np.load(fg_filename)
     freq_maps = data['freq_maps']
-    d = Stokes.from_stokes(I=freq_maps[:, 0, :], Q=freq_maps[:, 1, :], U=freq_maps[:, 2, :])
+    d = Stokes.from_stokes(i=freq_maps[:, 0, :], q=freq_maps[:, 1, :], u=freq_maps[:, 2, :])
 
     nside = 32
     stokes_type = 'IQU'
@@ -32,7 +32,7 @@ def test_cmb_k_cmb(fg_data):
     # Calculate CMB with K_CMB unit in furax
     cmb_fgbuster = data['CMB_K_CMB'][..., jnp.newaxis, jnp.newaxis] * data['freq_maps']
     cmb_fgbuster_tree = Stokes.from_stokes(
-        I=cmb_fgbuster[:, 0, :], Q=cmb_fgbuster[:, 1, :], U=cmb_fgbuster[:, 2, :]
+        i=cmb_fgbuster[:, 0, :], q=cmb_fgbuster[:, 1, :], u=cmb_fgbuster[:, 2, :]
     )
 
     cmb_operator = CMBOperator(nu, in_structure=in_structure, units='K_CMB')
@@ -48,7 +48,7 @@ def test_cmb_k_rj(fg_data):
     # Calculate CMB with K_RJ unit in furax
     cmb_fgbuster = data['CMB_K_RJ'][..., jnp.newaxis, jnp.newaxis] * data['freq_maps']
     cmb_fgbuster_tree = Stokes.from_stokes(
-        I=cmb_fgbuster[:, 0, :], Q=cmb_fgbuster[:, 1, :], U=cmb_fgbuster[:, 2, :]
+        i=cmb_fgbuster[:, 0, :], q=cmb_fgbuster[:, 1, :], u=cmb_fgbuster[:, 2, :]
     )
 
     cmb_operator = CMBOperator(nu, in_structure=in_structure, units='K_RJ')
@@ -64,7 +64,7 @@ def test_dust_k_cmb(fg_data):
     # Calculate Dust with K_CMB unit in furax
     dust_fgbuster = data['DUST_K_CMB'][..., jnp.newaxis, jnp.newaxis] * data['freq_maps']
     dust_fgbuster_tree = Stokes.from_stokes(
-        I=dust_fgbuster[:, 0, :], Q=dust_fgbuster[:, 1, :], U=dust_fgbuster[:, 2, :]
+        i=dust_fgbuster[:, 0, :], q=dust_fgbuster[:, 1, :], u=dust_fgbuster[:, 2, :]
     )
 
     dust_operator = DustOperator(
@@ -82,7 +82,7 @@ def test_dust_k_rj(fg_data):
     # Calculate Dust with K_RJ unit in furax
     dust_fgbuster = data['DUST_K_RJ'][..., jnp.newaxis, jnp.newaxis] * data['freq_maps']
     dust_fgbuster_tree = Stokes.from_stokes(
-        I=dust_fgbuster[:, 0, :], Q=dust_fgbuster[:, 1, :], U=dust_fgbuster[:, 2, :]
+        i=dust_fgbuster[:, 0, :], q=dust_fgbuster[:, 1, :], u=dust_fgbuster[:, 2, :]
     )
 
     dust_operator = DustOperator(
@@ -100,7 +100,7 @@ def test_synchrotron_k_cmb(fg_data):
     # Calculate Synchrotron with K_CMB unit in furax
     synch_fgbuster = data['SYNC_K_CMB'][..., jnp.newaxis, jnp.newaxis] * data['freq_maps']
     synch_fgbuster_tree = Stokes.from_stokes(
-        I=synch_fgbuster[:, 0, :], Q=synch_fgbuster[:, 1, :], U=synch_fgbuster[:, 2, :]
+        i=synch_fgbuster[:, 0, :], q=synch_fgbuster[:, 1, :], u=synch_fgbuster[:, 2, :]
     )
 
     synch_operator = SynchrotronOperator(
@@ -118,7 +118,7 @@ def test_synchrotron_k_rj(fg_data):
     # Calculate Synchrotron with K_RJ unit in furax
     synch_fgbuster = data['SYNC_K_RJ'][..., jnp.newaxis, jnp.newaxis] * data['freq_maps']
     synch_fgbuster_tree = Stokes.from_stokes(
-        I=synch_fgbuster[:, 0, :], Q=synch_fgbuster[:, 1, :], U=synch_fgbuster[:, 2, :]
+        i=synch_fgbuster[:, 0, :], q=synch_fgbuster[:, 1, :], u=synch_fgbuster[:, 2, :]
     )
 
     synch_operator = SynchrotronOperator(
@@ -146,9 +146,9 @@ def test_broadcasts_sky_map_without_frequency_axis(fg_data):
     assert cmb_operator.out_structure.shape == (len(nu),) + in_structure.shape
 
     x = Stokes.from_stokes(
-        I=jnp.arange(in_structure.shape[0], dtype=jnp.float64),
-        Q=jnp.ones(in_structure.shape),
-        U=-jnp.ones(in_structure.shape),
+        i=jnp.arange(in_structure.shape[0], dtype=jnp.float64),
+        q=jnp.ones(in_structure.shape),
+        u=-jnp.ones(in_structure.shape),
     )
     y = cmb_operator(x)
 

--- a/tests/obs/test_stokes.py
+++ b/tests/obs/test_stokes.py
@@ -39,13 +39,19 @@ def test_from_stokes_args(stokes: ValidStokesLiteral) -> None:
     [''.join(_) for _ in chain.from_iterable(combinations('IQUV', n) for n in range(1, 5))],
 )
 def test_from_stokes_kwargs(any_stokes: str) -> None:
-    kwargs = {stoke: jnp.ones(1) for stoke in any_stokes}
+    kwargs = {stoke.lower(): jnp.ones(1) for stoke in any_stokes}
     if any_stokes not in ('I', 'QU', 'IQU', 'IQUV'):
-        with pytest.raises(TypeError, match=f"Invalid Stokes vectors: '{any_stokes}'"):
+        with pytest.raises(TypeError, match=f"Invalid Stokes vectors: '{any_stokes.lower()}'"):
             _ = Stokes.from_stokes(**kwargs)
     else:
         pytree = Stokes.from_stokes(**kwargs)
         assert type(pytree) is Stokes.class_for(any_stokes)
+
+
+def test_from_stokes_kwargs_rejects_uppercase(stokes: ValidStokesLiteral) -> None:
+    kwargs = {stoke: jnp.ones(1) for stoke in stokes}
+    with pytest.raises(TypeError, match=f"Invalid Stokes vectors: '{stokes}'"):
+        _ = Stokes.from_stokes(**kwargs)
 
 
 def test_from_iquv(stokes: ValidStokesLiteral) -> None:
@@ -59,7 +65,7 @@ def test_from_iquv(stokes: ValidStokesLiteral) -> None:
 
 def test_ravel(stokes: ValidStokesLiteral) -> None:
     shape = (4, 2)
-    arrays = {k: jnp.ones(shape) for k in stokes}
+    arrays = {k.lower(): jnp.ones(shape) for k in stokes}
     pytree = Stokes.from_stokes(**arrays)
     raveled_pytree = pytree.ravel()
     for stoke in stokes:
@@ -69,7 +75,7 @@ def test_ravel(stokes: ValidStokesLiteral) -> None:
 def test_reshape(stokes: ValidStokesLiteral) -> None:
     shape = (4, 2)
     new_shape = (2, 2, 2)
-    arrays = {k: jnp.ones(shape) for k in stokes}
+    arrays = {k.lower(): jnp.ones(shape) for k in stokes}
     pytree = Stokes.from_stokes(**arrays)
     raveled_pytree = pytree.reshape(new_shape)
     for stoke in stokes:


### PR DESCRIPTION
## Summary

Replaces mypy with [ty](https://github.com/astral-sh/ty) as the project's type checker.

Motivation is speed and maintenance: ty checks the whole of `src/` in well under a second, and it resolves several JAX and lineax constructs that mypy did not, which removes a class of suppressions that existed only to work around the checker.

### Bugs found

Three reachable defects that mypy missed.

- `Stokes.from_stokes` rejected the only keyword form its own overloads allow. The overloads declare lowercase (`i=`, `q=`, `u=`), but the runtime check compared the sorted keywords against the uppercase `ValidStokesLiteral`, so `from_stokes(i=..., q=..., u=...)` raised `TypeError: Invalid Stokes vectors: 'iqu'`. This had already made `tests/obs/operators/seds/data/generate_fgbuster_data.py` unrunnable. Keywords are now lowercase-only, matching the overloads, with a regression test. Note this cuts both ways: uppercase was the spelling that worked, so `from_stokes(I=..., Q=..., U=...)` now raises. One spelling, and it is the one the signature can check.
- `SOTODLibObservation.get_pointing_and_spin_angles` returned a numpy array from a signature promising a JAX array, next to a `TODO` asking whether `jnp` would work. It does. mypy accepted the mismatch because the sotodlib value was `Any`.
- `MapMaker._get_pointing` used `indexer` after an `if`/`elif` chain over landscape types with no `else`, so an unsupported landscape gave `NameError` instead of a diagnosable message. It now raises `NotImplementedError` naming the type.

The remaining friction is not defects: the suppressions that survive cover untyped values from JAX, toast and sotodlib, plus stub errors in `scipy.signal.stft` and `np.savez`.

### Suppression count

`src/` goes from 126 mypy suppressions to 23.

| mypy code | n | under ty |
| --- | --- | --- |
| `no-any-return` | 50 | `unsound-return-statement`, left disabled (see below) |
| `no-untyped-def` | 34 | no equivalent; ty checks unannotated bodies unconditionally instead |
| `arg-type` | 14 | 6 survive as `invalid-argument-type` |
| `attr-defined` | 9 | mostly gone: ty resolves `PyTreeDef.unflatten` and `flatten_up_to` |
| `assignment`, `method-assign` | 8 | 5 survive as `invalid-assignment` |
| `untyped-decorator` | 3 | 3 as `dynamic-function-decorator-return` |
| `operator`, `abstract`, `misc`, `valid-type`, `index`, `return-value` | 8 | all accepted by ty |

New under ty: 7 `unresolved-attribute`, for dynamic attributes on astropy, pixell and a monkeypatched sotodlib helper that mypy waved through, and 2 `deprecated`, which ty checks by default.

Six dead `# type: ignore` comments are dropped from `tests/`, which neither checker ever read.

### Configuration

`replace-imports-with-any` covers `toast` and `litebird_sim`; the rest of the old `ignore_missing_imports` list is unnecessary because ty resolves those packages.

Four rules that are disabled by default are turned on, three of them from ty's recommended configuration for mypy users:

- `missing-type-argument`: `lx.AbstractLinearSolver` is generic in its solver state, now spelled `AbstractLinearSolver[Any]`
- `possibly-unresolved-reference`: found the `indexer` bug above
- `dynamic-function-decorator-return`: the closest thing to mypy's `untyped-decorator`
- `unused-ignore-comment`: already clean, pinned so it stays that way

`unsound-return-statement` (ty's `no-any-return`) is deliberately left off. It fires 68 times, every one of them a value arriving from an untyped library, and suppressing them all buys nothing over the mypy status quo.

ty has no equivalent of `disallow_untyped_defs`; its recommended configuration pairs the rules above with ruff's `ANN` rules instead. Those are not enabled here. Most of the 34 old `no-untyped-def` suppressions sat on the small closures handed to `fori_loop`, `scan`, `vmap` and `custom_vjp`, where the argument is a traced carry whose honest annotation is long, unenlightening, and longer than the function it documents. Leaving those bare reads better. ty checks the bodies either way, which is where the mistakes actually are.

ty checks all of `src`, matching mypy's old scope. That turned up one more diagnostic: `so_mapmaking.util.setup_logger` used `logging.getLevelName` to turn a level name into a number, which is the deprecated `str -> int` overload. The level name goes straight to `setLevel` instead.

### CI

ty resolves third-party imports from the Python environment, so the hook no longer needs an `additional_dependencies` list. mypy's did, and it was a hand-maintained set of pins (`jax==0.11.1` among them) that had to be kept in step with the lockfile by hand, alongside an `ignore_missing_imports` list for everything left over.

The trade is that the environment now has to be real. The prek job installs the optional dependencies from the lockfile (`uv sync --locked --all-extras --no-default-groups --group lint`); previously it held dependency groups only, so every import from the `mapmaking`, `so` and `comp_sep` extras came back unresolved.

## Checklist

- [x] Tests added/updated for new or changed behavior
- [x] `uvx prek run -a` passes (ruff, ty, etc.)
- [x] Added a changelog entry under `[Unreleased]` in `docs/development/changelog.md`, or this PR doesn't need one (e.g. internal refactor, CI-only change)
- [x] Updated docs for user-facing changes (docstrings, `docs/`)