### PR TITLE
Honour min_order in the polynomial template

### DIFF
--- a/docs/development/changelog.md
+++ b/docs/development/changelog.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `MapMakingConfig.max_buckets`: largest allowed number of buckets for grouping observation by shape (#236)
 - API reference page for `furax.mapmaking.layout` (#236)
 - `furax.mapmaking.pomme` module and API reference page (moved from `furax.mapmaking.templates`) (#255)
+- Honours `PolynomialConfig.legendre.min_order` in polynomial template (#256)
 
 ### Changed
 

--- a/src/furax/mapmaking/_model.py
+++ b/src/furax/mapmaking/_model.py
@@ -435,6 +435,7 @@ class ObservationTemplates:
                         times=data[ReaderField.TIMESTAMPS],
                         dtype=dtype,
                         valid_mask=data[ReaderField.VALID_SCANNING_MASKS],
+                        min_poly_order=(poly.legendre if s == 'I' else legendre_qu).min_order,
                     )
                     for s in legs
                 }
@@ -445,6 +446,7 @@ class ObservationTemplates:
                     times=data[ReaderField.TIMESTAMPS],
                     dtype=dtype,
                     valid_mask=data[ReaderField.VALID_SCANNING_MASKS],
+                    min_poly_order=poly.legendre.min_order,
                 )
             add('polynomial', bases, poly.explicit)
 

--- a/src/furax/mapmaking/templates.py
+++ b/src/furax/mapmaking/templates.py
@@ -724,11 +724,13 @@ def polynomial_basis(
     times: Float[Array, ' samp'],
     dtype: DTypeLike,
     valid_mask: Float[Array, ' samp'] | None = None,
+    min_poly_order: int = 0,
 ) -> Basis:
     """Basis for a polynomial drift template, one polynomial per scanning interval.
 
-    Each sample belongs to one interval and is fitted with Legendre orders `0..max_poly_order` over
-    that interval.
+    Each sample belongs to one interval and is fitted with Legendre orders
+    `min_poly_order..max_poly_order` over that interval. Under Pomme the constant is already
+    removed, so `min_poly_order=1` keeps the basis non-degenerate.
 
     Assumes `intervals` are sorted, non-overlapping `[start, end)` rows. Samples in gaps or past the
     last interval get a zero basis column. `valid_mask` optionally zeroes flagged samples (1 = keep,
@@ -752,7 +754,7 @@ def polynomial_basis(
     # rescale each sample to [-1, 1] within its own interval; out-of-range
     # samples sit at 0 and are zeroed by `in_range` below.
     u = jnp.where(in_range, -1.0 + 2.0 * (times - t0) / span, 0.0)
-    legs = _legendre_values(u, 0, max_poly_order, dtype)  # (k, n_samps)
+    legs = _legendre_values(u, min_poly_order, max_poly_order, dtype)  # (k, n_samps)
     legs = legs * in_range[None, :]
     if valid_mask is not None:
         legs = legs * valid_mask[None, :].astype(dtype)


### PR DESCRIPTION
`polynomial_basis` always started the polynomial drift template at Legendre order 0, ignoring `PolynomialConfig.legendre.min_order`.

This matters when combining the template with Pomme: Pomme already removes the per-interval constant, so a template that also fits order 0 is degenerate under the Pomme-filtered weight. Wiring `min_order` through lets the config skip the constant term.
