### PR TITLE
Widen the Pomme mask on the combined sample and scanning masks

### DIFF
--- a/docs/development/changelog.md
+++ b/docs/development/changelog.md
@@ -30,6 +30,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The fitted noise PSD no longer averages in Welch windows that fall in an observation's padded tail (#239)
 - The Welch segment is clipped to the shortest observation, so the noise fit never sees a padded sample (#236)
 - Aligned `Stokes.from_stokes` keyword handling with its declared overloads (#250)
+- Pomme in `MultiObservationMapMaker` now widens the scanning mask to whole intervals too (#254)
 
 ## [0.12.1]
 

--- a/src/furax/mapmaking/_model.py
+++ b/src/furax/mapmaking/_model.py
@@ -83,11 +83,7 @@ class ObservationModel:
             dtype=config.dtype,
         )
         tod_struct = H.out_structure
-        M = _mask_projector(
-            _sample_mask(data, config),
-            data.get(ReaderField.VALID_SCANNING_MASKS),
-            structure=tod_struct,
-        )
+        M = _mask_projector(_sample_mask(data, config), structure=tod_struct)
         noise_model, sample_rate = _noise_model(
             data, config, tod_structure=tod_struct, padding=padding
         )
@@ -252,11 +248,16 @@ def _noise_model(
 
 
 def _sample_mask(data: Any, config: MapMakingConfig) -> Array:
-    """Get the sample mask from data.
+    """The valid-sample mask, `(ndet, nsamp)`, combining the sample and scanning masks.
 
-    For Pomme mapmaker, extra pixels may be masked depending on pomme_tau.
+    For Pomme, every tau-interval with a masked sample is masked whole, and so is the partial
+    interval at the end. The weight is then constant on each interval, which makes it commute with
+    the Pomme projector (see [`PommeProjectionOperator`][]). The widening applies to the combined
+    mask: an interval straddling a scan boundary is dropped too.
     """
     mask = data[ReaderField.VALID_SAMPLE_MASKS]
+    if (scanning := data.get(ReaderField.VALID_SCANNING_MASKS)) is not None:
+        mask = jnp.logical_and(mask, scanning)
 
     if config.method == Methods.POMME:
         tau = config.pomme_tau

--- a/tests/mapmaking/test_model.py
+++ b/tests/mapmaking/test_model.py
@@ -53,6 +53,31 @@ class TestSampleMask:
 
         assert_array_equal(result[0, 2 * tau :], jnp.zeros(n_samp - 2 * tau, dtype=bool))
 
+    def test_pomme_widens_scanning_mask_to_whole_intervals(self):
+        """An interval partially flagged by the scanning mask is dropped whole.
+
+        The weight must be constant on every interval for it to commute with the Pomme projector,
+        whichever mask flags the samples.
+        """
+        tau, n_det, n_samp = 4, 2, 12  # 3 whole intervals
+        sample_mask = jnp.ones((n_det, n_samp), dtype=bool)
+        scanning = jnp.ones(n_samp, dtype=bool).at[5].set(False)  # one sample of interval 1
+
+        config = MapMakingConfig(method=Methods.POMME, pomme_tau=tau)
+        data = {'valid_sample_masks': sample_mask, 'valid_scanning_masks': scanning}
+        result = _sample_mask(data, config)
+
+        expected = jnp.ones((n_det, n_samp), dtype=bool).at[:, tau : 2 * tau].set(False)
+        assert_array_equal(result, expected)
+
+    def test_scanning_mask_applies_without_pomme(self):
+        n_det, n_samp = 2, 6
+        sample_mask = jnp.ones((n_det, n_samp), dtype=bool)
+        scanning = jnp.ones(n_samp, dtype=bool).at[1].set(False)
+        data = {'valid_sample_masks': sample_mask, 'valid_scanning_masks': scanning}
+        result = _sample_mask(data, MapMakingConfig())
+        assert_array_equal(result, sample_mask.at[:, 1].set(False))
+
 
 class TestIdentityNoise:
     @pytest.fixture


### PR DESCRIPTION
Pomme requires the weight to be constant on every `tau`-sample interval, so it commutes with the interval-mean projector (`PommeProjectionOperator`). The scanning mask was previously applied only at the final TOD masking step, after the sample mask had already been widened to whole intervals, so an interval straddling a scan boundary wasn't dropped whole and could break that invariant.

This folds the scanning mask into the sample mask before widening, so a scan-boundary interval is masked whole like any other partially-flagged interval.
